### PR TITLE
Fallback using a compatible HWLOC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,28 @@ IF( BUILD_PARSEC )
     CMAKE_POP_CHECK_STATE()
   endif (MPI_C_FOUND)
 
+  # If MPI enabled and the user did not requested a specific HWLOC
+  # installation try to use one that is compatible with MPI, by finding if MPI
+  # provide HWLOC and use it.
+  if(MPI_C_FOUND AND NOT HWLOC_ROOT)
+    cmake_push_check_state()
+    list(APPEND CMAKE_REQUIRED_INCLUDES MPI_C_INCLUDE_PATH)
+    check_include_file("hwloc.h" PARSEC_FOUND_IMPLICIT_HWLOC)
+    if(PARSEC_FOUND_IMPLICIT_HWLOC)
+      get_filename_component(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT
+                             ${MPI_C_INCLUDE_PATH} DIRECTORY)
+      find_path(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT "hwloc.h"
+                HINTS PARSEC_FOUND_IMPLICIT_HWLOC_ROOT
+                NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH
+                NO_CACHE)
+              if(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT)
+        message(STATUS "Use HWLOC from ${PARSEC_FOUND_IMPLICIT_HWLOC_ROOT}")
+        set(HWLOC_ROOT "${PARSEC_FOUND_IMPLICIT_HWLOC_ROOT}")
+      endif(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT)
+    endif(PARSEC_FOUND_IMPLICIT_HWLOC)
+    cmake_pop_check_state()
+  endif(MPI_C_FOUND AND NOT HWLOC_ROOT)
+
   find_package(HWLOC)
   set(PARSEC_HAVE_HWLOC ${HWLOC_FOUND})
   if( HWLOC_FOUND )
@@ -606,7 +628,15 @@ IF( BUILD_PARSEC )
         #
         # Note that we test the same link-order as in PaRSEC
         # Dependent upon which one links first, either PaRSEC, or MPI will break.
-        set(CMAKE_REQUIRED_LIBRARIES MPI::MPI_C HWLOC::HWLOC)
+        #
+        # Do not use use targets here becuase CMake consider all imported
+        # interfaces as system headers, and instead of using -I (which provide
+        # priority during header search) will use -isystem (which does not and
+        # might allow to find the header in the standard path).
+        list(APPEND CMAKE_REQUIRED_LIBRARIES ${HWLOC_LIBRARIES} ${MPI_C_LIBRARIES})
+        list(PREPEND CMAKE_REQUIRED_INCLUDES ${HWLOC_INCLUDE_DIRS} ${MPI_C_LIBRARIES})
+        message(TRACE "CMAKE_REQUIRED_LIBRARIES = ${CMAKE_REQUIRED_LIBRARIES}")
+        message(TRACE "CMAKE_REQUIRED_INCLUDES = ${CMAKE_REQUIRED_INCLUDES}")
         check_c_source_runs("
 #include <mpi.h>
 #include <hwloc.h>
@@ -621,7 +651,7 @@ int main(int argc, char *argv[]) {
 #else
     if (lib_api_version >= 0x00020000) {
 #endif
-        printf(\"Header and library versions are incompatible.\"); fflush(stdout);
+        printf(\"Header and library versions are incompatible.\\\\n\"); fflush(stdout);
         return 1;
     }
     printf(\"Calling `MPI_Init()`...\\\\n\"); fflush(stdout);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,22 +593,14 @@ IF( BUILD_PARSEC )
   # installation try to use one that is compatible with MPI, by finding if MPI
   # provide HWLOC and use it.
   if(MPI_C_FOUND AND NOT HWLOC_ROOT)
-    cmake_push_check_state()
-    list(APPEND CMAKE_REQUIRED_INCLUDES MPI_C_INCLUDE_PATH)
-    check_include_file("hwloc.h" PARSEC_FOUND_IMPLICIT_HWLOC)
-    if(PARSEC_FOUND_IMPLICIT_HWLOC)
-      get_filename_component(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT
-                             ${MPI_C_INCLUDE_PATH} DIRECTORY)
-      find_path(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT "hwloc.h"
-                HINTS PARSEC_FOUND_IMPLICIT_HWLOC_ROOT
-                NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH
-                NO_CACHE)
-              if(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT)
-        message(STATUS "Use HWLOC from ${PARSEC_FOUND_IMPLICIT_HWLOC_ROOT}")
-        set(HWLOC_ROOT "${PARSEC_FOUND_IMPLICIT_HWLOC_ROOT}")
-      endif(PARSEC_FOUND_IMPLICIT_HWLOC_ROOT)
-    endif(PARSEC_FOUND_IMPLICIT_HWLOC)
-    cmake_pop_check_state()
+    find_path(PARSEC_MPI_HWLOC_INCLUDE_DIR "hwloc.h"
+      HINTS ${MPI_C_INCLUDE_PATH}
+      NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+    if(PARSEC_MPI_HWLOC_INCLUDE_DIR)
+      get_filename_component(PARSEC_MPI_HWLOC_ROOT ${PARSEC_MPI_HWLOC_INCLUDE_DIR} DIRECTORY)
+      message(STATUS "Force HWLOC to match collocated MPI ${PARSEC_MPI_HWLOC_ROOT}; you can override this by setting HWLOC_ROOT")
+      set(HWLOC_ROOT ${PARSEC_MPI_HWLOC_ROOT})
+    endif(PARSEC_MPI_HWLOC_INCLUDE_DIR)
   endif(MPI_C_FOUND AND NOT HWLOC_ROOT)
 
   find_package(HWLOC)
@@ -634,7 +626,7 @@ IF( BUILD_PARSEC )
         # priority during header search) will use -isystem (which does not and
         # might allow to find the header in the standard path).
         list(APPEND CMAKE_REQUIRED_LIBRARIES ${HWLOC_LIBRARIES} ${MPI_C_LIBRARIES})
-        list(PREPEND CMAKE_REQUIRED_INCLUDES ${HWLOC_INCLUDE_DIRS} ${MPI_C_LIBRARIES})
+        list(PREPEND CMAKE_REQUIRED_INCLUDES ${HWLOC_INCLUDE_DIRS} ${MPI_C_INCLUDE_DIRS})
         message(TRACE "CMAKE_REQUIRED_LIBRARIES = ${CMAKE_REQUIRED_LIBRARIES}")
         message(TRACE "CMAKE_REQUIRED_INCLUDES = ${CMAKE_REQUIRED_INCLUDES}")
         check_c_source_runs("

--- a/cmake_modules/FindHWLOC.cmake
+++ b/cmake_modules/FindHWLOC.cmake
@@ -11,7 +11,7 @@
 #    link against to use HWLOC
 #  HWLOC_INCLUDE_DIRS - uncached list of required include directories to
 #    access HWLOC headers
-#  HWLOC_STATIC  if set on this determines what kind of linkage we do (static)
+#  HWLOC_DEFINITIONS - uncached list of required compile flags
 #
 #  PARSEC_HAVE_HWLOC_PARENT_MEMBER - new API, older versions don't have it
 #  PARSEC_HAVE_HWLOC_CACHE_ATTR - new API, older versions don't have it
@@ -21,25 +21,27 @@
 ##########
 
 include(CheckStructHasMember)
+include(CMakePushCheckState)
 
-mark_as_advanced(FORCE HWLOC_DIR HWLOC_INCLUDE_DIR HWLOC_LIBRARY)
+mark_as_advanced(FORCE HWLOC_INCLUDE_DIR HWLOC_LIBRARY)
 
 find_package(PkgConfig QUIET)
 if( HWLOC_ROOT )
-  set(HWLOC_DIR "${HWLOC_ROOT}")
+  # We don't use HWLOC_DIR as this is supposed to be used when finding hwloc-config.cmake only
+  set(ENV{PKG_CONFIG_PATH} "${HWLOC_ROOT}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 endif()
-set(ENV{PKG_CONFIG_PATH} "${HWLOC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+
 pkg_check_modules(PC_HWLOC QUIET hwloc)
 set(HWLOC_DEFINITIONS ${PC_HWLOC_CFLAGS_OTHER} )
 
 find_path(HWLOC_INCLUDE_DIR hwloc.h
-          HINTS ${HWLOC_ROOT} ${HWLOC_DIR} ${PC_HWLOC_INCLUDEDIR} ${PC_HWLOC_INCLUDE_DIRS}
+          HINTS ${PC_HWLOC_INCLUDEDIR} ${PC_HWLOC_INCLUDE_DIRS}
           PATH_SUFFIXES include
           DOC "HWLOC includes" )
 set(HWLOC_INCLUDE_DIRS ${HWLOC_INCLUDE_DIR})
 
 find_library(HWLOC_LIBRARY hwloc
-             HINTS ${HWLOC_ROOT} ${HWLOC_DIR} ${PC_HWLOC_LIBDIR} ${PC_HWLOC_LIBRARY_DIRS}
+             HINTS ${PC_HWLOC_LIBDIR} ${PC_HWLOC_LIBRARY_DIRS}
              PATH_SUFFIXES lib
              DOC "Where the HWLOC libraries are")
 set(HWLOC_LIBRARIES ${HWLOC_LIBRARY})
@@ -59,16 +61,14 @@ if(HWLOC_FOUND)
     message(FATAL_ERROR "HWLOC found (HWLOC_LIBRARY=${HWLOC_LIBRARY}) but cannot test it due to missing C language support; either enable_language(C) in your project or ensure that C compiler can be discovered")
   endif()
 
-  set(HWLOC_DIR "${HWLOC_DIR}" CACHE PATH "Root directory containing HWLOC" FORCE)
-
-  set(HWLOC_SAVE_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+  cmake_push_check_state()
   list(APPEND CMAKE_REQUIRED_INCLUDES ${HWLOC_INCLUDE_DIR})
   check_struct_has_member( "struct hwloc_obj" parent hwloc.h PARSEC_HAVE_HWLOC_PARENT_MEMBER )
   check_struct_has_member( "struct hwloc_cache_attr_s" size hwloc.h PARSEC_HAVE_HWLOC_CACHE_ATTR )
   check_c_source_compiles( "#include <hwloc.h>
     int main(void) { hwloc_obj_t o; o->type = HWLOC_OBJ_PU; return 0;}" PARSEC_HAVE_HWLOC_OBJ_PU)
   check_library_exists(${HWLOC_LIBRARY} hwloc_bitmap_free "" PARSEC_HAVE_HWLOC_BITMAP)
-  set(CMAKE_REQUIRED_INCLUDES ${HWLOC_SAVE_CMAKE_REQUIRED_INCLUDES})
+  cmake_pop_check_state()
 
   #===============================================================================
   # Import Target ================================================================
@@ -78,11 +78,12 @@ if(HWLOC_FOUND)
 
   set_property(TARGET HWLOC::HWLOC PROPERTY INTERFACE_LINK_LIBRARIES "${HWLOC_LIBRARY}")
   set_property(TARGET HWLOC::HWLOC PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${HWLOC_INCLUDE_DIR}")
+  set_property(TARGET HWLOC::HWLOC PROPERTY INTERFACE_COMPILE_OPTIONS "${HWLOC_DEFINITIONS}")
   #===============================================================================
+
 else(HWLOC_FOUND)
   unset(PARSEC_HAVE_HWLOC_PARENT_MEMBER CACHE)
   unset(PARSEC_HAVE_HWLOC_CACHE_ATTR CACHE)
   unset(PARSEC_HAVE_HWLOC_OBJ_PU CACHE)
   unset(PARSEC_HAVE_HWLOC_BITMAP CACHE)
-  unset(HWLOC_DIR CACHE)
 endif(HWLOC_FOUND)

--- a/cmake_modules/FindHWLOC.cmake
+++ b/cmake_modules/FindHWLOC.cmake
@@ -24,23 +24,22 @@ include(CheckStructHasMember)
 
 mark_as_advanced(FORCE HWLOC_DIR HWLOC_INCLUDE_DIR HWLOC_LIBRARY)
 
-set(HWLOC_DIR "" CACHE PATH "Root directory containing HWLOC")
-
 find_package(PkgConfig QUIET)
-if( HWLOC_DIR )
-  set(ENV{PKG_CONFIG_PATH} "${HWLOC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+if( HWLOC_ROOT )
+  set(HWLOC_DIR "${HWLOC_ROOT}")
 endif()
+set(ENV{PKG_CONFIG_PATH} "${HWLOC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 pkg_check_modules(PC_HWLOC QUIET hwloc)
 set(HWLOC_DEFINITIONS ${PC_HWLOC_CFLAGS_OTHER} )
 
 find_path(HWLOC_INCLUDE_DIR hwloc.h
-          HINTS ${HWLOC_DIR} ${PC_HWLOC_INCLUDEDIR} ${PC_HWLOC_INCLUDE_DIRS}
+          HINTS ${HWLOC_ROOT} ${HWLOC_DIR} ${PC_HWLOC_INCLUDEDIR} ${PC_HWLOC_INCLUDE_DIRS}
           PATH_SUFFIXES include
           DOC "HWLOC includes" )
 set(HWLOC_INCLUDE_DIRS ${HWLOC_INCLUDE_DIR})
 
 find_library(HWLOC_LIBRARY hwloc
-             HINTS ${HWLOC_DIR} ${PC_HWLOC_LIBDIR} ${PC_HWLOC_LIBRARY_DIRS}
+             HINTS ${HWLOC_ROOT} ${HWLOC_DIR} ${PC_HWLOC_LIBDIR} ${PC_HWLOC_LIBRARY_DIRS}
              PATH_SUFFIXES lib
              DOC "Where the HWLOC libraries are")
 set(HWLOC_LIBRARIES ${HWLOC_LIBRARY})
@@ -59,6 +58,8 @@ if(HWLOC_FOUND)
   else()
     message(FATAL_ERROR "HWLOC found (HWLOC_LIBRARY=${HWLOC_LIBRARY}) but cannot test it due to missing C language support; either enable_language(C) in your project or ensure that C compiler can be discovered")
   endif()
+
+  set(HWLOC_DIR "${HWLOC_DIR}" CACHE PATH "Root directory containing HWLOC" FORCE)
 
   set(HWLOC_SAVE_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
   list(APPEND CMAKE_REQUIRED_INCLUDES ${HWLOC_INCLUDE_DIR})
@@ -83,4 +84,5 @@ else(HWLOC_FOUND)
   unset(PARSEC_HAVE_HWLOC_CACHE_ATTR CACHE)
   unset(PARSEC_HAVE_HWLOC_OBJ_PU CACHE)
   unset(PARSEC_HAVE_HWLOC_BITMAP CACHE)
+  unset(HWLOC_DIR CACHE)
 endif(HWLOC_FOUND)

--- a/cmake_modules/PaRSECConfig.cmake.in
+++ b/cmake_modules/PaRSECConfig.cmake.in
@@ -19,10 +19,8 @@ list(APPEND CMAKE_MODULE_PATH "${PARSEC_CMAKE_DIRS}")
 find_package(Threads)
 
 if(@PARSEC_HAVE_HWLOC@)
-  # If HWLOC is found on the system directories the HWLOC_DIR is set to ""
-  if("@HWLOC_DIR@")
-    set_and_check(HWLOC_ROOT "@HWLOC_DIR@")
-  endif("@HWLOC_DIR@")
+  set_and_check(HWLOC_INCLUDE_DIR "@HWLOC_INCLUDE_DIR@")
+  set_and_check(HWLOC_LIBRARY "@HWLOC_LIBRARY@")
   find_package(HWLOC REQUIRED)
 endif(@PARSEC_HAVE_HWLOC@)
 

--- a/cmake_modules/PaRSECConfig.cmake.in
+++ b/cmake_modules/PaRSECConfig.cmake.in
@@ -21,7 +21,7 @@ find_package(Threads)
 if(@PARSEC_HAVE_HWLOC@)
   # If HWLOC is found on the system directories the HWLOC_DIR is set to ""
   if("@HWLOC_DIR@")
-    set_and_check(HWLOC_DIR "@HWLOC_DIR@")
+    set_and_check(HWLOC_ROOT "@HWLOC_DIR@")
   endif("@HWLOC_DIR@")
   find_package(HWLOC REQUIRED)
 endif(@PARSEC_HAVE_HWLOC@)

--- a/contrib/platforms/legacy/config.bgp
+++ b/contrib/platforms/legacy/config.bgp
@@ -40,7 +40,7 @@ export CC CXX FC LDFLAGS
  
 MPI="-DPARSEC_DIST_WITH_MPI=OFF"
 CUDA="-DPARSEC_GPU_WITH_CUDA=OFF"
-HWLOC="-DHWLOC_DIR=/home/bosilca/opt/"
+HWLOC="-DHWLOC_ROOT=/home/bosilca/opt/"
 OPTS="-DBUILD_TESTING=OFF -DBUILD_TOOLS=ON -DBUILD_PARSEC=ON -DBUILD_DPLASMA=OFF"
 
 cmake -G "Unix Makefiles" ${MPI} ${CUDA} ${OPTS} ${HWLOC} ${USER_OPTIONS} ../${LOCATION}
@@ -80,7 +80,7 @@ FC=mpixlf77_r
 LDFLAGS="${SAVE_LDFLAGS} -L/opt/ibmcmp/xlf/bg/11.1/bglib/ -qsmp=omp"
 
 MPI="-DPARSEC_DIST_WITH_MPI=ON"
-HWLOC="-DHWLOC_DIR=/home/bosilca/opt/bluegene"
+HWLOC="-DHWLOC_ROOT=/home/bosilca/opt/bluegene"
 CUDA="-DPARSEC_GPU_WITH_CUDA=OFF"
 OPTS="-DBUILD_64bits=OFF -DBUILD_TOOLS=OFF"
 

--- a/contrib/platforms/legacy/config.darter.crayxc30
+++ b/contrib/platforms/legacy/config.darter.crayxc30
@@ -14,9 +14,9 @@ USER_OPTIONS+=" -DPARSEC_GPU_WITH_CUDA=OFF" #remove for XK6/7
 # A default source for supplementary software on Kraken. 
 # This links to software I compiled myself, customize to your needs
 OPT_DIR="$HOME/DARTER/opt"
-HWLOC_DIR=${HWLOC_DIR:="$OPT_DIR"}
-if [ ! -z "$HWLOC_DIR" -a ! -d "$HWLOC_DIR" ]; then 
-    echo "You need to install HWLOC, could not be found in $HWLOC_DIR"
+HWLOC_ROOT=${HWLOC_ROOT:="$OPT_DIR"}
+if [ ! -z "$HWLOC_ROOT" -a ! -d "$HWLOC_ROOT" ]; then 
+    echo "You need to install HWLOC, could not be found in $HWLOC_ROOT"
     exit 1
 fi
 

--- a/contrib/platforms/legacy/config.inc
+++ b/contrib/platforms/legacy/config.inc
@@ -31,7 +31,7 @@ function guess_defaults {
     FC=${FC:=$(which ifort 2>/dev/null)}
     FC=${FC:=$(which gfortran 2>/dev/null)}
     MPI_DIR=${MPI_DIR:=$(dirname_bin mpicc)}
-    HWLOC_DIR=${HWLOC_DIR:=$(dirname_bin hwloc-ls)}
+    HWLOC_ROOT=${HWLOC_ROOT:=$(dirname_bin hwloc-ls)}
     GTG_DIR=${GTG_DIR:=$(pkg-config gtg --variable=prefix)}
     CUDA_DIR=${CUDA_DIR:=$(dirname_bin nvcc)}
 
@@ -79,8 +79,8 @@ if [ -n "$MPI_DIR" -a $(expr "${USER_OPTIONS}" : ".*PARSEC_DIST_WITH_MPI=OFF.*")
 fi
 
 # Make sure to always set all three compilers at the same time. The name of the wrapper may vary on your system
-if [ -n "$HWLOC_DIR" -a $(expr "${USER_OPTIONS}" : ".*PARSEC_WITH_HWLOC=OFF.*") -eq 0 ]; then
-    HWLOC="-DHWLOC_DIR=${HWLOC_DIR}"
+if [ -n "$HWLOC_ROOT" -a $(expr "${USER_OPTIONS}" : ".*PARSEC_WITH_HWLOC=OFF.*") -eq 0 ]; then
+    HWLOC="-DHWLOC_ROOT=${HWLOC_ROOT}"
 fi
 
 if [ -f "$GTG_DIR/include/GTG.h" -a -f "$GTG_DIR/lib/libgtg.so" ]; then

--- a/contrib/platforms/legacy/config.keeneland
+++ b/contrib/platforms/legacy/config.keeneland
@@ -11,7 +11,7 @@ CC=${CC:="icc"}
 CXX=${CXX:="icpc"}
 FC=${FC:="ifort"}
 #MPI_DIR=${MPI_DIR:="/opt/ompi"}
-HWLOC_DIR=${HWLOC_DIR:="/nics/c/home/bouteill/KEENELAND/hwloc/1.9"}
+HWLOC_ROOT=${HWLOC_ROOT:="/nics/c/home/bouteill/KEENELAND/hwloc/1.9"}
 #GTG_DIR=${GTG_DIR:="/opt/gtg"}
 #CUDA_DIR=${CUDA_DIR:="/opt/cuda"}
 

--- a/contrib/platforms/legacy/config.kraken.crayxt5
+++ b/contrib/platforms/legacy/config.kraken.crayxt5
@@ -13,7 +13,7 @@ USER_OPTIONS+=" -DPARSEC_GPU_WITH_CUDA=OFF" #remove for XK6/7
 # A default source for supplementary software on Kraken. 
 # This links to software I compiled myself, customize to your needs
 OPT_DIR="/nics/c/home/bouteill/.opt.kraken"
-HWLOC_DIR=${HWLOC_DIR:="$OPT_DIR/hwloc"}
+HWLOC_ROOT=${HWLOC_ROOT:="$OPT_DIR/hwloc"}
 #CUDA_DIR=${CUDA_DIR:="$OPT_DIR/cuda"}
 
 #GTG_DIR=${GTG_DIR:="$OPT_DIR/gtg"}

--- a/contrib/platforms/legacy/config.nautilus
+++ b/contrib/platforms/legacy/config.nautilus
@@ -16,7 +16,7 @@ export CMAKE_BUILD_TYPE=Release
 
 MPI_DIR="/opt/sgi/mpt/mpt-2.04/"
 #MPI_DIR="/nics/d/home/smoreaud/libs/ompi"
-HWLOC_DIR=${HWLOC_DIR:="/nics/d/home/smoreaud/libs/hwloc/"}  
+HWLOC_ROOT=${HWLOC_ROOT:="/nics/d/home/smoreaud/libs/hwloc/"}  
 CUDA_DIR=${CUDA_DIR:="not installed"}
 
 
@@ -32,9 +32,9 @@ if [ -n "$MPI_DIR" -a $(expr "${USER_OPTIONS}" : ".*PARSEC_DIST_WITH_MPI=OFF.*")
 # Make sure to always set all three compilers at the same time. The name of the wrapper may vary on your system
 fi
 
-if [ -n "$HWLOC_DIR" -a $(expr "${USER_OPTIONS}" : ".*PARSEC_WITH_HWLOC=OFF.*") -eq 0 ]; then
+if [ -n "$HWLOC_ROOT" -a $(expr "${USER_OPTIONS}" : ".*PARSEC_WITH_HWLOC=OFF.*") -eq 0 ]; then
     echo "With HWLOC"
-    HWLOC="-DHWLOC_DIR=${HWLOC_DIR}"
+    HWLOC="-DHWLOC_ROOT=${HWLOC_ROOT}"
 fi
 
 if [ -n "${CUDA_DIR}" -a $(expr "${USER_OPTIONS}" : ".*PARSEC_GPU_WITH_CUDA=OFF.*") -eq 0 ]; then 

--- a/contrib/platforms/legacy/titan.crayxk7
+++ b/contrib/platforms/legacy/titan.crayxk7
@@ -12,8 +12,8 @@ set -e
 
 
 # General variables
-: ${HWLOC_DIR:=$HOME/parsec/titan/hwloc-1.11.2}
-[ -d "$HWLOC_DIR" ] || echo "HWLOC_DIR='$HWLOC_DIR' does not point to a valid hwloc install. PaRSEC may use unoptimized schedulers." 1>&2
+: ${HWLOC_ROOT:=$HOME/parsec/titan/hwloc-1.11.2}
+[ -d "$HWLOC_ROOT" ] || echo "HWLOC_ROOT='$HWLOC_ROOT' does not point to a valid hwloc install. PaRSEC may use unoptimized schedulers." 1>&2
 
 : ${TOOLCHAIN_DIR:=ToolchainX-native}
 : ${COMPUTE_DIR:=$PWD}
@@ -99,7 +99,7 @@ export CC CXX FC CFLAGS LDFLAGS
 
 MPI="-DPARSEC_DIST_WITH_MPI=ON -DMPI_C_COMPILER=$CC -DMPI_CXX_COMPILER=$CXX -DMPI_Fortran_COMPILER=$FC"
 CUDA="-DPARSEC_GPU_WITH_CUDA=ON -DCUDA_TOOLKIT_ROOT_DIR=$CRAY_CUDATOOLKIT_DIR"
-HWLOC="-DHWLOC_DIR=$HWLOC_DIR"
+HWLOC="-DHWLOC_ROOT=$HWLOC_ROOT"
 OPTS="-DBUILD_TOOLS=OFF -DBUILD_SHARED_LIBS=OFF"
 
 # Done with variable allocation, do the thing with Cmake

--- a/parsec/CMakeLists.txt
+++ b/parsec/CMakeLists.txt
@@ -245,7 +245,8 @@ if( BUILD_PARSEC )
   install(TARGETS parsec
           EXPORT parsec-targets
           ARCHIVE DESTINATION ${PARSEC_INSTALL_LIBDIR}
-          LIBRARY DESTINATION ${PARSEC_INSTALL_LIBDIR})
+          LIBRARY DESTINATION ${PARSEC_INSTALL_LIBDIR}
+          PUBLIC_HEADER DESTINATION ${PARSEC_INSTALL_INCLUDEDIR})
   # Cmake < 3.20 does not support hierarchical PUBLIC and PRIVATE _HEADER,
   # so we need to provide our own support by crafting a similar property
   # PUBLIC_HEADER_H and PRIVATE_HEADER_H


### PR DESCRIPTION
If the MPI provides HWLOC and it conflicts with the HWLOC version installed by
default on the system, we were not correctly detecting the right HWLOC version
to use. With this patch, if HWLOC_DIR is not specified we will try to use the
MPI provided HWLOC first, if any.

In the same commit I tried to cleanup our usage of _ROOT and _DIR. HWLOC_ROOT is provided by the upper layer as a mean to direct the search process, while HWLOC_DIR is set by the detection itself to facilitate subsequent searches. HWLOC_ROOT is input only, while HWLOC is output only and cached.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>