### PR TITLE
[BBT#572] Implement hash table API providing a key handle during lock

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -922,10 +922,11 @@ parsec_dtd_register_task_class(parsec_taskpool_t *tp,
 {
     parsec_dtd_taskpool_t *dtd_tp = (parsec_dtd_taskpool_t *)tp;
     parsec_hash_table_t *hash_table = dtd_tp->function_h_table;
+    parsec_key_handle_t kh;
 
-    parsec_hash_table_lock_bucket(hash_table, key);
-    if( parsec_hash_table_nolock_find(hash_table, key) != NULL ) {
-        parsec_hash_table_unlock_bucket(hash_table, key);
+    parsec_hash_table_lock_bucket_handle(hash_table, key, &kh);
+    if( parsec_hash_table_nolock_find_handle(hash_table, &kh) != NULL ) {
+        parsec_hash_table_unlock_bucket_handle(hash_table, &kh);
         return;
     }
 
@@ -936,8 +937,8 @@ parsec_dtd_register_task_class(parsec_taskpool_t *tp,
     item->mempool_owner = dtd_tp->hash_table_bucket_mempool->thread_mempools;
     item->value = (void *)value;
 
-    parsec_hash_table_nolock_insert(hash_table, &item->ht_item);
-    parsec_hash_table_unlock_bucket(hash_table, key);
+    parsec_hash_table_nolock_insert_handle(hash_table, &kh, &item->ht_item);
+    parsec_hash_table_unlock_bucket_handle(hash_table, &kh);
 }
 
 /**

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -1521,6 +1521,7 @@ parsec_hash_find_deps(const parsec_taskpool_t *tp,
                       const parsec_task_t* restrict task)
 {
     parsec_hashable_dependency_t *hd;
+    parsec_key_handle_t kh;
     parsec_hash_table_t *ht = (parsec_hash_table_t*)tp->dependencies_array[task->task_class->task_class_id];
 
     if( NULL == es ) {
@@ -1530,16 +1531,16 @@ parsec_hash_find_deps(const parsec_taskpool_t *tp,
     }
     parsec_key_t key = task->task_class->make_key(tp, task->locals);
     assert(NULL != ht);
-    parsec_hash_table_lock_bucket(ht, key);
-    hd = parsec_hash_table_nolock_find(ht, key);
+    parsec_hash_table_lock_bucket_handle(ht, key, &kh);
+    hd = parsec_hash_table_nolock_find_handle(ht, &kh);
     if( NULL == hd ) {
         hd = (parsec_hashable_dependency_t *) parsec_thread_mempool_allocate(es->dependencies_mempool);
         hd->dependency = (parsec_dependency_t)0;
         hd->mempool_owner = es->dependencies_mempool;
         hd->ht_item.key = task->task_class->make_key(tp, task->locals);
-        parsec_hash_table_nolock_insert(ht, &hd->ht_item);
+        parsec_hash_table_nolock_insert_handle(ht, &kh, &hd->ht_item);
     }
-    parsec_hash_table_unlock_bucket(ht, key);
+    parsec_hash_table_unlock_bucket_handle(ht, &kh);
     return &hd->dependency;
 }
 

--- a/parsec/parsec_prof_grapher.c
+++ b/parsec/parsec_prof_grapher.c
@@ -173,6 +173,7 @@ static void parsec_prof_grapher_dataid(const parsec_data_t *dta, char *did, int 
     parsec_grapher_data_identifier_t id;
     parsec_key_t key;
     parsec_grapher_data_identifier_hash_table_item_t *it;
+    parsec_key_handle_t* kh;
 
     assert(NULL != dta);
     assert(NULL != grapher_file);
@@ -181,8 +182,8 @@ static void parsec_prof_grapher_dataid(const parsec_data_t *dta, char *did, int 
     id.dc = dta->dc;
     id.data_key = dta->key;
     key = (parsec_key_t)(uintptr_t)&id;
-    parsec_hash_table_lock_bucket(data_ht, key);
-    if( NULL == (it = parsec_hash_table_nolock_find(data_ht, key)) ) {
+    parsec_hash_table_lock_bucket_handle(data_ht, key, &kh);
+    if( NULL == (it = parsec_hash_table_nolock_find_handle(data_ht, &kh)) ) {
         char data_name[MAX_TASK_STRLEN];
         it = (parsec_grapher_data_identifier_hash_table_item_t*)malloc(sizeof(parsec_grapher_data_identifier_hash_table_item_t));
         it->id = id;
@@ -191,8 +192,8 @@ static void parsec_prof_grapher_dataid(const parsec_data_t *dta, char *did, int 
             asprintf(&it->did, "dc%p_%"PRIuPTR, it->id.dc, (uintptr_t)it->id.data_key);
         else
             asprintf(&it->did, "dta%p_%"PRIuPTR, dta, (uintptr_t)it->id.data_key);
-        parsec_hash_table_nolock_insert(data_ht, &it->ht_item);
-        parsec_hash_table_unlock_bucket(data_ht, key);
+        parsec_hash_table_nolock_insert_handle(data_ht, &kh, &it->ht_item);
+        parsec_hash_table_unlock_bucket_handle(data_ht, &kh);
 
         if(NULL != dta->dc && NULL != dta->dc->key_to_string) {
             dta->dc->key_to_string(dta->dc, dta->key, data_name, MAX_TASK_STRLEN);
@@ -201,7 +202,7 @@ static void parsec_prof_grapher_dataid(const parsec_data_t *dta, char *did, int 
         }
         fprintf(grapher_file, "%s [label=\"%s%s\",shape=\"circle\"]\n", it->did, NULL != dta->dc->key_base ? dta->dc->key_base : "", data_name);
     } else
-        parsec_hash_table_unlock_bucket(data_ht, key);
+        parsec_hash_table_unlock_bucket_handle(data_ht, &kh);
     strncpy(did, it->did, size);
 }
 

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -892,7 +892,8 @@ remote_dep_get_datatypes(parsec_execution_stream_t* es,
             local_mask = 0;
             local_mask |= (1U<<k);
 
-            parsec_hash_table_lock_bucket(dtd_tp->task_hash_table, (parsec_key_t)key);
+            parsec_key_handle_t kh;
+            parsec_hash_table_lock_bucket_handle(dtd_tp->task_hash_table, (parsec_key_t)key, &kh);
             dtd_task = parsec_dtd_find_task( dtd_tp, key );
 
             if( NULL == dtd_task ) {
@@ -920,7 +921,7 @@ remote_dep_get_datatypes(parsec_execution_stream_t* es,
                 parsec_dtd_track_remote_dep( dtd_tp, key, origin );
             }
 
-            parsec_hash_table_unlock_bucket(dtd_tp->task_hash_table, (parsec_key_t)key);
+            parsec_hash_table_unlock_bucket_handle(dtd_tp->task_hash_table, &kh);
 
             if(return_defer) {
                 return -2;

--- a/tests/apps/haar_tree/tree_dist.c
+++ b/tests/apps/haar_tree/tree_dist.c
@@ -24,9 +24,9 @@ static parsec_data_key_t tree_dist_data_key(parsec_data_collection_t *desc, ...)
 static tree_dist_node_t *lookup_or_create_node(tree_dist_t *tree, parsec_data_key_t key)
 {
     tree_dist_node_t *node;
-
-    parsec_hash_table_lock_bucket(&tree->nodes, key);
-    node = parsec_hash_table_nolock_find(&tree->nodes, key);
+    parsec_key_handle_t kh;
+    parsec_hash_table_lock_bucket_handle(&tree->nodes, key, &kh);
+    node = parsec_hash_table_nolock_find_handle(&tree->nodes, &kh);
     if(NULL == node) {
         node = (tree_dist_node_t*)malloc(sizeof(tree_dist_node_t));
         node->n = (int32_t) ( (key >> 32) );
@@ -35,9 +35,9 @@ static tree_dist_node_t *lookup_or_create_node(tree_dist_t *tree, parsec_data_ke
         node->data = NULL;
         node->rank = node->n % tree->super.nodes;
         node->vpid = node->n / tree->super.nodes % vpmap_get_nb_vp();
-        parsec_hash_table_nolock_insert(&tree->nodes, &node->ht_item);
+        parsec_hash_table_nolock_insert_handle(&tree->nodes, &kh, &node->ht_item);
     }
-    parsec_hash_table_unlock_bucket(&tree->nodes, key);
+    parsec_hash_table_unlock_bucket_handle(&tree->nodes, &kh);
     return node;
 }
 

--- a/tests/class/hash.c
+++ b/tests/class/hash.c
@@ -48,6 +48,7 @@ typedef struct {
     int new_table_each_time;
     int nb_loops;
     int nb_tests;
+    bool use_handle;
     uint64_t *keys;
 } param_t;
 
@@ -120,6 +121,8 @@ static void *do_test(void *_param)
     int nbthreads = param->nbthreads;
     int nbtests = param->nb_tests / nbthreads + (id < (param->nb_tests % nbthreads));
     int limit = (id*72 + 573) % nbtests;
+    bool use_handle = param->use_handle;
+    parsec_key_handle_t kh;
     parsec_time_t t0, t1;
     int l, t;
     void *rc;
@@ -148,8 +151,13 @@ static void *do_test(void *_param)
         }
 
         for(t = 0; t < limit; t++) {
-            parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
-            rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+            if (use_handle) {
+                parsec_hash_table_lock_bucket_handle(&hash_table, item_array[t].ht_item.key, &kh);
+                rc = parsec_hash_table_nolock_find_handle(&hash_table, &kh);
+            } else {
+                parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
+                rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+            }
             if( NULL != rc ) {
                 fprintf(stderr,
                         "Error in implementation of the hash table: item with key %"PRIu64" has not been inserted yet, but it is found in the hash table\n"
@@ -159,12 +167,24 @@ static void *do_test(void *_param)
                         id, nbthreads);
                 //raise(SIGABRT);
             }
-            parsec_hash_table_nolock_insert(&hash_table, &item_array[t].ht_item);
-            parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
+            if (use_handle) {
+                parsec_hash_table_nolock_insert_handle(&hash_table, &kh, &item_array[t].ht_item);
+                parsec_hash_table_unlock_bucket_handle(&hash_table, &kh);
+            } else {
+                parsec_hash_table_nolock_insert(&hash_table, &item_array[t].ht_item);
+                parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
+            }
         }
         for(t = 0; t < limit; t++) {
-            parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
-            rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+            if (use_handle) {
+                parsec_hash_table_lock_bucket_handle(&hash_table, item_array[t].ht_item.key, &kh);
+                rc = parsec_hash_table_nolock_find_handle(&hash_table, &kh);
+                parsec_hash_table_unlock_bucket_handle(&hash_table, &kh);
+            } else {
+                parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
+                rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+                parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
+            }
             if( rc != &item_array[t] ) {
                 if( NULL == rc ) {
                     fprintf(stderr, "Error in implementation of the hash table 3: item with key %"PRIu64" is not to be found in the hash table, but it was not removed yet\n",
@@ -176,7 +196,6 @@ static void *do_test(void *_param)
                             ((empty_hash_item_t*)rc)->thread_id, ((empty_hash_item_t*)rc)->nbthreads);
                 }
             }
-            parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
         }
         if(0 == id)
             parsec_hash_table_stat(&hash_table);
@@ -197,8 +216,13 @@ static void *do_test(void *_param)
         }
 
         for(t = limit; t < nbtests; t++) {
-            parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
-            rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+            if (use_handle) {
+                parsec_hash_table_lock_bucket_handle(&hash_table, item_array[t].ht_item.key, &kh);
+                rc = parsec_hash_table_nolock_find_handle(&hash_table, &kh);
+            } else {
+                parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
+                rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+            }
             if( NULL != rc ) {
                 fprintf(stderr,
                         "Error in implementation of the hash table: item with key %"PRIu64" has not been inserted yet, but it is found in the hash table\n"
@@ -208,12 +232,24 @@ static void *do_test(void *_param)
                         id, nbthreads);
                 //raise(SIGABRT);
             }
-            parsec_hash_table_nolock_insert(&hash_table, &item_array[t].ht_item);
-            parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
+            if (use_handle) {
+                parsec_hash_table_nolock_insert_handle(&hash_table, &kh, &item_array[t].ht_item);
+                parsec_hash_table_unlock_bucket_handle(&hash_table, &kh);
+            } else {
+                parsec_hash_table_nolock_insert(&hash_table, &item_array[t].ht_item);
+                parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
+            }
         }
         for(t = limit; t < nbtests; t++) {
-            parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
-            rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+            if (use_handle) {
+                parsec_hash_table_lock_bucket_handle(&hash_table, item_array[t].ht_item.key, &kh);
+                rc = parsec_hash_table_nolock_find_handle(&hash_table, &kh);
+                parsec_hash_table_unlock_bucket_handle(&hash_table, &kh);
+            } else {
+                parsec_hash_table_lock_bucket(&hash_table, item_array[t].ht_item.key);
+                rc = parsec_hash_table_nolock_find(&hash_table, item_array[t].ht_item.key);
+                parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
+            }
             if( rc != &item_array[t] ) {
                 if( NULL == rc ) {
                     fprintf(stderr, "Error in implementation of the hash table 1: item with key %"PRIu64" is not to be found in the hash table, but it was not removed yet\n",
@@ -225,7 +261,6 @@ static void *do_test(void *_param)
                             ((empty_hash_item_t*)rc)->thread_id, ((empty_hash_item_t*)rc)->nbthreads);
                 }
             }
-            parsec_hash_table_unlock_bucket(&hash_table, item_array[t].ht_item.key);
         }
         for(t = limit; t < nbtests; t++) {
             rc = parsec_hash_table_remove(&hash_table, item_array[t].ht_item.key);
@@ -349,6 +384,7 @@ int main(int argc, char *argv[])
     int md_tuning_inc = 1;
     int md_tuning;
     int simple_perf = 0;
+    bool use_handle = 0;
     int nb_tests = 30000;
     int nb_loops = 300;
     int new_table_each_time = 0;
@@ -370,7 +406,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Warning: unable to find the hash table hint, tuning behavior will be disabled\n");
     }
     
-    while( (ch = getopt(argc, argv, "c:m:M:t:T:i:d:D:I:#:r:hnp?")) != -1 ) {
+    while( (ch = getopt(argc, argv, "c:m:M:t:T:i:d:D:I:#:r:hnpH?")) != -1 ) {
         switch(ch) {
         case 'c':
             ch = strtol(optarg, &m, 0);
@@ -456,14 +492,19 @@ int main(int argc, char *argv[])
         case 'p':
             simple_perf = 1;
             break;
+        case 'H':
+            use_handle = true;
+            break;
         case 'h':
         case '?':
         default:
             fprintf(stderr,
-                    "Usage: %s [-p|-c nbthreads|-m minthreads -M maxthreads]\n"
+                    "Usage: %s [-c nbthreads|-m minthreads -M maxthreads]\n"
                     "          [-t max_ coll_min -T max_coll_max -i max_coll_inc]\n"
                     "          [-d max_table_depth_min -D max_table_depth_max -I max_table_depth_inc]\n"
-                    "          [-# number of items to insert][-r number of loops of the test][-n use a new hash table for each test]\n", argv[0]);
+                    "          [-# number of items to insert][-r number of loops of the test][-n use a new hash table for each test]\n"
+                    "          [-p (run simple performance test)]\n"
+                    "          [-H (use key handles for locking buckets)]\n", argv[0]);
             exit(1);
             break;
         }
@@ -543,6 +584,7 @@ int main(int argc, char *argv[])
                     params[e].nb_tests = nb_tests;
                     params[e].nb_loops = nb_loops;
                     params[e].new_table_each_time = new_table_each_time;
+                    params[e].use_handle = use_handle;
                 }
 
                 parsec_barrier_init(&barrier1, NULL, nbthreads+1);    


### PR DESCRIPTION
Original PR: https://bitbucket.org/icldistcomp/parsec/pull-requests/572

In TTG we use the following pattern to find/insert/remove items in a hash table bucket in the critical path of sending data along edges: (similar code can be found in PaRSEC/DPLASMA)

```C
parsec_hash_table_lock_bucket(ht, key);
item = parsec_hash_table_nolock_find(ht, key);
if (NULL == item) {
  item = create_new(key);
  parsec_hash_table_nolock_insert(ht, item);
} else if (is_complete(item)) {
  parsec_hash_table_nolock_remove(ht, key);
}
parsec_hash_table_unlock_bucket(ht, key);
```

This code computes the hash of key at least 3 times, potentially a fourth time if the item is inserted or removed. Hashing is rather expensive and involves a) an indirect call to a user-provided function where we don’t know how expensive it is; and b) compression of the hash value to the number of bits currently used (not terribly expensive, but probably a few dozen instructions each time).

This PR adds a key handle that caches the hash information and that is provided by parsec_hash_table_lock_bucket_handle. The handle can be used to insert, remove, and find items as well as when unlocking the bucket. The above code then becomes:

```C
parsec_key_handle_t kh;
parsec_hash_table_lock_bucket_handle(ht, key, &kh);
item = parsec_hash_table_nolock_find_handle(ht, key, &kh);
if (NULL == item) {
  item = create_new(key);
  parsec_hash_table_nolock_insert_handle(ht, &kh, item);
} else if (is_complete(item)) {
  parsec_hash_table_nolock_remove_handle(ht, &kh);
}
parsec_hash_table_unlock_bucket_handle(ht, &kh);
```

In this case, the key is hashed only once throughout this sequence in the call to lock the bucket. The handle is valid until the bucket is unlocked since no resizing may occur while a bucket is locked. The insert function ignores the key of the item and uses the key stored in the handle instead. It is unsafe to use a key in item that is different from the key used to lock the bucket, so IMO that is safe.

The handle stores the key as well as the compressed and uncompressed hash values:
```C
struct parsec_key_handle_s {
    uint64_t                  hash64;           /**< Is a 64-bits hash of the key */
    uint64_t                  hash;             /**< Is a 64-bits hash of the key,
                                                     trimmed to the current size of the table */
    parsec_key_t              key;              /**< Items are identified with this key */
};
```

The impact is measurable, albeit not overwhelming (about 10% in the TTG benchmark stressing the data flow handling). The changes are not terribly invasive and recomputing the hash every time is somewhat of a waste, no matter what.

I converted the code in datarepo.c to show how it looks like in code. If approved, I will convert more code that uses similar patterns.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>