### PR TITLE
Fix parsec_future: volatile and memory barriers

### DIFF
--- a/parsec/class/parsec_future.c
+++ b/parsec/class/parsec_future.c
@@ -29,6 +29,7 @@ static int parsec_base_future_is_ready(parsec_base_future_t* future)
 static void parsec_base_future_set(parsec_base_future_t* future, void* data)
 {
     if(parsec_atomic_cas_ptr(&(future->tracked_data), NULL, data)) {
+        parsec_atomic_wmb();
         /* increment flag to indicate data is ready */
         future->status |= PARSEC_DATA_FUTURE_STATUS_COMPLETED;
         if(future->cb_fulfill != NULL){
@@ -51,6 +52,7 @@ static void* parsec_base_future_get(parsec_base_future_t* future)
      * */
     while(1){
         if(parsec_base_future_is_ready(future)){
+            parsec_atomic_rmb();
             return future->tracked_data;
         }
     }

--- a/parsec/class/parsec_future.h
+++ b/parsec/class/parsec_future.h
@@ -73,7 +73,7 @@ struct parsec_future_fn_t {
 struct parsec_base_future_t {
     parsec_list_item_t       item;          /**< a base future type is list item (also a PaRSEC object) */
     parsec_future_fn_t      *future_class;  /**< struct that holds all the common function pointers */
-    uint8_t                  status;        /**< status of the future */
+    volatile uint8_t         status;        /**< status of the future */
     void                    *tracked_data;  /**< a pointer to the data this future is tracking */
     parsec_future_cb_fulfill cb_fulfill;    /**< callback function */
     parsec_atomic_lock_t     future_lock;   /**< lockable for multithread access */


### PR DESCRIPTION
The status and tracked_data fields of the future must be volatile
to prevent the compiler from hoisting the loads out of the loop.
Similarly, memory barriers are needed to ensure proper ordering
between setting/reading the data and status fields.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>