### PR TITLE
Reshape test: variable used for polling should be volatile

### DIFF
--- a/tests/collections/reshape/input_dep_single_copy_reshape.jdf
+++ b/tests/collections/reshape/input_dep_single_copy_reshape.jdf
@@ -9,7 +9,7 @@ extern "C" %{
 #include <pthread.h>
 static pthread_cond_t  cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-static int set = 0;
+static volatile int set = 0;
 
     /*******************************
      * Reshape read multiple copies


### PR DESCRIPTION
Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>