### PR TITLE
Hicma/recursive

### DIFF
--- a/parsec/data_dist/matrix/subtile.c
+++ b/parsec/data_dist/matrix/subtile.c
@@ -21,7 +21,7 @@ subtile_desc_t *subtile_desc_create( const parsec_tiled_matrix_t *tdesc,
                                      int i,  int j,    /* Starting point in the tile */
                                      int m,  int n)    /* Submatrix size (the one concerned by the computation) */
 {
-    subtile_desc_t *sdesc = malloc( sizeof(subtile_desc_t) );
+    subtile_desc_t *sdesc = (subtile_desc_t*)malloc( sizeof(subtile_desc_t) );
     parsec_data_collection_t *o = &(sdesc->super.super);
     (void)mt; (void)nt;
 

--- a/parsec/data_dist/matrix/subtile.h
+++ b/parsec/data_dist/matrix/subtile.h
@@ -21,18 +21,18 @@ typedef struct subtile_desc_s {
 } subtile_desc_t;
 
 /**
- * Initialize a descriptor to apply a recursive call on a single tile of a more
- * general tile descriptor.
+ * Initialize a data descriptor based on an already existing tile. This can be
+ * useful to apply a recursive call on a single tile of a larger data collection.
  *
  * @param[in] tdesc
  *        tiled_matrix_descriptor which owns the tile that will be split into
  *        smaller tiles.
  *
  * @param[in] mt
- *        Row coordinate of the tile to split int the larger matrix.
+ *        Row coordinate in the parent matrix of the tile to be split.
  *
  * @param[in] nt
- *        Column coordinate of the tile to split int the larger matrix.
+ *        Column coordinate in the parent matrix of the tile to be split.
  *
  * @param[in] mb
  *        Number of rows in each subtiles

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -48,7 +48,7 @@ typedef struct remote_dep_wire_get_s
 } remote_dep_wire_get_t;
 
 /**
- * This structure holds the key information for any data mouvement. It contains the arena
+ * This structure holds the key information for any data movement. It contains the arena
  * where the data is allocated from, or will be allocated from. It also contains the
  * pointer to the buffer involved in the communication (or NULL if the data will be
  * allocated before the reception). Finally, it contains the triplet allowing a correct send


### PR DESCRIPTION
Fix the parsec handling of recursive DAGs.

First call the associated callback, the complete the initiator task and only then release the temporary data.

Thanks @omor1 for finding the bug and proposing a solution.