### PR TITLE
We need BISON 3, and try to automatically pick the brew variant on Mac OSX 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ include (CheckCXXCompilerFlag)
 #
 
 # Check for compiler tools
-find_package(BISON)
+find_package(BISON 3)
 find_package(FLEX REQUIRED) # required because of utils/show_help and utils/keyval
 set(PARSEC_HAVE_RECENT_LEX 0)
 

--- a/contrib/platforms/macosx
+++ b/contrib/platforms/macosx
@@ -18,11 +18,18 @@ if [ "x$enable_fortran" != xno -a ! -x "$(command -v "$CC")" ]; then
   done
 fi
 
-# Per-user personalizations
-if [ "x$USER" == "xbosilca" ]; then
-    with_hwloc=${HWLOC_ROOT:=/Users/bosilca/opt}
-    #with_cuda=${CUDA_ROOT:=/Developer/NVIDIA/CUDA-9.1/}
-    with_ayudame=${AYUDAME_ROOT:="/Users/bosilca/opt/temanejo"}
+# OS-X 12.2 provides Bison 2.3, we need Bison 3 or better
+# Try to get the 'brew' Bison if installed
+if [ -d /usr/local/opt/bison ]; then
+  ENVVARS+=" BISON_ROOT=${BISON_ROOT:-/usr/local/opt/bison}"
 fi
-
+# Try to get the 'MacPort' Bison if installed
+if [ -x /opt/local/bin/bison ]; then
+  ENVVARS+=" BISON_ROOT=${BISON_ROOT:-/opt/local}"
+fi
+# Try to get the 'Fink' Bison if installed
+if [ -x /sw/bin/bison ]; then
+  ENVVARS+=" BISON_ROOT=${BISON_ROOT:-/sw}"
+fi
+# If Bison still not found, please set BISON_ROOT by hand
 


### PR DESCRIPTION
Bison 2 (as found on Mac OSX) is not good. Let's not pick it, and try to pick the `brew` bison 3 when its available with the platform file

Signed-off-by: Aurélien Bouteiller <bouteill@icl.utk.edu>