### PR TITLE
[BBT#493] New API for parsec_init w/o cores parameter

### DIFF
--- a/examples/Ex00_StartStop.c
+++ b/examples/Ex00_StartStop.c
@@ -7,7 +7,7 @@
  *
  * [mpicc|cc] -o Ex00_StartStop Ex00_StartStop.c `pkg-config --cflags --libs parsec` -lpthread -lm -lrt [-ldl -lcudart]
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex00_StartStop.c
+++ b/examples/Ex00_StartStop.c
@@ -38,13 +38,12 @@ int main(int argc, char *argv[])
 #endif
 
     /**
-     * Then, we can initialize the engine by giving the number of threads on the
-     * current process, and the arguments.
-     * If -1, is given for the number of threads, the number of physical core on
-     * the architecture will be detected and used as the default for the number
-     * of threads.
+     * Then, we can initialize the engine.
+     * The behavior of PaRSEC can be further configured by passing command line
+     * arguments, as forwarded here, or environment variables of the form 
+     * PARSEC_MCA_xyz=value
      */
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     /**
      * Let's do some computation with the runtime, and wait for the end.

--- a/examples/Ex01_HelloWorld.jdf
+++ b/examples/Ex01_HelloWorld.jdf
@@ -9,7 +9,7 @@ extern "C" %{
  *
  * Can play with the HelloWorld bounds to show embarissingly parallel algorithm.
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex01_HelloWorld.jdf
+++ b/examples/Ex01_HelloWorld.jdf
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     /**
      * See Ex03_ChainMPI.jdf for explanation

--- a/examples/Ex02_Chain.jdf
+++ b/examples/Ex02_Chain.jdf
@@ -7,7 +7,7 @@ extern "C" %{
  *    guarded calls, RW
  *    parsec_arena_datatype_construct()
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex02_Chain.jdf
+++ b/examples/Ex02_Chain.jdf
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     parsec_data_collection_init(&taskdist, world, rank);
     taskdist.rank_of = rank_of;

--- a/examples/Ex03_ChainMPI.jdf
+++ b/examples/Ex03_ChainMPI.jdf
@@ -5,7 +5,7 @@ extern "C" %{
  *    descriptor as global
  *    rank_of() / possibility of playing with value in rank_of
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex03_ChainMPI.jdf
+++ b/examples/Ex03_ChainMPI.jdf
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     /**
      * Let's initialize the task distribution descriptor

--- a/examples/Ex04_ChainData.jdf
+++ b/examples/Ex04_ChainData.jdf
@@ -6,7 +6,7 @@ extern "C" %{
  *    parsec_data_create()
  *    parsec_data_destroy()
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex04_ChainData.jdf
+++ b/examples/Ex04_ChainData.jdf
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     /**
      * Let's create the local data (mycounter), and the parsec_data_t associated to it

--- a/examples/Ex05_Broadcast.jdf
+++ b/examples/Ex05_Broadcast.jdf
@@ -7,7 +7,7 @@ extern "C" %{
  *
  * Each process broadcast an information to NB/2 tasks.
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex05_Broadcast.jdf
+++ b/examples/Ex05_Broadcast.jdf
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     mycounter = 300 + rank;
 

--- a/examples/Ex06_RAW.jdf
+++ b/examples/Ex06_RAW.jdf
@@ -4,7 +4,7 @@ extern "C" %{
  * This example illustrates the Read After Write problem that might happen when anti-dependencies are present in the code
  * Each process broadcast an information to NB/2 tasks, and to a local task that updates the information.
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex06_RAW.jdf
+++ b/examples/Ex06_RAW.jdf
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     parsec_data_collection_init(&mydata, world, rank);
     mydata.rank_of = rank_of;

--- a/examples/Ex07_RAW_CTL.jdf
+++ b/examples/Ex07_RAW_CTL.jdf
@@ -4,7 +4,7 @@ extern "C" %{
  * This example illustrates the Read After Write problem that might happen when anti-dependencies are present in the code
  * Each process broadcast an information to NB/2 tasks, and to a local task that updates the information.
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/Ex07_RAW_CTL.jdf
+++ b/examples/Ex07_RAW_CTL.jdf
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     parsec_data_collection_init(&mydata, world, rank);
     mydata.rank_of = rank_of;

--- a/examples/interfaces/dtd/dtd_example_hello_arg.c
+++ b/examples/interfaces/dtd/dtd_example_hello_arg.c
@@ -8,7 +8,7 @@
 /**
  * @file dtd_example_hello_world.c
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/interfaces/dtd/dtd_example_hello_arg.c
+++ b/examples/interfaces/dtd/dtd_example_hello_arg.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2018 The University of Tennessee and The University
+ * Copyright (c) 2015-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/examples/interfaces/dtd/dtd_example_hello_arg.c
+++ b/examples/interfaces/dtd/dtd_example_hello_arg.c
@@ -63,7 +63,7 @@ int main(int argc, char ** argv)
 
     /* Initializing parsec context */
     /* Let's PaRSEC know we'd like to use only one core */
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         printf("Cannot initialize PaRSEC\n");

--- a/examples/interfaces/dtd/dtd_example_hello_arg.c
+++ b/examples/interfaces/dtd/dtd_example_hello_arg.c
@@ -62,7 +62,9 @@ int main(int argc, char ** argv)
 #endif
 
     /* Initializing parsec context */
-    parsec = parsec_init( cores, &argc, &argv );
+    /* Let's PaRSEC know we'd like to use only one core */
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         printf("Cannot initialize PaRSEC\n");
         exit(-1);

--- a/examples/interfaces/dtd/dtd_example_hello_world.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world.c
@@ -8,7 +8,7 @@
 /**
  * @file dtd_example_hello_world.c
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/interfaces/dtd/dtd_example_hello_world.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2018 The University of Tennessee and The University
+ * Copyright (c) 2015-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/examples/interfaces/dtd/dtd_example_hello_world.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world.c
@@ -64,7 +64,7 @@ int main(int argc, char ** argv)
 
     /* Initializing parsec context */
     /* Let's PaRSEC know we'd like to use only one core */
-    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec_param_set_int("runtime_num_cores", 1);
     parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         printf("Cannot initialize PaRSEC\n");

--- a/examples/interfaces/dtd/dtd_example_hello_world.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world.c
@@ -47,7 +47,7 @@ task_hello_world( parsec_execution_stream_t *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rc, rank, world, cores = 1;
+    int rc, rank, world;
 
     /* Initializing MPI */
 #if defined(PARSEC_HAVE_MPI)
@@ -63,7 +63,9 @@ int main(int argc, char ** argv)
 #endif
 
     /* Initializing parsec context */
-    parsec = parsec_init( cores, &argc, &argv );
+    /* Let's PaRSEC know we'd like to use only one core */
+    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         printf("Cannot initialize PaRSEC\n");
         exit(-1);

--- a/examples/interfaces/dtd/dtd_example_hello_world_untied.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world_untied.c
@@ -8,7 +8,7 @@
 /**
  * @file dtd_example_hello_world_untied.c
  *
- * @version 3.0
+ * @version 4.0
  * @email parsec-users@icl.utk.edu
  *
  */

--- a/examples/interfaces/dtd/dtd_example_hello_world_untied.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world_untied.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2018 The University of Tennessee and The University
+ * Copyright (c) 2015-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/examples/interfaces/dtd/dtd_example_hello_world_untied.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world_untied.c
@@ -98,7 +98,7 @@ int main(int argc, char ** argv)
 
     /* Initializing parsec context */
     /* Let's PaRSEC know we'd like to use only one core */
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         printf("Cannot initialize PaRSEC\n");

--- a/examples/interfaces/dtd/dtd_example_hello_world_untied.c
+++ b/examples/interfaces/dtd/dtd_example_hello_world_untied.c
@@ -97,7 +97,9 @@ int main(int argc, char ** argv)
 #endif
 
     /* Initializing parsec context */
-    parsec = parsec_init( cores, &argc, &argv );
+    /* Let's PaRSEC know we'd like to use only one core */
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         printf("Cannot initialize PaRSEC\n");
         exit(-1);

--- a/parsec/fortran/parsecf.F90
+++ b/parsec/fortran/parsecf.F90
@@ -46,12 +46,11 @@ FUNCTION parsec_version_ex_f08(len, version_string) &
     INTEGER(KIND=c_int)                     :: parsec_version_ex_f08
 END FUNCTION parsec_version_ex_f08
 
-SUBROUTINE parsec_init_f08(nbcores, ctx, ierr) &
+SUBROUTINE parsec_init_f08(ctx, ierr) &
          BIND(C, name="parsec_init_f08")
     USE, intrinsic :: ISO_C_BINDING, only : C_INT
     IMPORT parsec_context_t
     IMPLICIT NONE
-    INTEGER(KIND=c_int), VALUE, INTENT(IN)  :: nbcores
     TYPE(parsec_context_t), INTENT(OUT)     :: ctx
     INTEGER(KIND=c_int), INTENT(OUT)        :: ierr
 END SUBROUTINE parsec_init_f08
@@ -180,15 +179,14 @@ END INTERFACE
 
 CONTAINS
 
-SUBROUTINE parsec_init(nbcores, ctx, ierr)
+SUBROUTINE parsec_init(ctx, ierr)
     USE, intrinsic :: ISO_C_BINDING, only : C_INT
     IMPLICIT NONE
-    INTEGER(KIND=c_int), VALUE, INTENT(IN)     :: nbcores
     TYPE(parsec_context_t), INTENT(OUT)        :: ctx
     INTEGER(KIND=c_int), OPTIONAL, INTENT(OUT) :: ierr
     INTEGER(KIND=c_int)                        :: c_err
 
-    call parsec_init_f08(nbcores, ctx, c_err)
+    call parsec_init_f08(ctx, c_err)
     if(present(ierr)) ierr = c_err
 END SUBROUTINE parsec_init
 

--- a/parsec/fortran/parsecf.F90
+++ b/parsec/fortran/parsecf.F90
@@ -1,5 +1,5 @@
 ! -*- f90 -*-
-! Copyright (c) 2013-2018 The University of Tennessee and The University
+! Copyright (c) 2013-2021 The University of Tennessee and The University
 !                         of Tennessee Research Foundation.  All rights
 !                         reserved.
 ! $COPYRIGHT$

--- a/parsec/fortran/parsecf.c
+++ b/parsec/fortran/parsecf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 The University of Tennessee and The University
+ * Copyright (c) 2013-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/parsec/fortran/parsecf.c
+++ b/parsec/fortran/parsecf.c
@@ -11,14 +11,13 @@
 /**
  * @brief A function callable from Fortran allowing to initialize the PaRSEC runtime
  * 
- * @param nbcores 
  * @param context 
  * @param ierr 
  * 
  * As there is no standard way to find the arg[cv] in Fortran, we build them using
  * the PARSEC_ARGS environment variable.
  */
-void parsec_init_f08(int nbcores, parsec_context_t** context, int* ierr)
+void parsec_init_f08(parsec_context_t** context, int* ierr)
 {
     char *args = NULL, *token, **argv = NULL;
     int argc = 0;
@@ -38,7 +37,7 @@ void parsec_init_f08(int nbcores, parsec_context_t** context, int* ierr)
         }
         argv[argc] = NULL;
     }
-    *context = parsec_init(nbcores, &argc, &argv);
+    *context = parsec_init(&argc, &argv);
     /* Cleanup the locals used to initialize parsec */
     free(argv);
     if( NULL != args )

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -488,6 +488,9 @@ parsec_context_t* parsec_init( int* pargc, char** pargv[] )
     parsec_debug_init();
     mca_components_repository_init();
 
+    intptr_t comm_ctx = -1;
+    parsec_mca_param_reg_intptrt_name("runtime", "comm_ctx", "Change the communication context used by the parsec engine (e.g., substitute MPI_COMM_WORLD with an user-created communicator)", false, false, comm_ctx, &comm_ctx);
+
     parsec_mca_param_reg_int_name("runtime", "warn_slow_binding", "Disable warnings about the runtime detecting poorly performing binding configuration", false, false, slow_bind_warning, &slow_bind_warning);
 
 #if defined(PARSEC_HAVE_HWLOC)
@@ -625,7 +628,7 @@ parsec_context_t* parsec_init( int* pargc, char** pargv[] )
     context->active_taskpools      = 0;
     context->flags               = 0;
     context->nb_nodes            = 1;
-    context->comm_ctx            = -1;
+    context->comm_ctx            = comm_ctx;
     context->my_rank             = 0;
     context->nb_vp               = nb_vp;
     /* initialize dtd taskpool list */

--- a/parsec/runtime.h
+++ b/parsec/runtime.h
@@ -161,13 +161,12 @@ typedef enum parsec_hook_return_e {
  * execution context. Several contextes can cohexist on disjoint resources
  * in same time.
  *
- * @param[in]    nb_cores the number of cores to use
  * @param[inout] pargc a pointer to the number of arguments passed in pargv
  * @param[inout] pargv an argv-like NULL terminated array of arguments to pass to
  *        the PaRSEC engine.
  * @return the newly created PaRSEC context
  */
-parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[]);
+parsec_context_t* parsec_init(int* pargc, char** pargv[]);
 
 /**
  * @brief Obtain the version number of the PaRSEC runtime

--- a/parsec/runtime.h
+++ b/parsec/runtime.h
@@ -153,6 +153,40 @@ typedef enum parsec_hook_return_e {
 
 
 /**
+ * Set an MCA environment parameter with a string value
+ *
+ * @param param Name of the type containing the variable.
+ * @param value Value of the mca parameter to set.
+ *
+ * This function sets an MCA environment parameter in the global environment
+ * of the application (i.e., environ) so that it cane be used as the default
+ * value for the parameter when it is accessed by the PaRSEC engine. Thus, an
+ * external application can register some parameters that will later be used by
+ * the initialization in the engine.
+ *
+ */
+PARSEC_DECLSPEC void
+parsec_param_set_string( char *param,
+                         char *value);
+
+/**
+ * Set an MCA environment parameter with an integer value
+ *
+ * @param param Name of the type containing the variable.
+ * @param value Value of the mca parameter to set.
+ *
+ * This function sets an MCA environment parameter in the global environment
+ * of the application (i.e., environ) so that it cane be used as the default
+ * value for the parameter when it is accessed by the PaRSEC engine. Thus, an
+ * external application can register some parameters that will later be used by
+ * the initialization in the engine.
+ *
+ */
+PARSEC_DECLSPEC void
+parsec_param_set_int( char *param,
+                      int ivalue);
+
+/**
  * @brief Create a new PaRSEC execution context
  *
  * @details

--- a/parsec/utils/mca_param.c
+++ b/parsec/utils/mca_param.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2019 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,

--- a/parsec/utils/mca_param.c
+++ b/parsec/utils/mca_param.c
@@ -2593,14 +2593,32 @@ void parsec_mca_show_mca_params(parsec_list_t *info,
 }
 
 /*
- * Set an MCA parameter in the environment provided.
- * If environment is environ, the MCA parameter is into the global environment
- * and can be accessed when the parameter is actually registered.
+ * Set a string type MCA parameter in the global environment so
+ * it can be accessed when the parameter is actually registered.
  */
-void parsec_setenv_mca_param( char *param, char *value, char ***env )
+void parsec_setenv_mca_param_string( char *param, char *value )
 {
     char *name;
+    extern char **environ;
+
     (void) parsec_mca_var_env_name (param, &name);
-    parsec_setenv(name, value, true, env);
+    parsec_setenv(name, value, true, &environ);
     free(name);
 }
+
+/*
+ * Set an integer type MCA parameter in the global environment so
+ * it can be accessed when the parameter is actually registered.
+ */
+void parsec_setenv_mca_param_int( char *param, int ivalue ) {
+    char *name;
+    char *value;
+    extern char **environ;
+
+    (void)parsec_mca_var_env_name(param, &name);
+    (void)asprintf(&value, "%d", ivalue);
+    parsec_setenv(name, value, true, &environ);
+    free(name);
+    free(value);
+}
+

--- a/parsec/utils/mca_param.c
+++ b/parsec/utils/mca_param.c
@@ -2596,7 +2596,7 @@ void parsec_mca_show_mca_params(parsec_list_t *info,
  * Set a string type MCA parameter in the global environment so
  * it can be accessed when the parameter is actually registered.
  */
-void parsec_setenv_mca_param_string( char *param, char *value )
+void parsec_param_set_string( char *param, char *value )
 {
     char *name;
     extern char **environ;
@@ -2610,7 +2610,7 @@ void parsec_setenv_mca_param_string( char *param, char *value )
  * Set an integer type MCA parameter in the global environment so
  * it can be accessed when the parameter is actually registered.
  */
-void parsec_setenv_mca_param_int( char *param, int ivalue ) {
+void parsec_param_set_int( char *param, int ivalue ) {
     char *name;
     char *value;
     extern char **environ;

--- a/parsec/utils/mca_param.h
+++ b/parsec/utils/mca_param.h
@@ -787,7 +787,7 @@ parsec_mca_show_mca_params(parsec_list_t *info,
                           bool pretty_print);
 
 /**
- * Set an MCA environment parameter.with a string value
+ * Set an MCA environment parameter with a string value
  *
  * @param param Name of the type containing the variable.
  * @param value Value of the mca parameter to set.
@@ -800,11 +800,11 @@ parsec_mca_show_mca_params(parsec_list_t *info,
  *
  */
 PARSEC_DECLSPEC void
-parsec_setenv_mca_param_string( char *param,
-                                char *value);
+parsec_param_set_string( char *param,
+                         char *value);
 
 /**
- * Set an MCA environment parameter.with an integer value
+ * Set an MCA environment parameter with an integer value
  *
  * @param param Name of the type containing the variable.
  * @param value Value of the mca parameter to set.
@@ -817,8 +817,8 @@ parsec_setenv_mca_param_string( char *param,
  *
  */
 PARSEC_DECLSPEC void
-parsec_setenv_mca_param_int( char *param,
-                             int ivalue);
+parsec_param_set_int( char *param,
+                      int ivalue);
 END_C_DECLS
 
 #endif /* PARSEC_MCA_PARAM_H */

--- a/parsec/utils/mca_param.h
+++ b/parsec/utils/mca_param.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2019 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,

--- a/parsec/utils/mca_param.h
+++ b/parsec/utils/mca_param.h
@@ -787,26 +787,38 @@ parsec_mca_show_mca_params(parsec_list_t *info,
                           bool pretty_print);
 
 /**
- * Set an MCA environment parameter.
+ * Set an MCA environment parameter.with a string value
  *
  * @param param Name of the type containing the variable.
  * @param value Value of the mca parameter to set.
- * @param env   Environment in which to store the MCA parameter.
  *
- * This function sets an MCA environment parameter. If env = environ,
- * then the variable is set into the global environment of the application and
- * is used as the default value for the parameter when it is accessed by the
- * PaRSEC engine. Thus, an external application can register some parameters that
- * will later be used by the initialization in the engine.
- * If env != environ, the value is just added to the given environment. This is
- * used internally by PaRSEC.
+ * This function sets an MCA environment parameter in the global environment
+ * of the application (i.e., environ) so that it cane be used as the default
+ * value for the parameter when it is accessed by the PaRSEC engine. Thus, an
+ * external application can register some parameters that will later be used by
+ * the initialization in the engine.
  *
  */
 PARSEC_DECLSPEC void
-parsec_setenv_mca_param( char *param,
-                        char *value,
-                        char ***env );
+parsec_setenv_mca_param_string( char *param,
+                                char *value);
 
+/**
+ * Set an MCA environment parameter.with an integer value
+ *
+ * @param param Name of the type containing the variable.
+ * @param value Value of the mca parameter to set.
+ *
+ * This function sets an MCA environment parameter in the global environment
+ * of the application (i.e., environ) so that it cane be used as the default
+ * value for the parameter when it is accessed by the PaRSEC engine. Thus, an
+ * external application can register some parameters that will later be used by
+ * the initialization in the engine.
+ *
+ */
+PARSEC_DECLSPEC void
+parsec_setenv_mca_param_int( char *param,
+                             int ivalue);
 END_C_DECLS
 
 #endif /* PARSEC_MCA_PARAM_H */

--- a/parsec/utils/mca_param.h
+++ b/parsec/utils/mca_param.h
@@ -55,6 +55,7 @@
 #if defined(PARSEC_HAVE_STDBOOL_H)
 #include <stdbool.h>
 #endif  /* defined(PARSEC_HAVE_STDBOOL_H) */
+#include <stdint.h>
 #include "parsec/class/list.h"
 
 #include "parsec/constants.h"
@@ -67,6 +68,8 @@ typedef enum {
     PARSEC_MCA_PARAM_ERROR = -1,
     /** The parameter is of type signed integer. */
     PARSEC_MCA_PARAM_TYPE_INT,
+    /** The parameter is of type intptr_t. */
+    PARSEC_MCA_PARAM_TYPE_INTPTRT,
     /** The parameter is of type size_t. */
     PARSEC_MCA_PARAM_TYPE_SIZET,
     /** The parameter is of type string. */
@@ -218,6 +221,55 @@ PARSEC_DECLSPEC int parsec_mca_param_recache_files(void);
                               bool read_only,
                               int default_value,
                               int *current_value);
+
+/**
+ * Register a intptr_t MCA parameter that is not associated with a
+ * component.
+ *
+ * @param type [in] Although this parameter is not associated with
+ * a component, it still must have a string type name that will
+ * act as a prefix (string).
+ * @param param_name [in] The name of the parameter being
+ * registered (string).
+ * @param help_msg [in] A string describing the use and valid
+ * values of the parameter (string).
+ * @param internal [in] Indicates whether the parameter is internal
+ * (i.e., not to be shown to users) or not (bool).
+ * @param read_only [in] Indicates whether the parameter value can
+ * ever change (bool).
+ * @param default_value [in] The value that is used for this
+ * parameter if the user does not supply one.
+ * @param current_value [out] After registering the parameter, look
+ * up its current value and return it unless current_value is
+ * NULL.
+ *
+ * @retval PARSEC_ERROR Upon failure to register the parameter.
+ * @retval index Index value that can be used with
+ * parsec_mca_param_lookup_intptr_t() to retrieve the value of the
+ * parameter.
+ *
+ * Note that the type should always be a framework or a level name
+ * (e.g., "btl" or "mpi") -- it should not include the component
+ * name, even if the component is the base of a framework.  Hence,
+ * "btl_base" is not a valid type name.  Specifically, registering
+ * a parameter with an unrecognized type is not an error, but
+ * ompi_info has a hard-coded list of frameworks and levels;
+ * parameters that have recongized types, although they can be
+ * used by the user, will not be displayed by ompi_info.
+ *
+ * Note that if you use parsec_mca_param_find() to lookup the index
+ * of the registered parameter, the "component" argument should be
+ * NULL (because it is not specified in this registration
+ * function, and is therefore registered with a NULL value).
+ */
+ PARSEC_DECLSPEC int
+ parsec_mca_param_reg_intptrt_name(const char *type,
+                                const char *param_name,
+                                const char *help_msg,
+                                bool internal,
+                                bool read_only,
+                                intptr_t default_value,
+                                intptr_t *current_value);
 
 /**
  * Register a size_t MCA parameter that is not associated with a
@@ -819,6 +871,23 @@ parsec_param_set_string( char *param,
 PARSEC_DECLSPEC void
 parsec_param_set_int( char *param,
                       int ivalue);
+
+/**
+ * Set an MCA environment parameter with an pointer value
+ *
+ * @param param Name of the type containing the variable.
+ * @param value Value of the mca parameter to set.
+ *
+ * This function sets an MCA environment parameter in the global environment
+ * of the application (i.e., environ) so that it cane be used as the default
+ * value for the parameter when it is accessed by the PaRSEC engine. Thus, an
+ * external application can register some parameters that will later be used by
+ * the initialization in the engine.
+ *
+ */
+PARSEC_DECLSPEC void
+parsec_param_set_intptr( char *param,
+                      intptr_t pvalue);
 END_C_DECLS
 
 #endif /* PARSEC_MCA_PARAM_H */

--- a/parsec/utils/mca_param_cmd_line.c
+++ b/parsec/utils/mca_param_cmd_line.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,

--- a/parsec/utils/mca_param_cmd_line.c
+++ b/parsec/utils/mca_param_cmd_line.c
@@ -171,6 +171,9 @@ static void add_to_env(char **params, char **values, char ***env)
        vars of the form OMPI_MCA_*=value. */
 
     for (i = 0; NULL != params && NULL != params[i]; ++i) {
-        parsec_setenv_mca_param( params[i], values[i], env );
+        char *name;
+        (void) parsec_mca_var_env_name(params[i], &name);
+        parsec_setenv(name, values[i], true, env);
+        free(name);
     }
 }

--- a/parsec/utils/mca_param_internal.h
+++ b/parsec/utils/mca_param_internal.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2019 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -38,6 +38,7 @@
 #include "parsec/class/parsec_object.h"
 #include "parsec/utils/mca_param.h"
 #include "parsec/class/list.h"
+#include <stdint.h>
 
 BEGIN_C_DECLS
 
@@ -49,6 +50,8 @@ BEGIN_C_DECLS
 typedef union {
     /** Integer value */
     int intval;
+    /** INTPTR_T value */
+    intptr_t intptrtval;
     /** SIZE_T value */
     size_t sizetval;
     /** String value */

--- a/tests/api/compose.c
+++ b/tests/api/compose.c
@@ -78,7 +78,9 @@ int main(int argc, char* argv[])
         argc -= 1;
     }
 
-    parsec = parsec_init(1, &argc, &argv);
+    extern char **environ;
+    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec = parsec_init(&argc, &argv);
     assert( NULL != parsec );
 
     parsec_matrix_block_cyclic_init( &dcA, TYPE, PARSEC_MATRIX_TILE,

--- a/tests/api/compose.c
+++ b/tests/api/compose.c
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
     }
 
     extern char **environ;
-    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec_param_set_int("runtime_num_cores", 1);
     parsec = parsec_init(&argc, &argv);
     assert( NULL != parsec );
 

--- a/tests/api/operator.c
+++ b/tests/api/operator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -38,7 +38,7 @@ int main( int argc, char* argv[] )
     parsec_context_t* parsec;
     parsec_taskpool_t* op;
     parsec_matrix_block_cyclic_t dcA;
-    int cores = -1, world = 1, rank = 0;
+    int world = 1, rank = 0;
     int mb = 100, nb = 100;
     int lm = 1000, ln = 1000;
     int rows = 1, rc;
@@ -52,7 +52,7 @@ int main( int argc, char* argv[] )
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif
 
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     parsec_matrix_block_cyclic_init( &dcA, PARSEC_MATRIX_FLOAT, PARSEC_MATRIX_TILE,
                                rank, mb, nb, lm, ln, 0, 0, lm, ln,

--- a/tests/api/touch_ex.c
+++ b/tests/api/touch_ex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 The University of Tennessee and The University
+ * Copyright (c) 2013-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tests/api/touch_ex.c
+++ b/tests/api/touch_ex.c
@@ -39,7 +39,7 @@ int main( int argc, char** argv )
         argc -= 1;
     }
 
-    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec_param_set_int("runtime_num_cores", 1);
     parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-2);

--- a/tests/api/touch_ex.c
+++ b/tests/api/touch_ex.c
@@ -39,7 +39,8 @@ int main( int argc, char** argv )
         argc -= 1;
     }
 
-    parsec = parsec_init(1, &argc, &argv);
+    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-2);
     }

--- a/tests/api/touch_exf.F90
+++ b/tests/api/touch_exf.F90
@@ -1,3 +1,8 @@
+! -*- f90 -*-
+! Copyright (c) 2014-2021 The University of Tennessee and The University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
 PROGRAM TOUCH_EXF
 
   use, INTRINSIC :: ISO_C_BINDING, only : c_int

--- a/tests/api/touch_exf.F90
+++ b/tests/api/touch_exf.F90
@@ -27,7 +27,7 @@ end interface
 
   call MPI_INIT(ret)
 
-  call parsec_init(1, context)
+  call parsec_init(context)
 
   tp = touch_initialize_f08(BLOCK, N)
 

--- a/tests/apps/all2all/main.c
+++ b/tests/apps/all2all/main.c
@@ -15,7 +15,7 @@
 int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int size, repeat, rc;
     parsec_tiled_matrix_t *dcA, *dcB;
     parsec_taskpool_t *a2a;
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
     world = 1;
     rank = 0;
 #endif
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     size = 256;
     repeat = 10;

--- a/tests/apps/generalized_reduction/main.c
+++ b/tests/apps/generalized_reduction/main.c
@@ -19,7 +19,7 @@
 int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nt, nb, rc;
     parsec_tiled_matrix_t *dcA;
     parsec_taskpool_t *BT_reduction;
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     world = 1;
     rank = 0;
 #endif
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     nb = 1;
     nt = 7;

--- a/tests/apps/haar_tree/main.c
+++ b/tests/apps/haar_tree/main.c
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    parsec = parsec_init(-1, &pargc, &pargv);
+    parsec = parsec_init(&pargc, &pargv);
 
 
     while ((ch = getopt(argc, argv, "xvd:")) != -1) {

--- a/tests/apps/haar_tree/main.c
+++ b/tests/apps/haar_tree/main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2016-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "parsec/runtime.h"
 #include "parsec/data_dist/matrix/two_dim_rectangle_cyclic.h"
 #include "parsec/arena.h"

--- a/tests/apps/merge_sort/main.c
+++ b/tests/apps/merge_sort/main.c
@@ -17,7 +17,7 @@
 int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
-    int rank = 0, world = 1, cores = -1;
+    int rank = 0, world = 1;
     int nt = 1234, nb = 5, rc;
     parsec_tiled_matrix_t *dcA;
     parsec_taskpool_t *msort;
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(1);
     }

--- a/tests/apps/pingpong/bandwidth.jdf
+++ b/tests/apps/pingpong/bandwidth.jdf
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize PaRSEC */
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init(&pargc, &pargv);
 
     free(pargv);

--- a/tests/apps/pingpong/bandwidth.jdf
+++ b/tests/apps/pingpong/bandwidth.jdf
@@ -214,7 +214,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize PaRSEC */
-    parsec = parsec_init(cores, &pargc, &pargv);
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init(&pargc, &pargv);
 
     free(pargv);
     if( NULL == parsec ) {
@@ -224,15 +225,9 @@ int main(int argc, char *argv[])
         exit(-1);
     }
 
-    /* If the number of cores has not been defined as a parameter earlier
-     * update it with the default parameter computed in parsec_init. */
-    if(cores <= 0)
-    {
-        int p, nb_total_comp_threads = 0;
-        for(p = 0; p < parsec->nb_vp; p++) {
-            nb_total_comp_threads += parsec->virtual_processes[p]->nb_cores;
-        }
-        cores = nb_total_comp_threads;
+    /* compute the number of cores as detected from parsec */
+    for(int p = 0, cores = 0; p < parsec->nb_vp; p++) {
+        cores += parsec->virtual_processes[p]->nb_cores;
     }
 
     /* initializing matrix structure */

--- a/tests/apps/pingpong/main.c
+++ b/tests/apps/pingpong/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tests/apps/pingpong/main.c
+++ b/tests/apps/pingpong/main.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     size = 256;
 

--- a/tests/apps/stencil/testing_stencil_1D.c
+++ b/tests/apps/stencil/testing_stencil_1D.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize PaRSEC */
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init(&pargc, &pargv);
 
     if( NULL == parsec ) {

--- a/tests/apps/stencil/testing_stencil_1D.c
+++ b/tests/apps/stencil/testing_stencil_1D.c
@@ -95,7 +95,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize PaRSEC */
-    parsec = parsec_init(cores, &pargc, &pargv);
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init(&pargc, &pargv);
 
     if( NULL == parsec ) {
         /* Failed to correctly initialize. In a correct scenario report
@@ -104,15 +105,9 @@ int main(int argc, char *argv[])
         exit(-1);
     }
 
-    /* If the number of cores has not been defined as a parameter earlier
-     * update it with the default parameter computed in parsec_init. */
-    if(cores <= 0)
-    {
-        int p, nb_total_comp_threads = 0;
-        for(p = 0; p < parsec->nb_vp; p++) {
-            nb_total_comp_threads += parsec->virtual_processes[p]->nb_cores;
-        }
-        cores = nb_total_comp_threads;
+    /* compute the number of cores as detected from parsec */
+    for(int p = 0, cores = 0; p < parsec->nb_vp; p++) {
+        cores += parsec->virtual_processes[p]->nb_cores;
     }
 
     /* Make sure valid parameters are passed */

--- a/tests/collections/kcyclic.jdf
+++ b/tests/collections/kcyclic.jdf
@@ -39,7 +39,8 @@ int main( int argc, char** argv )
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif
 
-    parsec = parsec_init(1, &argc, &argv);
+    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-2);
     }

--- a/tests/collections/kcyclic.jdf
+++ b/tests/collections/kcyclic.jdf
@@ -39,7 +39,7 @@ int main( int argc, char** argv )
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif
 
-    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec_param_set_int("runtime_num_cores", 1);
     parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-2);

--- a/tests/collections/redistribute/common.c
+++ b/tests/collections/redistribute/common.c
@@ -402,7 +402,7 @@ parsec_context_t* setup_parsec(int argc, char **argv, int *iparam, double *dpara
         for( parsec_argc = 1, idx++; idx < argc;
              parsec_argv[parsec_argc] = argv[idx], parsec_argc++, idx++);
     }
-    parsec_setenv_mca_param_int("runtime_num_cores", iparam[IPARAM_NCORES]);
+    parsec_param_set_int("runtime_num_cores", iparam[IPARAM_NCORES]);
     parsec_context_t* ctx = parsec_init(&parsec_argc, &parsec_argv);
     free(parsec_argv);
     if( NULL == ctx ) {

--- a/tests/collections/redistribute/common.c
+++ b/tests/collections/redistribute/common.c
@@ -402,8 +402,8 @@ parsec_context_t* setup_parsec(int argc, char **argv, int *iparam, double *dpara
         for( parsec_argc = 1, idx++; idx < argc;
              parsec_argv[parsec_argc] = argv[idx], parsec_argc++, idx++);
     }
-    parsec_context_t* ctx = parsec_init(iparam[IPARAM_NCORES],
-                                      &parsec_argc, &parsec_argv);
+    parsec_setenv_mca_param_int("runtime_num_cores", iparam[IPARAM_NCORES]);
+    parsec_context_t* ctx = parsec_init(&parsec_argc, &parsec_argv);
     free(parsec_argv);
     if( NULL == ctx ) {
         /* Failed to correctly initialize. In a correct scenario report

--- a/tests/collections/reduce.c
+++ b/tests/collections/reduce.c
@@ -34,7 +34,7 @@ int main( int argc, char* argv[] )
     int rc;
     parsec_taskpool_t* tp;
     parsec_matrix_block_cyclic_t dcA;
-    int cores = -1, world = 1, rank = 0;
+    int world = 1, rank = 0;
     int nb = 100, ln = 900;
     int rows = 1;
     parsec_datatype_t newtype;
@@ -60,7 +60,7 @@ int main( int argc, char* argv[] )
         }
     }
 
-    parsec = parsec_init(cores, &pargc, &pargv);
+    parsec = parsec_init(&pargc, &pargv);
 
     parsec_matrix_block_cyclic_init( &dcA, PARSEC_MATRIX_FLOAT, PARSEC_MATRIX_TILE,
                                rank, nb, 1, ln, 1, 0, 0, ln, 1,

--- a/tests/collections/reshape/common.h
+++ b/tests/collections/reshape/common.h
@@ -118,7 +118,7 @@ int reshape_print(parsec_execution_stream_t *es,
             break;                                                                       \
         }                                                                                \
     }                                                                                    \
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);                             \
+    parsec_param_set_int("runtime_num_cores", cores);                                    \
     parsec = parsec_init(&pargc, &pargv);                                                \
     if( NULL == parsec ) {                                                               \
         /* Failed to correctly initialize. In a correct scenario report*/                \

--- a/tests/collections/reshape/common.h
+++ b/tests/collections/reshape/common.h
@@ -118,7 +118,8 @@ int reshape_print(parsec_execution_stream_t *es,
             break;                                                                       \
         }                                                                                \
     }                                                                                    \
-    parsec = parsec_init(cores, &pargc, &pargv);                                         \
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);                             \
+    parsec = parsec_init(&pargc, &pargv);                                                \
     if( NULL == parsec ) {                                                               \
         /* Failed to correctly initialize. In a correct scenario report*/                \
          /* upstream, but in this particular case bail out.*/                            \

--- a/tests/collections/two_dim_band/main.c
+++ b/tests/collections/two_dim_band/main.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize PaRSEC */
-    parsec = parsec_init(-1, &pargc, &pargv);
+    parsec = parsec_init(&pargc, &pargv);
 
     while ((ch = getopt(argc, argv, "N:T:s:S:P:p:f:F:b:h")) != -1) {
         switch (ch) {

--- a/tests/dsl/dtd/dtd_bench_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_bench_simple_gemm.c
@@ -591,9 +591,7 @@ int main(int argc, char **argv)
         while(loop) { sleep(1); }
     }
 
-    // Number of CPU cores involved
-    int ncores = -1; // Use all available cores
-    parsec_context = parsec_init(ncores, &pargc, &pargv);
+    parsec_context = parsec_init(&pargc, &pargv);
 
     int *cuda_device_index = NULL;
     if( PARSEC_DEV_CUDA == device ) {

--- a/tests/dsl/dtd/dtd_test_allreduce.c
+++ b/tests/dsl/dtd/dtd_test_allreduce.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
     parsec_context_t* parsec;
     parsec_arena_datatype_t *adt;
     int rc, nb, nt;
-    int rank, world, cores = -1, root = 0;
+    int rank, world, root = 0;
     int i;
     parsec_tiled_matrix_t *dcA;
 
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
         argc -= 1;
     }
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         return -1;
     }

--- a/tests/dsl/dtd/dtd_test_allreduce.c
+++ b/tests/dsl/dtd/dtd_test_allreduce.c
@@ -129,6 +129,13 @@ int main(int argc, char **argv)
         argc -= 1;
     }
 
+    MPI_Comm comm;
+    MPI_Comm_split(MPI_COMM_WORLD, rank%2, 0, &comm);
+    parsec_param_set_intptr("runtime_comm_ctx", comm);
+    if(rank%2) goto end;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &world);
+
     parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         return -1;
@@ -236,6 +243,7 @@ int main(int argc, char **argv)
 
     parsec_fini(&parsec);
 
+end:
 #ifdef PARSEC_HAVE_MPI
     MPI_Finalize();
 #endif

--- a/tests/dsl/dtd/dtd_test_broadcast.c
+++ b/tests/dsl/dtd/dtd_test_broadcast.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_broadcast.c
+++ b/tests/dsl/dtd/dtd_test_broadcast.c
@@ -52,7 +52,7 @@ task_rank_1( parsec_execution_stream_t *es,
 int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
     parsec_arena_datatype_t *adt;
@@ -72,11 +72,7 @@ int main(int argc, char **argv)
     nb = 1; /* tile_size */
     nt = world; /* total no. of tiles */
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_cuda_task_insert.c
+++ b/tests/dsl/dtd/dtd_test_cuda_task_insert.c
@@ -896,9 +896,7 @@ int main(int argc, char **argv)
     rank = 0;
 #endif
 
-    // Number of CPU cores involved
-    int ncores = -1; // Use all available cores
-    parsec_context = parsec_init(ncores, &argc, &argv);
+    parsec_context = parsec_init(&argc, &argv);
 
     rc = !(get_nb_cuda_devices() >= 1);
     print_test_result("Have CUDA accelerators", rc);

--- a/tests/dsl/dtd/dtd_test_data_flush.c
+++ b/tests/dsl/dtd/dtd_test_data_flush.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_data_flush.c
+++ b/tests/dsl/dtd/dtd_test_data_flush.c
@@ -84,7 +84,7 @@ task_to_check_overhead_15(parsec_execution_stream_t *es, parsec_task_t *this_tas
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
 
@@ -100,14 +100,10 @@ int main(int argc, char ** argv)
     rank = 0;
 #endif
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
     int i, j, total_tasks = 10000;
 
     /* Creating parsec context and initializing dtd environment */
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     parsec_taskpool_t *dtd_tp;
 
     /*

--- a/tests/dsl/dtd/dtd_test_explicit_task_creation.c
+++ b/tests/dsl/dtd/dtd_test_explicit_task_creation.c
@@ -56,7 +56,7 @@ call_to_kernel_type_write( parsec_execution_stream_t    *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rc, rank = 0, world = 1, cores = -1;
+    int rc, rank = 0, world = 1;
     int nb, nt, i, no_of_tasks, key;
     parsec_tiled_matrix_t *dcA;
     parsec_arena_datatype_t *adt;
@@ -75,15 +75,11 @@ int main(int argc, char ** argv)
                       "Try with \"mpirun -np 1 .....\"\n" );
     }
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
     no_of_tasks = world;
     nb = 1; /* tile_size */
     nt = no_of_tasks; /* total no. of tiles */
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new(  );
 

--- a/tests/dsl/dtd/dtd_test_explicit_task_creation.c
+++ b/tests/dsl/dtd/dtd_test_explicit_task_creation.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_flag_dont_track.c
+++ b/tests/dsl/dtd/dtd_test_flag_dont_track.c
@@ -35,7 +35,7 @@ task_to_check_dont_track(parsec_execution_stream_t *es, parsec_task_t *this_task
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
 
@@ -56,12 +56,8 @@ int main(int argc, char ** argv)
                       "Try with \"mpirun -np 1 .....\"\n" );
     }
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
     /* Creating parsec context and initializing dtd environment */
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     /****** Checking Dont track flag ******/
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new(  );

--- a/tests/dsl/dtd/dtd_test_flag_dont_track.c
+++ b/tests/dsl/dtd/dtd_test_flag_dont_track.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_global_id_for_dc_assumed.c
+++ b/tests/dsl/dtd/dtd_test_global_id_for_dc_assumed.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
     nt = world; /* total no. of tiles */
     cores = 8;
 
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init( &argc, &argv );
 
     dcA = create_and_distribute_data(rank, world, nb, nt);

--- a/tests/dsl/dtd/dtd_test_global_id_for_dc_assumed.c
+++ b/tests/dsl/dtd/dtd_test_global_id_for_dc_assumed.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_global_id_for_dc_assumed.c
+++ b/tests/dsl/dtd/dtd_test_global_id_for_dc_assumed.c
@@ -42,7 +42,8 @@ int main(int argc, char **argv)
     nt = world; /* total no. of tiles */
     cores = 8;
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init( &argc, &argv );
 
     dcA = create_and_distribute_data(rank, world, nb, nt);
     parsec_data_collection_set_key((parsec_data_collection_t *)dcA, "A");

--- a/tests/dsl/dtd/dtd_test_hierarchy.c
+++ b/tests/dsl/dtd/dtd_test_hierarchy.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_hierarchy.c
+++ b/tests/dsl/dtd/dtd_test_hierarchy.c
@@ -97,7 +97,7 @@ test_task_generator( parsec_execution_stream_t *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1, rc;
+    int rank, world, rc;
     parsec_arena_datatype_t *adt;
 
 #if defined(PARSEC_HAVE_MPI)
@@ -117,7 +117,7 @@ int main(int argc, char ** argv)
     parsec_tiled_matrix_t *dcA;
     parsec_taskpool_t *dtd_tp;
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_insert_task_interface.c
+++ b/tests/dsl/dtd/dtd_test_insert_task_interface.c
@@ -57,7 +57,7 @@ call_to_kernel_type_write( parsec_execution_stream_t    *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rc, rank, world, cores = -1;
+    int rc, rank, world;
     int nb, nt, i, no_of_tasks, key;
     parsec_tiled_matrix_t *dcA;
     parsec_arena_datatype_t *adt;
@@ -79,15 +79,11 @@ int main(int argc, char ** argv)
                       "Try with \"mpirun -np 1 .....\"\n" );
     }
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
     no_of_tasks = world;
     nb = 1; /* tile_size */
     nt = no_of_tasks; /* total no. of tiles */
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new(  );
 

--- a/tests/dsl/dtd/dtd_test_insert_task_interface.c
+++ b/tests/dsl/dtd/dtd_test_insert_task_interface.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_interleave_actions.c
+++ b/tests/dsl/dtd/dtd_test_interleave_actions.c
@@ -129,8 +129,7 @@ int main(int argc, char **argv) {
    nb = 1;
    nt = 1;
 
-   int ncores = -1;
-   parsec_context = parsec_init(ncores, &pargc, &pargv);
+   parsec_context = parsec_init(&pargc, &pargv);
 
    if(world == 1) {
        parsec_warning("*** This test only makes sense with at least two nodes");

--- a/tests/dsl/dtd/dtd_test_multiple_handle_wait.c
+++ b/tests/dsl/dtd/dtd_test_multiple_handle_wait.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_multiple_handle_wait.c
+++ b/tests/dsl/dtd/dtd_test_multiple_handle_wait.c
@@ -32,9 +32,7 @@ task_to_check_generation(parsec_execution_stream_t *es, parsec_task_t *this_task
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1, rc;
-    int parsec_argc;
-    char** parsec_argv;
+    int rank, world, rc;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -48,16 +46,8 @@ int main(int argc, char ** argv)
     rank = 0;
 #endif
 
-    parsec_argv = &argv[1];
-    parsec_argc = argc - 1;
-    if(argv[1] != NULL) {
-        cores = atoi(argv[1]);
-        parsec_argv++;
-        parsec_argc--;
-    }
-
     /* Creating parsec context and initializing dtd environment */
-    parsec = parsec_init( cores, &parsec_argc, &parsec_argv );
+    parsec = parsec_init( &argc, &argv );
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/dtd/dtd_test_null_as_tile.c
+++ b/tests/dsl/dtd/dtd_test_null_as_tile.c
@@ -36,11 +36,7 @@ call_to_kernel_type( parsec_execution_stream_t *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1, rc;
-
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
+    int rank, world, rc;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -57,7 +53,7 @@ int main(int argc, char ** argv)
     int m;
     int no_of_tasks = 1;
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new(  );
 

--- a/tests/dsl/dtd/dtd_test_null_as_tile.c
+++ b/tests/dsl/dtd/dtd_test_null_as_tile.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_pingpong.c
+++ b/tests/dsl/dtd/dtd_test_pingpong.c
@@ -76,7 +76,7 @@ task_rank_1( parsec_execution_stream_t  *es,
 int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
     parsec_arena_datatype_t *adt;
@@ -104,11 +104,7 @@ int main(int argc, char **argv)
     nb = 1; /* tile_size */
     nt = 2; /* total no. of tiles */
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_pingpong.c
+++ b/tests/dsl/dtd/dtd_test_pingpong.c
@@ -1,8 +1,10 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
+
+/* parsec things */
 #include "parsec/runtime.h"
 
 /* system and io */

--- a/tests/dsl/dtd/dtd_test_reduce.c
+++ b/tests/dsl/dtd/dtd_test_reduce.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_reduce.c
+++ b/tests/dsl/dtd/dtd_test_reduce.c
@@ -55,7 +55,7 @@ task_rank_1( parsec_execution_stream_t    *es,
 int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
     parsec_arena_datatype_t *adt;
@@ -75,11 +75,7 @@ int main(int argc, char **argv)
     nb = 1; /* tile_size */
     nt = world; /* total no. of tiles */
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new(  );
 

--- a/tests/dsl/dtd/dtd_test_task_generation.c
+++ b/tests/dsl/dtd/dtd_test_task_generation.c
@@ -112,7 +112,7 @@ task_to_check_overhead_15(parsec_execution_stream_t *es, parsec_task_t *this_tas
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
 
@@ -136,12 +136,8 @@ int main(int argc, char ** argv)
                       "Try with \"mpirun -np 1 .....\"\n" );
     }
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
     /* Creating parsec context and initializing dtd environment */
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     /****** Checking task generation ******/
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();

--- a/tests/dsl/dtd/dtd_test_task_generation.c
+++ b/tests/dsl/dtd/dtd_test_task_generation.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_task_inserting_task.c
+++ b/tests/dsl/dtd/dtd_test_task_inserting_task.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_task_inserting_task.c
+++ b/tests/dsl/dtd/dtd_test_task_inserting_task.c
@@ -62,11 +62,7 @@ task_to_insert_task( parsec_execution_stream_t *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1, rc;
-
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
+    int rank, world, rc;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -83,7 +79,7 @@ int main(int argc, char ** argv)
     int m;
     int no_of_tasks = 1;
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new(  );
 

--- a/tests/dsl/dtd/dtd_test_task_insertion.c
+++ b/tests/dsl/dtd/dtd_test_task_insertion.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_task_insertion.c
+++ b/tests/dsl/dtd/dtd_test_task_insertion.c
@@ -75,11 +75,7 @@ test_task_generator( parsec_execution_stream_t *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1, rc;
-
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
+    int cores = 0, rank, world, rc;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -98,7 +94,11 @@ int main(int argc, char ** argv)
     int amount_of_work[3] = {100, 1000, 10000};
     parsec_taskpool_t *dtd_tp;
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
+    /* compute the number of cores as detected from parsec */
+    for(int p = 0; p < parsec->nb_vp; p++) {
+        cores += parsec->virtual_processes[p]->nb_cores;
+    }
 
     dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_task_placement.c
+++ b/tests/dsl/dtd/dtd_test_task_placement.c
@@ -78,7 +78,7 @@ task_moving_data(parsec_execution_stream_t *es,
 int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
     parsec_arena_datatype_t *adt;
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
     nb = 1; /* tile_size */
     nt = world; /* total no. of tiles */
 
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_task_placement.c
+++ b/tests/dsl/dtd/dtd_test_task_placement.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_template_counter.c
+++ b/tests/dsl/dtd/dtd_test_template_counter.c
@@ -51,7 +51,7 @@ task_rank_1( parsec_execution_stream_t *es,
 int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, i, rc;
     parsec_tiled_matrix_t *dcA;
     parsec_arena_datatype_t *adt;
@@ -71,11 +71,7 @@ int main(int argc, char **argv)
     nb = 1; /* tile_size */
     nt = world; /* total no. of tiles */
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_template_counter.c
+++ b/tests/dsl/dtd/dtd_test_template_counter.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_tp_enqueue_dequeue.c
+++ b/tests/dsl/dtd/dtd_test_tp_enqueue_dequeue.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 #include "parsec/parsec_config.h"
 
 /* system and io */

--- a/tests/dsl/dtd/dtd_test_tp_enqueue_dequeue.c
+++ b/tests/dsl/dtd/dtd_test_tp_enqueue_dequeue.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
     int rc, i;
-    int rank, world, cores = -1;
+    int rank, world;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -110,11 +110,7 @@ int main(int argc, char **argv)
                       "Try with \"mpirun -np 1 .....\"\n" );
     }
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_untie.c
+++ b/tests/dsl/dtd/dtd_test_untie.c
@@ -118,7 +118,7 @@ int main(int argc, char ** argv)
 
     int tasks_in_each_chain[3] = {1000, 10000, 100000};
 
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init( &argc, &argv );
     /* compute the number of cores as detected from parsec */
     for(int p = 0, cores = 0; p < parsec->nb_vp; p++) {

--- a/tests/dsl/dtd/dtd_test_untie.c
+++ b/tests/dsl/dtd/dtd_test_untie.c
@@ -80,13 +80,7 @@ test_task_generator( parsec_execution_stream_t *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1, rc;
-
-    if(argc > 1) {
-        cores = atoi(argv[1]);
-    }
-    if( 0 >= cores )
-        cores = 8;  /* fix it to a sane number */
+    int rank, world, cores = 8, rc;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -117,10 +111,15 @@ int main(int argc, char ** argv)
     parsec_taskpool_t *dtd_tp;
     parsec_arena_datatype_t *adt;
 
-    no_of_chain = cores;
     int tasks_in_each_chain[3] = {1000, 10000, 100000};
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init( &argc, &argv );
+    /* compute the number of cores as detected from parsec */
+    for(int p = 0, cores = 0; p < parsec->nb_vp; p++) {
+        cores += parsec->virtual_processes[p]->nb_cores;
+    }
+    no_of_chain = cores;
 
     dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_untie.c
+++ b/tests/dsl/dtd/dtd_test_untie.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/dtd/dtd_test_war.c
+++ b/tests/dsl/dtd/dtd_test_war.c
@@ -58,7 +58,7 @@ call_to_kernel_type_write( parsec_execution_stream_t    *es,
 int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int nb, nt, rc;
     parsec_tiled_matrix_t *dcA;
 
@@ -78,15 +78,11 @@ int main(int argc, char ** argv)
     rank = 0;
 #endif
 
-    if(argv[1] != NULL){
-        cores = atoi(argv[1]);
-    }
-
     no_of_tasks = world;
     nb = 1; /* tile_size */
     nt = no_of_tasks; /* total no. of tiles */
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( &argc, &argv );
 
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 

--- a/tests/dsl/dtd/dtd_test_war.c
+++ b/tests/dsl/dtd/dtd_test_war.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 /* parsec things */
 #include "parsec/runtime.h"
 

--- a/tests/dsl/ptg/branching/main.c
+++ b/tests/dsl/ptg/branching/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tests/dsl/ptg/branching/main.c
+++ b/tests/dsl/ptg/branching/main.c
@@ -22,7 +22,7 @@ volatile int32_t nb_taskC = 0;
 int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
-    int rank, world, cores = 1;
+    int rank, world;
     int size, nb, rc;
     parsec_data_collection_t *dcA;
     parsec_taskpool_t *branching;
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     world = 1;
     rank = 0;
 #endif
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     size = 256;
     if(argc != 2) {

--- a/tests/dsl/ptg/choice/main.c
+++ b/tests/dsl/ptg/choice/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tests/dsl/ptg/choice/main.c
+++ b/tests/dsl/ptg/choice/main.c
@@ -21,7 +21,7 @@
 int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int size, nb, i, j, c, rc;
     parsec_data_collection_t *dcA;
     int *decision;
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     }
 
     pargv = &dargv;
-    parsec = parsec_init(cores, &j, pargv);
+    parsec = parsec_init(&j, pargv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/complex_deps.jdf
+++ b/tests/dsl/ptg/complex_deps.jdf
@@ -149,7 +149,8 @@ int main( int argc, char** argv )
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif  /* DISTRIBUTED */
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/complex_deps.jdf
+++ b/tests/dsl/ptg/complex_deps.jdf
@@ -149,7 +149,7 @@ int main( int argc, char** argv )
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif  /* DISTRIBUTED */
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);

--- a/tests/dsl/ptg/controlgather/main.c
+++ b/tests/dsl/ptg/controlgather/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tests/dsl/ptg/controlgather/main.c
+++ b/tests/dsl/ptg/controlgather/main.c
@@ -18,7 +18,7 @@
 int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
-    int rank, world, cores = -1;
+    int rank, world;
     int size, nb, rc;
     parsec_data_collection_t *dcA;
     parsec_taskpool_t *ctlgat;
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
     world = 1;
     rank = 0;
 #endif
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     size = 256;
     nb   = 4 * world;

--- a/tests/dsl/ptg/cuda/nvlink_main.c
+++ b/tests/dsl/ptg/cuda/nvlink_main.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2020 The University of Tennessee and The University
+ * Copyright (c) 2019-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tests/dsl/ptg/cuda/nvlink_main.c
+++ b/tests/dsl/ptg/cuda/nvlink_main.c
@@ -31,8 +31,8 @@ int main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif /* DISTRIBUTED */
-    
-    parsec = parsec_init(-1, &argc, &argv);
+
+    parsec = parsec_init(&argc, &argv);
 
     tp = testing_nvlink_New(parsec, 10, 512);
     if( NULL != tp ) {

--- a/tests/dsl/ptg/cuda/stage_main.c
+++ b/tests/dsl/ptg/cuda/stage_main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "parsec.h"
 #include "parsec/data_distribution.h"
 #include "parsec/data_dist/matrix/matrix.h"

--- a/tests/dsl/ptg/cuda/stage_main.c
+++ b/tests/dsl/ptg/cuda/stage_main.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
         }
     }
     /* Initialize PaRSEC */
-    parsec = parsec_init(-1, &pargc, &pargv);
+    parsec = parsec_init(&pargc, &pargv);
     if( NULL == parsec ) {
         /* Failed to correctly initialize. In a correct scenario report*/
          /* upstream, but in this particular case bail out.*/

--- a/tests/dsl/ptg/cuda/stress_main.c
+++ b/tests/dsl/ptg/cuda/stress_main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "parsec.h"
 #include "parsec/data_distribution.h"
 #include "parsec/data_dist/matrix/matrix.h"

--- a/tests/dsl/ptg/cuda/stress_main.c
+++ b/tests/dsl/ptg/cuda/stress_main.c
@@ -25,8 +25,8 @@ int main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif /* DISTRIBUTED */
-    
-    parsec = parsec_init(-1, &argc, &argv);
+
+    parsec = parsec_init(&argc, &argv);
 
     tp = testing_stress_New(parsec, 4000, 1024);
     if( NULL != tp ) {
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
         parsec_context_wait(parsec);
         parsec_taskpool_free(tp);
     }
-    
+
     parsec_fini(&parsec);
 #if defined(DISTRIBUTED)
     MPI_Finalize();

--- a/tests/dsl/ptg/cuda/testing_get_best_device.c
+++ b/tests/dsl/ptg/cuda/testing_get_best_device.c
@@ -106,10 +106,10 @@ int main(int argc, char *argv[])
     if( nb_gpus < 1 && 0 == rank ) {
 	    fprintf(stderr, "Warnning: if run on GPUs, please set --gpus=value bigger than 0\n");
     }
-    parsec_setenv_mca_param_int( "device_cuda_enabled", nb_gpus );
+    parsec_param_set_int( "device_cuda_enabled", nb_gpus );
 #endif
     if( -1 != cores )
-        parsec_setenv_mca_param_int( "runtime_num_cores", cores );
+        parsec_param_set_int( "runtime_num_cores", cores );
 
     /* Initialize PaRSEC */
     parsec = parsec_init(&pargc, &pargv);

--- a/tests/dsl/ptg/cuda/testing_get_best_device.c
+++ b/tests/dsl/ptg/cuda/testing_get_best_device.c
@@ -103,18 +103,16 @@ int main(int argc, char *argv[])
     }
 
 #if defined(PARSEC_HAVE_CUDA)
-    extern char **environ;
-    char *value;
     if( nb_gpus < 1 && 0 == rank ) {
 	    fprintf(stderr, "Warnning: if run on GPUs, please set --gpus=value bigger than 0\n");
     }
-    asprintf(&value, "%d", nb_gpus);
-    parsec_setenv_mca_param( "device_cuda_enabled", value, &environ );
-    free(value);
+    parsec_setenv_mca_param_int( "device_cuda_enabled", nb_gpus );
 #endif
+    if( -1 != cores )
+        parsec_setenv_mca_param_int( "runtime_num_cores", cores );
 
     /* Initialize PaRSEC */
-    parsec = parsec_init(cores, &pargc, &pargv);
+    parsec = parsec_init(&pargc, &pargv);
 
     if( NULL == parsec ) {
         /* Failed to correctly initialize. In a correct scenario report
@@ -125,7 +123,6 @@ int main(int argc, char *argv[])
 
     /* If the number of cores has not been defined as a parameter earlier
      * update it with the default parameter computed in parsec_init. */
-    if(cores <= 0)
     {
         int p, nb_total_comp_threads = 0;
         for(p = 0; p < parsec->nb_vp; p++) {

--- a/tests/dsl/ptg/local-indices/local_indices.jdf
+++ b/tests/dsl/ptg/local-indices/local_indices.jdf
@@ -1,9 +1,8 @@
 extern "C" %{
 /*
- * Copyright (c) 2019-2020 The University of Tennessee and The University
+ * Copyright (c) 2019-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- *
  */
 
 #include <sys/time.h>

--- a/tests/dsl/ptg/local-indices/local_indices.jdf
+++ b/tests/dsl/ptg/local-indices/local_indices.jdf
@@ -144,7 +144,7 @@ int main( int argc, char** argv )
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
        exit(-1);
     }

--- a/tests/dsl/ptg/ptgpp/forward_READ_NULL.jdf
+++ b/tests/dsl/ptg/ptgpp/forward_READ_NULL.jdf
@@ -1,4 +1,9 @@
 extern "C" %{
+/*
+ * Copyright (c) 2014-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 
 /*
  * Copyright (c) 2014-2020 The University of Tennessee and The University

--- a/tests/dsl/ptg/ptgpp/forward_READ_NULL.jdf
+++ b/tests/dsl/ptg/ptgpp/forward_READ_NULL.jdf
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     /**
      * Let's initialize the task distribution descriptor

--- a/tests/dsl/ptg/ptgpp/forward_RW_NULL.jdf
+++ b/tests/dsl/ptg/ptgpp/forward_RW_NULL.jdf
@@ -1,4 +1,9 @@
 extern "C" %{
+/*
+ * Copyright (c) 2014-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 
 /*
  * Copyright (c) 2014-2020 The University of Tennessee and The University

--- a/tests/dsl/ptg/ptgpp/forward_RW_NULL.jdf
+++ b/tests/dsl/ptg/ptgpp/forward_RW_NULL.jdf
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
 
     /**
      * Let's initialize the task distribution descriptor

--- a/tests/dsl/ptg/ptgpp/too_many_in_deps.jdf
+++ b/tests/dsl/ptg/ptgpp/too_many_in_deps.jdf
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/ptgpp/too_many_local_vars.jdf
+++ b/tests/dsl/ptg/ptgpp/too_many_local_vars.jdf
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/ptgpp/too_many_out_deps.jdf
+++ b/tests/dsl/ptg/ptgpp/too_many_out_deps.jdf
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/ptgpp/too_many_read_flows.jdf
+++ b/tests/dsl/ptg/ptgpp/too_many_read_flows.jdf
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/ptgpp/too_many_write_flows.jdf
+++ b/tests/dsl/ptg/ptgpp/too_many_write_flows.jdf
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/ptgpp/write_check.jdf
+++ b/tests/dsl/ptg/ptgpp/write_check.jdf
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
         argc -= 1;
     }
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/startup.jdf
+++ b/tests/dsl/ptg/startup.jdf
@@ -127,7 +127,7 @@ int main( int argc, char** argv )
         argc -= 1;
     }
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     if( NULL == parsec ) {
        exit(-1);
     }

--- a/tests/dsl/ptg/startup.jdf
+++ b/tests/dsl/ptg/startup.jdf
@@ -1,10 +1,9 @@
 extern "C" %{
 /*
- * Copyright (c) 2019-2020 The Universiy of Tennessee and The Universiy
- *                         of Tennessee Research Foundation. All rights
+ * Copyright (c) 2013-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
-
 #include <sys/time.h>
 #include <inttypes.h>
 #include <string.h>

--- a/tests/dsl/ptg/strange.jdf
+++ b/tests/dsl/ptg/strange.jdf
@@ -154,7 +154,7 @@ int main(int argc, char* argv[] )
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(&argc, &argv);
     assert( NULL != parsec );
 
     parsec_matrix_block_cyclic_init( &descA, TYPE, PARSEC_MATRIX_TILE,

--- a/tests/dsl/ptg/user-defined-functions/main.c
+++ b/tests/dsl/ptg/user-defined-functions/main.c
@@ -102,7 +102,8 @@ int main(int argc, char *argv[])
 
     largc = argc - optind;
     largv = argv + optind;
-    parsec = parsec_init(cores, &largc, &largv);
+    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec = parsec_init(&largc, &largv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/user-defined-functions/main.c
+++ b/tests/dsl/ptg/user-defined-functions/main.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 
     largc = argc - optind;
     largv = argv + optind;
-    parsec_setenv_mca_param_int("runtime_num_cores", cores);
+    parsec_param_set_int("runtime_num_cores", cores);
     parsec = parsec_init(&largc, &largv);
     if( NULL == parsec ) {
         exit(-1);

--- a/tests/dsl/ptg/user-defined-functions/main.c
+++ b/tests/dsl/ptg/user-defined-functions/main.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2019-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 #include <unistd.h>
 #include <getopt.h>
 

--- a/tests/profiling/async.jdf
+++ b/tests/profiling/async.jdf
@@ -1,4 +1,10 @@
 extern "C" %{
+/*
+ * Copyright (c) 2020-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include <sys/time.h>
 #include <inttypes.h>
 #include <string.h>

--- a/tests/profiling/async.jdf
+++ b/tests/profiling/async.jdf
@@ -198,7 +198,7 @@ int main( int argc, char** argv )
         argc--;
     }
 
-    parsec = parsec_init(-1, &parsec_argc, &parsec_argv);
+    parsec = parsec_init(&parsec_argc, &parsec_argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/runtime/dtt_bug_replicator_ex.c
+++ b/tests/runtime/dtt_bug_replicator_ex.c
@@ -45,7 +45,8 @@ int main( int argc, char** argv )
     rank = 0;
 #endif
 
-    parsec = parsec_init(1, &argc, &argv);
+    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec = parsec_init(&argc, &argv);
     assert( NULL != parsec );
 
     PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,

--- a/tests/runtime/dtt_bug_replicator_ex.c
+++ b/tests/runtime/dtt_bug_replicator_ex.c
@@ -45,7 +45,7 @@ int main( int argc, char** argv )
     rank = 0;
 #endif
 
-    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec_param_set_int("runtime_num_cores", 1);
     parsec = parsec_init(&argc, &argv);
     assert( NULL != parsec );
 

--- a/tests/runtime/multichain.jdf
+++ b/tests/runtime/multichain.jdf
@@ -155,7 +155,8 @@ int main(int argc, char* argv[])
     }
     create_communicators();
 #endif  /* DISTRIBUTED */
-    parsec = parsec_init(2, &argc, &argv);
+    parsec_setenv_mca_param_int("runtime_num_cores", 2);
+    parsec = parsec_init(&argc, &argv);
     assert( NULL != parsec );
 
     for( i = 0; i < max_comms; i++ ) {

--- a/tests/runtime/multichain.jdf
+++ b/tests/runtime/multichain.jdf
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
     }
     create_communicators();
 #endif  /* DISTRIBUTED */
-    parsec_setenv_mca_param_int("runtime_num_cores", 2);
+    parsec_param_set_int("runtime_num_cores", 2);
     parsec = parsec_init(&argc, &argv);
     assert( NULL != parsec );
 

--- a/tests/runtime/scheduling/main.c
+++ b/tests/runtime/scheduling/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 The University of Tennessee and The University
+ * Copyright (c) 2013-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tests/runtime/scheduling/main.c
+++ b/tests/runtime/scheduling/main.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE);
     }
 
-    parsec = parsec_init(0, &parsec_argc, &parsec_argv);
+    parsec = parsec_init(&parsec_argc, &parsec_argv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tools/grapher.c
+++ b/tools/grapher.c
@@ -176,6 +176,8 @@ static int dump_graph(const char *filename)
     return 0;
 }
 
+extern char **environ;
+
 int main(int argc, char *argv[])
 {
     int i;
@@ -185,7 +187,8 @@ int main(int argc, char *argv[])
     parsec_context_t *parsec;
 
     o = NULL;
-    parsec = parsec_init( 1, &argc, &argv, 1 );
+    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec = parsec_init(&argc, &argv);
     for(i = 0; i < NB_CREATE_FUNCTIONS; i++) {
         if( !strcmp( create_functions[i].command_name, argv[1]) ) {
             o = create_functions[i].create_function(argc-2, argv+2);

--- a/tools/grapher.c
+++ b/tools/grapher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2017 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tools/grapher.c
+++ b/tools/grapher.c
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
     parsec_context_t *parsec;
 
     o = NULL;
-    parsec_setenv_mca_param_int("runtime_num_cores", 1);
+    parsec_param_set_int("runtime_num_cores", 1);
     parsec = parsec_init(&argc, &argv);
     for(i = 0; i < NB_CREATE_FUNCTIONS; i++) {
         if( !strcmp( create_functions[i].command_name, argv[1]) ) {


### PR DESCRIPTION
https://bitbucket.org/icldistcomp/parsec/pull-requests/493

- [x] add info comm=%p to permit selection of comm before init
- [ ] add parsec_info_create, use parsec_info_set to pass-in arguments to parsec before parsec_init
- [x] Dplasma corresponding request
- [x] rename setenv_mca_param_int to something less obnoxious
- [x] include definition of setenv_mca_param_int from public API
- [ ] decide what to do with argc, argv
    * We will keep argc/argv so that command line parameters can be 'cleaned-up' and return only argc/argv that PaRSEC didn't consume, it should be valid to pass NULL, NULL.
- [x] update copyrights