### PR TITLE
Apply -g3 to DEBUG only, set default config to Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ option(BUILD_SHARED_LIBS
 option(BUILD_64bits
   "Build 64 bits mode" ON)
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build, options are None, Debug, Release, RelWithDebInfo and MinSizeRel." FORCE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are None, Debug, Release, RelWithDebInfo and MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 option(PARSEC_WANT_HOME_CONFIG_FILES
        "Should the runtime check for the parameter configuration file in the user home (\$HOME/.parsec/mca-params.conf)" ON)

--- a/cmake_modules/ParsecCompilerFlags.cmake
+++ b/cmake_modules/ParsecCompilerFlags.cmake
@@ -128,15 +128,15 @@ endif(NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
 #
 
 # add gdb symbols in debug and relwithdebinfo, g3 for macro support when available
-check_and_set_compiler_option(OPTION "-g3" NAME PARSEC_HAVE_G3 COMMENT "List of compile options used to enable highest level of debugging (e.g. -g3)")
+check_and_set_compiler_option(OPTION "-g3" NAME PARSEC_HAVE_G3 COMMENT "List of compile options used to enable highest level of debugging (e.g. -g3)" CONFIG DEBUG)
 
 # Some compilers produce better debugging outputs with Og vs O0
 # but this should only be used in RelWithDebInfo mode.
 check_and_set_compiler_option(OPTION "-Og" NAME PARSEC_HAVE_Og CONFIG RELWITHDEBINFO)
 
 # Set warnings for debug builds
-check_and_set_compiler_option(OPTION "-Wall" NAME PARSEC_HAVE_WALL )
-check_and_set_compiler_option(OPTION "-Wextra" NAME PARSEC_HAVE_WEXTRA )
+check_and_set_compiler_option(OPTION "-Wall" NAME PARSEC_HAVE_WALL)
+check_and_set_compiler_option(OPTION "-Wextra" NAME PARSEC_HAVE_WEXTRA)
 
 # Flex-generated files make some compilers generate a significant
 # amount of warnings. We define here warning silent options


### PR DESCRIPTION
When we changed the way compiler flags are applied, we changed what config receive what flags. This is a proposal PR to restore some (but not all) of the flag scoping we had before:

New:
- default config set to release

Revert: 
- apply -g3 to DEBUG config only

Keep:
- -Wall -Wextra applies to all configs