### PR TITLE
Work around GCC bug for atomic_thread_fence with memory order acquire

### DIFF
--- a/parsec/include/parsec/sys/atomic-c11.h
+++ b/parsec/include/parsec/sys/atomic-c11.h
@@ -46,8 +46,18 @@ void parsec_atomic_wmb(void)
 ATOMIC_STATIC_INLINE
 void parsec_atomic_rmb(void)
 {
+    /* Earlier GCC versions ignored the acquire thread fence.
+     * It seems to be resolved in 8.3 so play it safe by
+     * falling back to mfence for anything earlier than 8.3.
+     */
+#if !defined(__clang__) \
+   && defined(__GNUC__) \
+   && (__GNUC__ > 8 || (__GNUC__ == 8 && __GNUC_MINOR__ >= 3))
     atomic_thread_fence(memory_order_acquire);
-}
+#else
+    parsec_mfence();
+#endif
+ }
 
 /* Compare and Swap */
 

--- a/tests/class/lifo.c
+++ b/tests/class/lifo.c
@@ -340,7 +340,7 @@ int main(int argc, char *argv[])
     printf(" - all tests passed\n");
 
 #if defined(PARSEC_HAVE_MPI)
-    MPI_Finalized(&ch);
+    MPI_Finalize();
 #endif
     return 0;
 }


### PR DESCRIPTION
It appears that at least until 7.3.0 GCC ignored acquire thread fences.
It also appears to be fixed in 8.3.0, so fall back to mfence for anything
earlier than 8.3.0.


Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>