### PR TITLE
[BBT#582] bugfix/atomic lifo: The offsetof was incorrect leading to lifo padding being wrong in external lifo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1008,7 +1008,11 @@ check_type_size("parsec_lifo_t" PARSEC_LIFO_OPAQUE_SIZEOF)
 include(CheckStructureFieldOffset)
 # NB: the structure below *needs* to be kept in sync with the structure
 # in lifo-external.h
-check_structure_field_offset("lifo_private" "struct{parsec_object_t super;uint8_t alignment;char lifo_private;}" PARSEC_LIFO_HEAD_OFFSET)
+if(PARSEC_ATOMIC_HAS_ATOMIC_CAS_INT128)
+    check_structure_field_offset("lifo_private" "struct{parsec_object_t super;uint8_t alignment; union{__int128_t i128; char lifo_private;};}" PARSEC_LIFO_HEAD_OFFSET)
+else()
+    check_structure_field_offset("lifo_private" "struct{parsec_object_t super;uint8_t alignment; union{int64_t i64; char lifo_private;};}" PARSEC_LIFO_HEAD_OFFSET)
+endif()
 cmake_pop_check_state()
 
 if( PARSEC_LIFO_HEAD_OFFSET )


### PR DESCRIPTION
https://bitbucket.org/icldistcomp/parsec/pull-requests/582

atomic lifo: The offsetoff was computed incorrectly because it didn't account for alignment and that caused static initializers to overspill

This would cause DPLASMA ctest to fail in spectacular ways. 

Tested with C11 128bit atomics and 64bit CAS (gcc/7.3.0)

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>