### PR TITLE
[BBT#337] Topic/smarter mpi

### DIFF
--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -1464,6 +1464,26 @@ struct parsec_comm_callback_s {
 
 typedef struct parsec_comm_am_s parsec_comm_am_t;
 
+/**
+ * The Active Message (AM) management structure for MPI. The first 3 fields
+ * cb_fct, cb_data and tag are mostly traditional, indicating what function,
+ * and with what argument to be called for a specific tag. The rest of the
+ * fields are specific to MPI and are as follows:
+ * - am_length: the maximum length for the AM messages of this type
+ * - req_count: the number of entris of this type the MPI layer is expected
+ *              to create. All these entries (basically persistent requests)
+ *              are always started, but will not be tested until they are
+ *              expected to contain valid information (circular waiting list
+ *              on the posted received taking in account the FIFO order of
+ *              the match.
+ * - req_idx: the index in the array_of_requests where this type of AM starts
+ * - comm: the communicator on which requests for this type of AM are posted.
+ *         Posting each type of tag on its own communicator might ease issues
+ *         with matching in multi-threaded environments.
+ * - buf: a pointer to the memory used by all posted AM of this type, assuming
+ *        req_count messages of max length am_length.
+ * - reqs: the array of posted persistent requests for this tag.
+ */
 struct parsec_comm_am_s {
     parsec_comm_callback_f cb_fct;
     void* cb_data;

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -113,6 +113,11 @@ static int parsec_comm_gets_max        = DEP_NB_CONCURENT * MAX_PARAM_COUNT;
 static int parsec_comm_gets            = 0;
 static int parsec_comm_puts_max        = DEP_NB_CONCURENT * MAX_PARAM_COUNT;
 static int parsec_comm_puts            = 0;
+/* The number of valid requests in the array_of_requests, bounded by the total number
+ * of possibly posted requests (DEP_NB_REQ). This is the number that we pass to
+ * MPI_Testsome and should be maintained as small as possible in order to minimize
+ * MPI overheads.
+ */
 static int parsec_comm_last_active_req = 0;
 
 /* These internal communicators are used by the communication engine to host its requests
@@ -1788,7 +1793,6 @@ static int remote_dep_mpi_setup(parsec_context_t* context)
         cb->dep_idx  = array_of_active_messages[i].req_idx;
         parsec_comm_last_active_req++;
     }
-    parsec_comm_last_active_req = REMOTE_DEP_MAX_CTRL_TAG;
     return 0;
 }
 

--- a/tests/apps/pingpong/bandwidth.jdf
+++ b/tests/apps/pingpong/bandwidth.jdf
@@ -159,9 +159,10 @@ int main(int argc, char *argv[])
     /* Default */
     int loops = 100;
     int frags = 60;
-    int size = 1024;
+    int size, inc, nq, idx;
     int cores = 1;
     int nb_runs = 1;
+    int start_length = 1, end_length = 8*1024*1024;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -175,24 +176,28 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    while ((ch = getopt(argc, argv, "n:f:l:c:h:e:")) != -1) {
+    while ((ch = getopt(argc, argv, "n:f:l:c:h:e:u:")) != -1) {
         switch (ch) {
             case 'n': loops = atoi(optarg); break;
             case 'f': frags = atoi(optarg); break;
-            case 'l': size = atoi(optarg) / sizeof(double); break;
+            case 'l': start_length = atoi(optarg); break;
+            case 'u': end_length = atoi(optarg); break;
             case 'e': nb_runs = atoi(optarg); break;
             case 'c': cores = atoi(optarg); break;
             case '?': case 'h': default:
                 fprintf(stderr,
                         "-n : loops of bandwidth(default: 100)\n"
                         "-f : frags, number of fragments (default: 60)\n"
-                        "-l : size, size of message (default: 1024 * sizeof(double))\n"
+                        "-l : min size of message (default: 1 * sizeof(float))\n"
                         "-c : number of cores used (default: 1)\n"
                         "-e : number of runs (default: 1)\n"
+                        "-u : max size of message (default: 8MB)\n"
                         "\n");
                  exit(1);
         }
     }
+    if( start_length > end_length )
+        end_length = start_length;
 
     for(i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
@@ -226,8 +231,7 @@ int main(int argc, char *argv[])
 
     /* If the number of cores has not been defined as a parameter earlier
      * update it with the default parameter computed in parsec_init. */
-    if(cores <= 0)
-    {
+    if(cores <= 0) {
         int p, nb_total_comp_threads = 0;
         for(p = 0; p < parsec->nb_vp; p++) {
             nb_total_comp_threads += parsec->virtual_processes[p]->nb_cores;
@@ -259,36 +263,38 @@ int main(int argc, char *argv[])
                                        (parsec_tiled_matrix_t *)&Disk,
                                        loops, frags, nodes);
 
-        bandwidth_taskpool = (parsec_taskpool_t*)taskpool;
+            bandwidth_taskpool = (parsec_taskpool_t*)taskpool;
 
-        parsec_add2arena( &taskpool->arenas_datatypes[PARSEC_bandwidth_DEFAULT_ADT_IDX],
-                                 parsec_datatype_double_t, PARSEC_MATRIX_FULL,
-                                 1, 1, size, 1,
-                                 PARSEC_ARENA_ALIGNMENT_SSE, -1 );
+            parsec_add2arena( &taskpool->arenas_datatypes[PARSEC_bandwidth_DEFAULT_ADT_IDX],
+                              parsec_datatype_double_t, PARSEC_MATRIX_FULL,
+                              1, 1, size, 1,
+                              PARSEC_ARENA_ALIGNMENT_SSE, -1 );
 
-        /* Time start */
+            parsec_context_add_taskpool(parsec, bandwidth_taskpool);
+
+            /* Time start */
 #if defined(PARSEC_HAVE_MPI)
-        MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Barrier(MPI_COMM_WORLD);
 #endif  /* defined(PARSEC_HAVE_MPI) */
-        gettimeofday(&tstart, NULL);
+            gettimeofday(&tstart, NULL);
 
-        parsec_context_add_taskpool(parsec, bandwidth_taskpool);
-        parsec_context_start(parsec);
-        parsec_context_wait(parsec);
+            parsec_context_start(parsec);
+            parsec_context_wait(parsec);
 
-        /* Time end */
+            /* Time end */
 #if defined(PARSEC_HAVE_MPI)
-        MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Barrier(MPI_COMM_WORLD);
 #endif  /* defined(PARSEC_HAVE_MPI) */
-        gettimeofday(&tend, NULL);
+            gettimeofday(&tend, NULL);
 
-        if( 0 == rank ) {
-            t = (tend.tv_sec - tstart.tv_sec) * 1000000.0 + (tend.tv_usec - tstart.tv_usec);
-            bw = ((double)loops * (double)frags * (double)size) / t * 1000.0 * 1000.0 / (1000.0 * 1000.0 * 1000.0) * sizeof(double) * 8;
-            printf("%d %d %zu %08.4g %4.8g GB/s\n", loops, frags, size*sizeof(double), t / 1000000.0, bw);
+            if( 0 == rank ) {
+                t = (tend.tv_sec - tstart.tv_sec) * 1000000.0 + (tend.tv_usec - tstart.tv_usec);
+                bw = ((double)loops * (double)frags * (double)size * 8) / t * 1000.0 * 1000.0 / (1024.0 * 1024.0);
+                printf("%3u: %8u bytes %d times --> %10.2f Mbps in %10.2f usec\n", idx, size, loops * frags, bw, t / ((double)loops * (double)frags));
+            }
+
+            parsec_bandwidth_Destruct(bandwidth_taskpool);
         }
-
-        parsec_bandwidth_Destruct(bandwidth_taskpool);
     }
 
     parsec_tiled_matrix_destroy((parsec_tiled_matrix_t*)&dcA);


### PR DESCRIPTION
https://bitbucket.org/icldistcomp/parsec/pull-requests/337

Start less MPI requests. This ensure a smaller number of requests to check every time we need to progress the communication layer.

Implement a cleaner Active Message layer