### PR TITLE
Dust off the cmake_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,7 +681,7 @@ int main(int argc, char *argv[]) {
   if(AYUDAME_FOUND)
     target_include_directories(parsec
         PRIVATE
-        ${AYUDAME_INCLUDE_DIR})
+        ${AYUDAME_INCLUDE_DIRS})
     if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
       message(STATUS "Add '-undefined dynamic_lookup' to the linking flags")
       target_link_libraries(parsec

--- a/cmake_modules/FindAyudame.cmake
+++ b/cmake_modules/FindAyudame.cmake
@@ -7,35 +7,28 @@
 #    is found
 #  AYUDAME_LIBRARIES - uncached list of libraries (using full path name) to
 #    link against to use Ayudame
-#  AYUDAME_INCLUDE_DIR - directory where the Ayudame header files are
+#  AYUDAME_INCLUDE_DIRS - directory where the Ayudame header files are
 #
 ##########
-mark_as_advanced(FORCE AYUDAME_DIR AYUDAME_INCLUDE_DIR AYUDAME_LIBRARY)
-set(AYUDAME_DIR "" CACHE PATH "Root directory containing the Ayudame library")
 
-if( AYUDAME_DIR )
-  if( NOT AYUDAME_INCLUDE_DIR )
-    set(AYUDAME_INCLUDE_DIR "${AYUDAME_DIR}/include")
-  endif( NOT AYUDAME_INCLUDE_DIR )
-  if( NOT AYUDAME_LIBRARY_DIR )
-    set(AYUDAME_LIBRARY_DIR "${AYUDAME_DIR}/lib")
-  endif( NOT AYUDAME_LIBRARY_DIR )
-endif( AYUDAME_DIR )
+find_library(AYUDAME_LIBRARY ayudame
+  DOC "Library path for Ayudame")
+find_path(AYUDAME_INCLUDE_DIR "Ayudame.h"
+  DOC "Include path for Ayudame")
 
-CMAKE_PUSH_CHECK_STATE()
-if(AYUDAME_INCLUDE_DIR)
-  list(APPEND CMAKE_REQUIRED_INCLUDES ${AYUDAME_INCLUDE_DIR})
-endif(AYUDAME_INCLUDE_DIR)
+cmake_push_check_state()
+list(APPEND CMAKE_REQUIRED_INCLUDES ${AYUDAME_INCLUDE_DIR})
 check_include_files("Ayudame.h" FOUND_AYUDAME_INCLUDE)
-if(FOUND_AYUDAME_INCLUDE)
-  check_library_exists("ayudame" AYU_event ${AYUDAME_LIBRARY_DIR} FOUND_AYUDAME_LIB)
-  if( FOUND_AYUDAME_LIB )
-    set(AYUDAME_LIBRARIES "-L${AYUDAME_LIBRARY_DIR} -layudame")
-  endif( FOUND_AYUDAME_LIB )
-endif(FOUND_AYUDAME_INCLUDE)
-CMAKE_POP_CHECK_STATE()
+check_library_exists("ayudame" AYU_event ${AYUDAME_LIBRARY_DIR} FOUND_AYUDAME_LIB)
+cmake_pop_check_state()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(AYUDAME DEFAULT_MSG
-                                  FOUND_AYUDAME_INCLUDE AYUDAME_LIBRARIES AYUDAME_INCLUDE_DIR )
+  AYUDAME_LIBRARY AYUDAME_INCLUDE_DIR FOUND_AYUDAME_INCLUDE FOUND_AYUDAME_LIB)
+mark_as_advanced(FORCE AYUDAME_INCLUDE_DIR AYUDAME_LIBRARY)
+
+if(AYUDAME_FOUND)
+  set(AYUDAME_INCLUDE_DIRS ${AYUDAME_INCLUDE_DIR})
+  set(AYUDAME_LIBRARIES ${AYUDAME_LIBRARY})
+endif(AYUDAME_FOUND)
 

--- a/cmake_modules/FindPAPI.cmake
+++ b/cmake_modules/FindPAPI.cmake
@@ -7,32 +7,26 @@
 #    is found
 #  PAPI_LIBRARIES - uncached list of libraries (using full path name) to
 #    link against to use PAPI
-#  PAPI_INCLUDE_DIR - directory where the PAPI header files are
+#  PAPI_INCLUDE_DIRS - directory where the PAPI header files are
 #
 #  PAPI::PAPI interface library target for linking
 ##########
 
 find_package(PkgConfig QUIET)
 
-if( PAPI_DIR )
-  set(ENV{PKG_CONFIG_PATH} "${PAPI_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+if( PAPI_ROOT )
+  set(ENV{PKG_CONFIG_PATH} "${PAPI_ROOT}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 endif()
 pkg_check_modules(PC_PAPI QUIET papi)
 set(PAPI_DEFINITIONS ${PC_PAPI_CFLAGS_OTHER} )
 
 find_path(PAPI_INCLUDE_DIR papi.h
-          PATHS ${PAPI_DIR}/include ENV PAPI_INCLUDE_DIR
-          HINTS ${PC_PAPI_INCLUDEDIR} ${PC_PAPI_INCLUDE_DIRS} ${PAPI_DIR}/include
+          PATHS ${PAPI_ROOT}/include ENV PAPI_INCLUDE_DIR
+          HINTS ${PC_PAPI_INCLUDEDIR} ${PC_PAPI_INCLUDE_DIRS}
           DOC "Include path for PAPI")
 
-#get_cmake_property(_variableNames VARIABLES)
-#foreach (_variableName ${_variableNames})
-#    message(STATUS "${_variableName}=${${_variableName}}")
-#endforeach()
-
 find_library(PAPI_LIBRARY NAMES papi
-             PATHS ${PAPI_DIR}/lib
-             HINTS ${PC_PAPI_LIBDIR} ${PC_PAPI_LIBRARY_DIRS} ${PAPI_DIR}/lib
+             HINTS ${PC_PAPI_LIBDIR} ${PC_PAPI_LIBRARY_DIRS}
              DOC "Library path for PAPI")
 
 include(FindPackageHandleStandardArgs)
@@ -49,10 +43,10 @@ if( PAPI_FOUND )
 
     set_property(TARGET PAPI::PAPI APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${PAPI_LIBRARY}")
     set_property(TARGET PAPI::PAPI PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${PAPI_INCLUDE_DIR}")
-    #===============================================================================
+  #===============================================================================
 
   set(PAPI_LIBRARIES ${PAPI_LIBRARY} )
   set(PAPI_INCLUDE_DIRS ${PAPI_INCLUDE_DIR} )
-  mark_as_advanced(FORCE PAPI_DIR PAPI_INCLUDE_DIR PAPI_LIBRARY)
+  mark_as_advanced(FORCE PAPI_INCLUDE_DIR PAPI_LIBRARY)
 
 endif( PAPI_FOUND )

--- a/cmake_modules/FindTAU.cmake
+++ b/cmake_modules/FindTAU.cmake
@@ -18,7 +18,6 @@ pkg_check_modules(PC_TAU QUIET TAU)
 set(TAU_DEFINITIONS ${PC_TAU_CFLAGS_OTHER})
 
 find_path(TAU_INCLUDE_DIR TAU.h
-          HINTS ${TAU_ROOT}/include
           PATH_SUFFIXES TAU )
 if( NOT TAU_INCLUDE_DIR )
   message(STATUS "TAU libraries not found")
@@ -27,23 +26,23 @@ endif
 
 if (${APPLE})
   find_library(TAU_LIBRARY NAMES TAU
-             HINTS ${TAU_ROOT}/x86_64/lib/shared-icpc-papi-pthread-pdt )
+    PATH_SUFFIXES x86_64/lib/shared-icpc-papi-pthread-pdt )
   find_path(TAU_LIBRARY_DIR NAMES libTAU.dylib
-             HINTS ${TAU_ROOT}/x86_64/lib/shared-icpc-papi-pthread-pdt )
+    PATH_SUFFIXES x86_64/lib/shared-icpc-papi-pthread-pdt )
 else()
   find_library(TAU_LIBRARY NAMES TAU
-             HINTS ${TAU_ROOT}/x86_64/lib/shared-icpc-papi-pthread-pdt )
+    PATH_SUFFIXES x86_64/lib/shared-icpc-papi-pthread-pdt )
   # find_library(TAU_ICPC_LIBRARY NAMES TAUsh-icpc-papi-pthread
   #            HINTS ${TAU_ROOT}/src/Profile)
   find_path(TAU_LIBRARY_DIR NAMES libTAU.so libTAU.a libTAU.dylib
-             HINTS ${TAU_ROOT}/x86_64/lib/shared-icpc-papi-pthread-pdt )
+    PATH_SUFFIXES x86_64/lib/shared-icpc-papi-pthread-pdt )
 #   find_path(TAU_ICPC_LIBRARY_DIR NAMES libTAUsh-icpc-papi-pthread.so
 #              HINTS ${TAU_ROOT}/src/Profile)
 # #             HINTS ${TAU_ROOT}/${CMAKE_SYSTEM_PROCESSOR}/lib  ${TAU_ROOT}/*/lib )
 endif()
 
 find_path(TAU_LIBRARY_DIR_2 NAMES libTauPthreadWrap.a
-             HINTS ${TAU_LIBRARY_DIR}/static-papi-pthread)
+  PATH_SUFFIXES static-papi-pthread)
 
 if (TAU_LIBRARY_DIR_2_FOUND)
   message(ERROR "I don't think this is the one we want, because it's static...")
@@ -62,4 +61,3 @@ find_package_handle_standard_args(TAU  DEFAULT_MSG
                                   TAU_LIBRARY TAU_INCLUDE_DIR TAU_LIBRARIES )
 
 mark_as_advanced(TAU_INCLUDE_DIR TAU_LIBRARY TAU_LIBRARIES )
-set(TAU_DIR ${TAU_ROOT})

--- a/configure
+++ b/configure
@@ -493,7 +493,7 @@ case x$with_ayudame in
 xno) ;; # No CMAKE control to remove if available
 xyes) ;; # No CMAKE control to force using
 x) ;;
-*) CMAKE_DEFINES+=" -DAYUDAME_DIR=$(printf %q "$with_ayudame")";;
+*) CMAKE_DEFINES+=" -DAYUDAME_ROOT=$(printf %q "$with_ayudame")";;
 esac
 
 case x$with_hwloc in

--- a/parsec/mca/pins/papi/ValidateModule.CMake
+++ b/parsec/mca/pins/papi/ValidateModule.CMake
@@ -15,7 +15,7 @@ if (PARSEC_PROF_PINS)
       SET(MCA_${COMPONENT}_${MODULE}_CONSTRUCTOR "${COMPONENT}_${MODULE}_static_component")
 
       list(APPEND EXTRA_LIBS ${PAPI_LIBRARIES})
-      include_directories( ${PAPI_INCLUDE_DIR} )
+      include_directories( ${PAPI_INCLUDE_DIRS} )
     else (PARSEC_HAVE_PAPI)
       MESSAGE(STATUS "Module ${MODULE} not selectable: does not have PAPI")
       SET(MCA_${COMPONENT}_${MODULE} OFF)


### PR DESCRIPTION
Proper use of INCLUDE_DIRS, LIBARIES, PACKAGE_ROOT, find_path and
find_libaries, etc.

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>