### PR TITLE
[BBT#541] A new way to install the internal headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,33 +1038,9 @@ else()
 endif()
 
 install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR})
-
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/runtime.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/ayudame.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/constants.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/parsec_config_bottom.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/data_distribution.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/datatype.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/profiling.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/dictionary.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/data.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/private_mempool.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/deprecated.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec)
-
-install(FILES
   ${PROJECT_INCLUDE_DIR}/parsec/parsec_options.h
   DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec
   RENAME parsec_config.h)
-
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/output.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/debug.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/mca_param.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/utils)
 #
 # Never install directly the parsec/class/lifo.h header.
 # Instead replace it with the lifo-external.h during the installation.
@@ -1073,76 +1049,6 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/parsec/class/lifo-external.h
   DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/class
   RENAME lifo.h)
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/parsec_object.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/parsec_hash_table.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/list_item.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/parsec_rwlock.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/fifo.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/barrier.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/list.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/info.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/parsec_future.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/class)
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/scheduling.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/recursive.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/remote_dep.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/parsec_description_structures.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/datarepo.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/mempool.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/data_internal.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/arena.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/execution_stream.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/parsec_internal.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/vpmap.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec)
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/mca/pins/pins.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/mca/pins)
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/mca/mca.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/mca)
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsec/interfaces/interface.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/interfaces/ )
-if(PARSEC_PROF_GRAPHER)
-  install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/parsec_prof_grapher.h
-    DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec )
-endif(PARSEC_PROF_GRAPHER)
-# Install header files for jdf generated code
-if( PARSEC_WITH_DEVEL_HEADERS )
-  install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/parsec_binary_profile.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/hbbuffer.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/include/parsec/os-spec-timing.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/maxheap.h
-    DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec )
-
-  install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/mca/pins/pins_papi_utils.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/mca/pins/pins_tau_utils.h
-    DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/mca/pins )
-
-  install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/argv.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/cmd_line.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/parsec_environ.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/mca_param_cmd_line.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/os_path.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/output.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/show_help.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/utils/zone_malloc.h
-    DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/utils )
-
-  install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/dequeue.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/parsec/class/fifo.h
-    DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/class )
-
-endif(PARSEC_WITH_DEVEL_HEADERS)
-
 #
 # Never install directly the parsec/include/parsec/sys/atomic.h header.
 # Instead replace it with the atomic-external.h during the installation.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -74,20 +74,20 @@ will appear in the ``config.log``) by using the following form:
 
     configure CC=icc FC=ftn CXX=icpc -DPARSEC_DIST_SHORT_LIMIT=0
 
-Plarform Files
+Platform Files
 --------------
 
 Platform files, found in ``contrib/platforms`` let us distribute recipes
 for well known systems that may be similar to a supercomputer near you.
 For example, the ``ibm.ac922.summit`` file is intended to compile on the
-eponyme Oak Ridge Leadership Computing Facility system.
+eponym Oak Ridge Leadership Computing Facility system.
 
 .. code:: bash
 
   configure --prefix=$INSTALL_DIR --with-platform=ibm.ac922.summit --disable-debug
 
 This call should get you running in no time on that machine, and you
-may still customize and overide the platform file with command line
+may still customize and override the platform file with command line
 arguments.
 
 We also provide a ``macosx`` platform file that helps dealing with the
@@ -134,7 +134,7 @@ calling
 In this case, the configuration stage will also include a build stage
 to produce some of the utilities needed to compile PaRSEC. After
 the configure state has completed, you will find in your build directory
-a subdirectory named ``native`` that contains profiling and devellopper
+a subdirectory named ``native`` that contains profiling and developer
 tools that can be used on the frontend system.
 
 After the configure step has completed, the build step is carried out

--- a/parsec/CMakeLists.txt
+++ b/parsec/CMakeLists.txt
@@ -51,15 +51,6 @@ if(PARSEC_FLEX_GENERATED_OPTIONS)
     PROPERTIES COMPILE_OPTIONS "${PARSEC_FLEX_GENERATED_OPTIONS}")
 endif(PARSEC_FLEX_GENERATED_OPTIONS)
 
-# Read the Modular Components
-#   This must be read using include and not add_subdirectory because
-#   we want the mca/CMakeLists.txt to export the MCA_EXTRA_SOURCES it builds.
-include(mca/CMakeLists.txt)
-
-# Import all the available Domain Specific Language interfaces
-include(interfaces/CMakeLists.txt)
-add_executable(PaRSEC::parsec-ptgpp ALIAS parsec-ptgpp)
-
 if( PARSEC_PAPI_SDE )
   list(APPEND EXTRA_SOURCES "papi_sde.c")
 endif( PARSEC_PAPI_SDE )
@@ -97,10 +88,7 @@ set(SOURCES
   vpmap.c
   maxheap.c
   hbbuffer.c
-  datarepo.c
-  ${EXTRA_SOURCES}
-  ${MCA_EXTRA_SOURCES}
-)
+  datarepo.c)
 if( PARSEC_PROF_TRACE )
   list(APPEND SOURCES dictionary.c)
 endif( PARSEC_PROF_TRACE )
@@ -120,6 +108,31 @@ endif( PARSEC_PROF_GRAPHER )
 # Setup targets
 #
 if( BUILD_PARSEC )
+  # As suggested @ https://crascit.com/2016/01/31/enhanced-source-file-handling-with-target_sources/
+  # create the target at the upper level and add sources to all directories below.
+  if(NOT TARGET parsec)
+    if( ${BUILD_SHARED_LIBS} )
+      add_library(parsec SHARED)
+    else( ${BUILD_SHARED_LIBS} )
+      add_library(parsec STATIC)
+    endif( ${BUILD_SHARED_LIBS} )
+  endif(NOT TARGET parsec)
+  add_library(PaRSEC::parsec ALIAS parsec)
+endif( BUILD_PARSEC )
+
+# Read the Modular Components
+#   This must be read using include and not add_subdirectory because
+#   we want the mca/CMakeLists.txt to export the MCA_EXTRA_SOURCES it builds.
+include(mca/CMakeLists.txt)
+
+# Import all the available Domain Specific Language interfaces
+include(interfaces/CMakeLists.txt)
+if(TARGET parsec-ptgpp)
+  add_executable(PaRSEC::parsec-ptgpp ALIAS parsec-ptgpp)
+endif(TARGET parsec-ptgpp)
+
+if( BUILD_PARSEC )
+
   # Build this as a collection of objects that can be easily either used to
   # create an interface library or imported into the main library.
   if(NOT TARGET parsec-base-obj)
@@ -150,19 +163,8 @@ if( BUILD_PARSEC )
     target_link_libraries(parsec-base PUBLIC parsec-base-obj)
   endif(NOT TARGET parsec-base)
 
-  # As suggested @ https://crascit.com/2016/01/31/enhanced-source-file-handling-with-target_sources/
-  # create the target at the upper level and add sources to all directories below.
-  if(NOT TARGET parsec)
-    if( ${BUILD_SHARED_LIBS} )
-      add_library(parsec SHARED)
-    else( ${BUILD_SHARED_LIBS} )
-      add_library(parsec STATIC mca/device/device_gpu.h mca/device/device_gpu.c)
-    endif( ${BUILD_SHARED_LIBS} )
-  endif(NOT TARGET parsec)
-  add_library(PaRSEC::parsec ALIAS parsec)
-
   target_sources(parsec PRIVATE $<IF:$<BOOL:PARSEC_SANITIZE_COMPILE_OPTIONS>,${BASE_SOURCES},$<TARGET_OBJECTS:parsec-base-obj>>)
-  target_sources(parsec PRIVATE ${SOURCES})
+  target_sources(parsec PRIVATE ${SOURCES} ${EXTRA_SOURCES} ${MCA_EXTRA_SOURCES})
   add_subdirectory(data_dist)
 
   target_compile_options(parsec
@@ -220,11 +222,17 @@ if( BUILD_PARSEC )
       PUBLIC parsec-papi-sde $<$<BOOL:${PAPI_FOUND}>:PAPI::PAPI>)
 
     # parsec-papi-sde has to be installed, to provide the default empty functions
+    set_property(TARGET parsec-papi-sde
+                 APPEND PROPERTY
+                        PUBLIC_HEADER_H papi_sde_interface.h)
     install(TARGETS parsec-papi-sde
       EXPORT parsec-targets
       DESTINATION ${PARSEC_INSTALL_LIBDIR})
-  #install(FILES papi_sde_interface.h DESTINATION ${PARSEC_INSTALL_LIBDIR}/parsec)
   endif( PARSEC_PAPI_SDE )
+
+  set_property(TARGET parsec
+               APPEND PROPERTY
+                      PUBLIC_HEADER include/parsec.h)
 
 #
 # If we have support for F90 build the PaRSEC module
@@ -234,11 +242,109 @@ if( BUILD_PARSEC )
   endif(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
 
   install(TARGETS parsec
-    EXPORT parsec-targets
-    ARCHIVE DESTINATION ${PARSEC_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${PARSEC_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${PARSEC_INSTALL_INCLUDEDIR})
+          EXPORT parsec-targets
+          ARCHIVE DESTINATION ${PARSEC_INSTALL_LIBDIR}
+          LIBRARY DESTINATION ${PARSEC_INSTALL_LIBDIR})
+  # Cmake < 3.20 does not support hierarchical PUBLIC and PRIVATE _HEADER,
+  # so we need to provide our own support by crafting a similar property
+  # PUBLIC_HEADER_H and PRIVATE_HEADER_H
+  # Extract these properties and properly install the files respecting the
+  # defined hierarchy
+  get_target_property(_public_headers parsec PUBLIC_HEADER_H)
+  foreach(_FILE ${_public_headers})
+    get_filename_component(_DIR ${_FILE} DIRECTORY)
+    INSTALL(FILES ${_FILE} DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/${_DIR})
+  endforeach()
+  get_target_property(_private_headers parsec PRIVATE_HEADER_H)
+  foreach(_FILE ${_private_headers})
+    get_filename_component(_DIR ${_FILE} DIRECTORY)
+    INSTALL(FILES ${_FILE} DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/${_DIR})
+  endforeach()
 
-  install(FILES utils/help-mca-param.txt DESTINATION ${PARSEC_INSTALL_DATADIR}/parsec)
+  install(FILES utils/help-mca-param.txt
+          DESTINATION ${PARSEC_INSTALL_DATADIR}/parsec)
+  install(FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/runtime.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/ayudame.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/constants.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/parsec_config_bottom.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/data_distribution.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/datatype.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/profiling.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/dictionary.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/data.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/private_mempool.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/deprecated.h
+          DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec)
+
+install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/utils/output.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/utils/debug.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/utils/mca_param.h
+        DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/utils)
+install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/parsec_object.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/parsec_hash_table.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/list_item.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/parsec_rwlock.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/fifo.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/barrier.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/list.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/info.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/parsec_future.h
+        DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/class)
+install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/scheduling.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/recursive.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/remote_dep.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/parsec_description_structures.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/datarepo.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/mempool.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/data_internal.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/arena.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/execution_stream.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/parsec_internal.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/vpmap.h
+        DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec)
+if(PARSEC_PROF_GRAPHER)
+  install(FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/parsec_prof_grapher.h
+          DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec )
+endif(PARSEC_PROF_GRAPHER)
+# Install header files for jdf generated code
+if( PARSEC_WITH_DEVEL_HEADERS )
+  install(FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/parsec_binary_profile.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/hbbuffer.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/include/parsec/os-spec-timing.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/maxheap.h
+          DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec )
+
+  install(FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/mca/pins/pins_papi_utils.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/mca/pins/pins_tau_utils.h
+          DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/mca/pins )
+
+  install(FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/argv.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/cmd_line.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/parsec_environ.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/mca_param_cmd_line.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/os_path.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/output.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/show_help.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/zone_malloc.h
+          DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/utils )
+
+  install(FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/class/dequeue.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/class/fifo.h
+          DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/class )
+
+endif(PARSEC_WITH_DEVEL_HEADERS)
+
+
+
 ENDIF( BUILD_PARSEC )
+
 

--- a/parsec/data_dist/CMakeLists.txt
+++ b/parsec/data_dist/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(matrix)
 
 target_sources(parsec PRIVATE ${sources})
 
-install(FILES
-  hash_datadist.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/data_dist )
+set_property(TARGET parsec
+             APPEND PROPERTY
+             PRIVATE_HEADER_H data_dist/hash_datadist.h)
 

--- a/parsec/data_dist/matrix/CMakeLists.txt
+++ b/parsec/data_dist/matrix/CMakeLists.txt
@@ -33,28 +33,27 @@ target_sources(parsec PRIVATE ${sources})
 
 add_subdirectory(redistribute)
 
-install(FILES
-  matrix.h
-  two_dim_rectangle_cyclic.h
-  two_dim_rectangle_cyclic_band.h
-  sym_two_dim_rectangle_cyclic.h
-  sym_two_dim_rectangle_cyclic_band.h
-  vector_two_dim_cyclic.h
-  two_dim_tabular.h
-  grid_2Dcyclic.h
-  subtile.h
-  ${CMAKE_CURRENT_BINARY_DIR}/diag_band_to_rect.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/data_dist/matrix )
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PRIVATE_HEADER_H data_dist/matrix/matrix.h
+                                     data_dist/matrix/two_dim_rectangle_cyclic.h
+                                     data_dist/matrix/two_dim_rectangle_cyclic_band.h
+                                     data_dist/matrix/sym_two_dim_rectangle_cyclic.h
+                                     data_dist/matrix/sym_two_dim_rectangle_cyclic_band.h
+                                     data_dist/matrix/vector_two_dim_cyclic.h
+                                     data_dist/matrix/two_dim_tabular.h
+                                     data_dist/matrix/grid_2Dcyclic.h
+                                     data_dist/matrix/subtile.h
+                                     ${CMAKE_CURRENT_BINARY_DIR}/diag_band_to_rect.h)
 
-
-install(FILES
-  deprecated/grid_2Dcyclic.h
-  deprecated/matrix.h
-  deprecated/two_dim_rectangle_cyclic.h
-  deprecated/two_dim_rectangle_cyclic_band.h
-  deprecated/sym_two_dim_rectangle_cyclic.h
-  deprecated/sym_two_dim_rectangle_cyclic_band.h
-  deprecated/vector_two_dim_cyclic.h
-  deprecated/two_dim_tabular.h
-  deprecated/grid_2Dcyclic.h
-  DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/data_dist/matrix/deprecated )
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PRIVATE_HEADER_H data_dist/matrix/deprecated/grid_2Dcyclic.h
+                                     data_dist/matrix/deprecated/matrix.h
+                                     data_dist/matrix/deprecated/two_dim_rectangle_cyclic.h
+                                     data_dist/matrix/deprecated/two_dim_rectangle_cyclic_band.h
+                                     data_dist/matrix/deprecated/sym_two_dim_rectangle_cyclic.h
+                                     data_dist/matrix/deprecated/sym_two_dim_rectangle_cyclic_band.h
+                                     data_dist/matrix/deprecated/vector_two_dim_cyclic.h
+                                     data_dist/matrix/deprecated/two_dim_tabular.h
+                                     data_dist/matrix/deprecated/grid_2Dcyclic.h)

--- a/parsec/data_dist/matrix/redistribute/CMakeLists.txt
+++ b/parsec/data_dist/matrix/redistribute/CMakeLists.txt
@@ -24,7 +24,6 @@ endif( )
 
 target_ptg_sources(parsec PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/redistribute.jdf;${CMAKE_CURRENT_SOURCE_DIR}/redistribute_reshuffle.jdf")
 
-
-install(FILES
-  redistribute_internal.h
-  DESTINATION include/parsec/data_dist/matrix/redistribute )
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PUBLIC_HEADER_H data_dist/matrix/redistribute/redistribute_internal.h)

--- a/parsec/interfaces/CMakeLists.txt
+++ b/parsec/interfaces/CMakeLists.txt
@@ -9,3 +9,7 @@ if( BUILD_PARSEC )
   include(interfaces/dtd/CMakeLists.txt)
 
 endif( BUILD_PARSEC )
+
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PUBLIC_HEADER_H interfaces/interface.h)

--- a/parsec/interfaces/dtd/CMakeLists.txt
+++ b/parsec/interfaces/dtd/CMakeLists.txt
@@ -9,9 +9,9 @@ if( BUILD_PARSEC )
     DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/interfaces/dtd/)
 
   if( PARSEC_WITH_DEVEL_HEADERS )
-    install(FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/interfaces/dtd/insert_function_internal.h
-            DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/interfaces/dtd/)
+    set_property(TARGET parsec
+                 APPEND PROPERTY
+                        PUBLIC_HEADER_H interfaces/dtd/insert_function_internal.h)
   endif( PARSEC_WITH_DEVEL_HEADERS )
 
 endif( BUILD_PARSEC )

--- a/parsec/mca/CMakeLists.txt
+++ b/parsec/mca/CMakeLists.txt
@@ -61,3 +61,6 @@ ENDFOREACH(COMPONENT)
 MESSAGE(STATUS "PARSEC Modular Component Architecture (MCA) discovery done.")
 
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/mca/mca_static_components.h.in ${CMAKE_CURRENT_BINARY_DIR}/mca/mca_static_components.h)
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PUBLIC_HEADER_H mca/mca.h)

--- a/parsec/mca/device/CMakeLists.txt
+++ b/parsec/mca/device/CMakeLists.txt
@@ -4,6 +4,7 @@ if( PARSEC_HAVE_CUDA )
   LIST(APPEND MCA_${COMPONENT}_SOURCES mca/device/device_gpu.c mca/device/transfer_gpu.c)
 endif( PARSEC_HAVE_CUDA )
 
-install(FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/mca/device/device.h ${CMAKE_CURRENT_SOURCE_DIR}/mca/device/device_gpu.h
-        DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/mca/device )
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PUBLIC_HEADER_H mca/device/device.h
+                                    mca/device/device_gpu.h)

--- a/parsec/mca/device/cuda/ValidateModule.CMake
+++ b/parsec/mca/device/cuda/ValidateModule.CMake
@@ -5,10 +5,10 @@ if( PARSEC_HAVE_CUDA )
   SET(MCA_${COMPONENT}_${MODULE} ON)
   FILE(GLOB MCA_${COMPONENT}_${MODULE}_SOURCES ${MCA_BASE_DIR}/${COMPONENT}/${MODULE}/[^\\.]*.c)
   SET(MCA_${COMPONENT}_${MODULE}_CONSTRUCTOR "${COMPONENT}_${MODULE}_static_component")
-  install(FILES
-          ${CMAKE_CURRENT_SOURCE_DIR}/mca/device/cuda/device_cuda.h
-          ${CMAKE_CURRENT_SOURCE_DIR}/mca/device/cuda/device_cuda_internal.h
-          DESTINATION include/parsec/mca/device/cuda )
+  set_property(TARGET parsec
+               APPEND PROPERTY
+                      PUBLIC_HEADER_H mca/device/cuda/device_cuda.h
+                                      mca/device/cuda/device_cuda_internal.h)
 else (PARSEC_HAVE_CUDA)
   MESSAGE(STATUS "Module ${MODULE} not selectable: does not have CUDA")
   SET(MCA_${COMPONENT}_${MODULE} OFF)

--- a/parsec/mca/device/template/ValidateModule.CMake
+++ b/parsec/mca/device/template/ValidateModule.CMake
@@ -23,7 +23,6 @@ SET(MCA_${COMPONENT}_${MODULE}_CONSTRUCTOR "${COMPONENT}_${MODULE}_static_compon
 
 # add the list of files to be installed. This step can be conditional, and must
 # take in account the WITH_DEVEL_HEADER request.
-
-# install(FILES
-#   ${CMAKE_CURRENT_SOURCE_DIR}/${COMPONENT}/${MODULE}/file.h
-#   DESTINATION include/parsec/mca/${COMPONENT}/${MODULE}/ )
+#set_property(TARGET parsec
+#                    APPEND PROPERTY
+#                           PUBLIC_HEADER_H ${COMPONENT}/${MODULE}/file.h)

--- a/parsec/mca/pins/CMakeLists.txt
+++ b/parsec/mca/pins/CMakeLists.txt
@@ -2,3 +2,6 @@
 IF(PARSEC_PROF_PINS)
   set(MCA_${COMPONENT}_SOURCES mca/pins/pins.c mca/pins/pins_init.c)
 ENDIF(PARSEC_PROF_PINS)
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PUBLIC_HEADER_H mca/pins/pins.h)

--- a/parsec/mca/pins/papi/ValidateModule.CMake
+++ b/parsec/mca/pins/papi/ValidateModule.CMake
@@ -2,7 +2,7 @@
 # variables not used.
 find_package(PAPI QUIET)
 
-# Save it in the cache we will need it t generate the PaRSECConfig.cmake file
+# Save it in the cache we will need it to generate the PaRSECConfig.cmake file
 set(PARSEC_HAVE_PAPI ${PAPI_FOUND} CACHE INTERNAL "Support for PAPI has been found")
 
 if (PARSEC_PROF_PINS)
@@ -13,7 +13,6 @@ if (PARSEC_PROF_PINS)
       SET(MCA_${COMPONENT}_${MODULE} ON)
       FILE(GLOB MCA_${COMPONENT}_${MODULE}_SOURCES mca/pins/pins_papi_utils.c ${MCA_BASE_DIR}/${COMPONENT}/${MODULE}/[^\\.]*.c)
       SET(MCA_${COMPONENT}_${MODULE}_CONSTRUCTOR "${COMPONENT}_${MODULE}_static_component")
-      include_directories( ${PAPI_INCLUDE_DIR} )
 
       list(APPEND EXTRA_LIBS ${PAPI_LIBRARIES})
       include_directories( ${PAPI_INCLUDE_DIR} )

--- a/tests/runtime/scheduling/main.c
+++ b/tests/runtime/scheduling/main.c
@@ -18,10 +18,10 @@
 #include <mpi.h>
 #endif  /* defined(PARSEC_HAVE_MPI) */
 
-static int   MAXNT              = 16384;
-static int   MAXLEVEL           =  1024;
-static int   MAXTRY             =   100;
-static float MAX_RELATIVE_STDEV =   0.1;
+static int MAXNT                 = 16384;
+static int MAXLEVEL              =  1024;
+static int MAXTRY                =   100;
+static double MAX_RELATIVE_STDEV =   0.1;
 
 double stdev(double sum, double sumsqr, double n)
 {

--- a/tools/profiling/python/examples/parsec_dag.py
+++ b/tools/profiling/python/examples/parsec_dag.py
@@ -39,7 +39,7 @@ class ParsecDAG:
 
         Raises
         ------
-        All execeptions due to file errors
+        All exceptions due to file errors
         Additional exceptions when the file does not follow the format that PaRSEC is supposed to produce
         """
         node = re.compile(r'''


### PR DESCRIPTION
https://bitbucket.org/icldistcomp/parsec/pull-requests/541

Move the install directive in the corresponding CMake file.

Clean the install and the usage of PaRSEC as an internal or external project.

The other 2 commits were minor cleanups to remove typos and compiler warnings.