### PR TITLE
Handle error in CUDA/HIP module init and configurable max_streams

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_component.c
+++ b/parsec/mca/device/cuda/device_cuda_component.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -35,7 +35,7 @@ static int device_cuda_component_register(void);
 
 /* mca params */
 int parsec_device_cuda_enabled_index, parsec_device_cuda_enabled;
-int parsec_cuda_sort_pending = 0;
+int parsec_cuda_sort_pending = 0, parsec_cuda_max_streams = PARSEC_GPU_MAX_STREAMS;
 int parsec_cuda_memory_block_size, parsec_cuda_memory_percentage, parsec_cuda_memory_number_of_blocks;
 char* parsec_cuda_lib_path = NULL;
 
@@ -189,6 +189,9 @@ static int device_cuda_component_register(void)
     (void)parsec_mca_param_reg_int_name("device_cuda", "max_number_of_ejected_data",
                                         "Sets up the maximum number of blocks that can be ejected from GPU memory",
                                         false, false, MAX_PARAM_COUNT, &parsec_gpu_d2h_max_flows);
+    (void)parsec_mca_param_reg_int_name("device_cuda", "max_streams",
+                                        "Maximum number of Streams to use for the GPU engine; 2 streams are used for communication between host and device, so the minimum is 3",
+                                        false, false, PARSEC_GPU_MAX_STREAMS, &parsec_cuda_max_streams);
     (void)parsec_mca_param_reg_int_name("device_cuda", "sort_pending_tasks",
                                         "Boolean to let the GPU engine sort the first pending tasks stored in the list",
                                         false, false, 0, &parsec_cuda_sort_pending);

--- a/parsec/mca/device/cuda/device_cuda_internal.h
+++ b/parsec/mca/device/cuda/device_cuda_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -15,7 +15,7 @@ BEGIN_C_DECLS
 
 /* From MCA parameters */
 extern int parsec_device_cuda_enabled_index, parsec_device_cuda_enabled;
-extern int parsec_cuda_sort_pending;
+extern int parsec_cuda_sort_pending, parsec_cuda_max_streams;
 extern int parsec_cuda_memory_block_size, parsec_cuda_memory_percentage, parsec_cuda_memory_number_of_blocks;
 extern char* parsec_cuda_lib_path;
 

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -354,6 +354,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
     streaming_multiprocessor = prop.multiProcessorCount;
     computemode = prop.computeMode;
 
+    // We use calloc because we need some fields to be zero-initialized to ensure graceful handling of errors
     cuda_device = (parsec_device_cuda_module_t*)calloc(1, sizeof(parsec_device_cuda_module_t));
     gpu_device = &cuda_device->super;
     device = &gpu_device->super;
@@ -361,30 +362,29 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
     cuda_device->cuda_index = (uint8_t)dev_id;
     cuda_device->major      = (uint8_t)major;
     cuda_device->minor      = (uint8_t)minor;
-    len = asprintf(&gpu_device->super.name, "%s (%d)", szName, dev_id);
-    if(-1 == len)
-        gpu_device->super.name = strdup("");
+    len = asprintf(&gpu_device->super.name, "%s: cuda(%d)", szName, dev_id);
+    if(-1 == len) { gpu_device->super.name = NULL; goto release_device; }
     gpu_device->data_avail_epoch = 0;
 
-    gpu_device->max_exec_streams = 0; // We will increment this as streams are succesfully initialized
+    gpu_device->max_exec_streams = parsec_cuda_max_streams;
     gpu_device->exec_stream =
-        (parsec_gpu_exec_stream_t**)malloc(PARSEC_MAX_STREAMS * sizeof(parsec_gpu_exec_stream_t*));
+        (parsec_gpu_exec_stream_t**)malloc(gpu_device->max_exec_streams * sizeof(parsec_gpu_exec_stream_t*));
     // To reduce the number of separate malloc, we allocate all the streams in a single block, stored in exec_stream[0]
     // Because the gpu_device structure does not know the size of cuda_stream or other GPU streams, it needs to keep
     // separate pointers for the beginning of each exec_stream
     // We use calloc because we need some fields to be zero-initialized to ensure graceful handling of errors
-    gpu_device->exec_stream[0] = (parsec_gpu_exec_stream_t*)calloc(PARSEC_MAX_STREAMS,
-								   sizeof(parsec_cuda_exec_stream_t));
-    for( j = 1; j < PARSEC_MAX_STREAMS; j++ ) {
+    gpu_device->exec_stream[0] = (parsec_gpu_exec_stream_t*)calloc(gpu_device->max_exec_streams,
+                                                                   sizeof(parsec_cuda_exec_stream_t));
+    for( j = 1; j < gpu_device->max_exec_streams; j++ ) {
         gpu_device->exec_stream[j] = (parsec_gpu_exec_stream_t*)(
                 (parsec_cuda_exec_stream_t*)gpu_device->exec_stream[0] + j);
     }
-    for( j = 0; j < PARSEC_MAX_STREAMS; j++ ) {
+    for( j = 0; j < gpu_device->max_exec_streams; j++ ) {
         parsec_cuda_exec_stream_t* cuda_stream = (parsec_cuda_exec_stream_t*)gpu_device->exec_stream[j];
         parsec_gpu_exec_stream_t* exec_stream = &cuda_stream->super;
 
-	/* We will have to release up to this stream in case of error */
-	gpu_device->max_exec_streams++;
+        /* We will have to release up to this stream in case of error */
+        gpu_device->num_exec_streams++;
 
         /* Allocate the stream */
         cudastatus = cudaStreamCreate( &(cuda_stream->cuda_stream) );
@@ -412,18 +412,13 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
                                      {goto release_device;} );
         }
         if(j == 0) {
-            len = asprintf(&exec_stream->name, "h2d(%d)", j);
-            if(-1 == len)
-	      exec_stream->name = strdup("h2d");
+            len = asprintf(&exec_stream->name, "h2d_cuda(%d)", j);
         } else if(j == 1) {
-            len = asprintf(&exec_stream->name, "d2h(%d)", j);
-            if(-1 == len)
-	      exec_stream->name = strdup("d2h");
+            len = asprintf(&exec_stream->name, "d2h_cuda(%d)", j);
         } else {
             len = asprintf(&exec_stream->name, "cuda(%d)", j);
-            if(-1 == len)
-	      exec_stream->name = strdup("cuda");
         }
+        if(-1 == len) { exec_stream->name = NULL; goto release_device; }
 #if defined(PARSEC_PROF_TRACE)
         /* Each 'exec' stream gets its own profiling stream, except IN and OUT stream that share it.
          * It's good to separate the exec streams to know what was submitted to what stream
@@ -513,6 +508,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
     if( NULL != gpu_device->exec_stream) {
         for( j = 0; j < gpu_device->max_exec_streams; j++ ) {
             parsec_cuda_exec_stream_t *cuda_stream = (parsec_cuda_exec_stream_t*)gpu_device->exec_stream[j];
+            if(NULL == cuda_stream) continue;
             parsec_gpu_exec_stream_t* exec_stream = &cuda_stream->super;
 
             if( NULL != exec_stream->fifo_pending ) {
@@ -569,7 +565,7 @@ parsec_cuda_module_fini(parsec_device_module_t* device)
     PARSEC_OBJ_DESTRUCT(&gpu_device->pending);
 
     /* Release all streams */
-    for( j = 0; j < gpu_device->max_exec_streams; j++ ) {
+    for( j = 0; j < gpu_device->num_exec_streams; j++ ) {
         parsec_cuda_exec_stream_t* cuda_stream = (parsec_cuda_exec_stream_t*)gpu_device->exec_stream[j];
         parsec_gpu_exec_stream_t* exec_stream = &cuda_stream->super;
 
@@ -2635,7 +2631,7 @@ parsec_cuda_kernel_scheduler( parsec_execution_stream_t *es,
     gpu_task = progress_task;
 
     /* Stage-in completed for this task: it is ready to be executed */
-    exec_stream = (exec_stream + 1) % (gpu_device->max_exec_streams - 2);  /* Choose an exec_stream */
+    exec_stream = (exec_stream + 1) % (gpu_device->num_exec_streams - 2);  /* Choose an exec_stream */
     if( NULL != gpu_task ) {
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%s]:\tExecute %s priority %d", gpu_device->super.name,
                              parsec_task_snprintf(tmp, MAX_TASK_STRLEN, gpu_task->ec),

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2021      The University of Tennessee and The University
+ * Copyright (c) 2021-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -9,8 +9,6 @@
 #include "parsec/mca/device/device.h"
 #include "parsec/mca/device/device_gpu.h"
 #include "parsec/utils/zone_malloc.h"
-#include "parsec/utils/mca_param.h"
-#include "parsec/mca/mca_repository.h"
 #include "parsec/constants.h"
 #include "parsec/utils/debug.h"
 #include "parsec/execution_stream.h"
@@ -219,7 +217,7 @@ int parsec_gpu_free_workspace(parsec_device_gpu_module_t * gpu_device)
     (void)gpu_device;
 #if !defined(PARSEC_GPU_ALLOC_PER_TILE)
     int i, j;
-    for( i = 0; i < gpu_device->max_exec_streams; i++ ) {
+    for( i = 0; i < gpu_device->num_exec_streams; i++ ) {
         parsec_gpu_exec_stream_t *gpu_stream = gpu_device->exec_stream[i];
         if (gpu_stream->workspace != NULL) {
             for (j = 0; j < gpu_stream->workspace->total_workspace; j++) {
@@ -310,13 +308,13 @@ void dump_GPU_state(parsec_device_gpu_module_t* gpu_device)
     parsec_output(parsec_gpu_output_stream, "\n\n");
     parsec_output(parsec_gpu_output_stream, "Device %d:%d (%p) epoch\n", gpu_device->super.device_index,
                   gpu_device->super.device_index, gpu_device, gpu_device->data_avail_epoch);
-    parsec_output(parsec_gpu_output_stream, "\tpeer mask %x executed tasks %llu max streams %d\n",
-                  gpu_device->peer_access_mask, (unsigned long long)gpu_device->super.executed_tasks, gpu_device->max_exec_streams);
+    parsec_output(parsec_gpu_output_stream, "\tpeer mask %x executed tasks with %llu streams %d\n",
+                  gpu_device->peer_access_mask, (unsigned long long)gpu_device->super.executed_tasks, gpu_device->num_exec_streams);
     parsec_output(parsec_gpu_output_stream, "\tstats transferred [in: %llu from host %llu from other device out: %llu] required [in: %llu out: %llu]\n",
                   (unsigned long long)gpu_device->super.transferred_data_in, (unsigned long long)gpu_device->super.d2d_transfer,
                   (unsigned long long)gpu_device->super.transferred_data_out,
                   (unsigned long long)gpu_device->super.required_data_in, (unsigned long long)gpu_device->super.required_data_out);
-    for( i = 0; i < gpu_device->max_exec_streams; i++ ) {
+    for( i = 0; i < gpu_device->num_exec_streams; i++ ) {
         dump_exec_stream(gpu_device->exec_stream[i]);
     }
     if( !parsec_list_is_empty(&gpu_device->gpu_mem_lru) ) {

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -18,7 +18,7 @@
 BEGIN_C_DECLS
 
 #define PARSEC_GPU_USE_PRIORITIES     1
-#define PARSEC_MAX_STREAMS            6
+#define PARSEC_GPU_MAX_STREAMS        6
 #define PARSEC_MAX_EVENTS_PER_STREAM  4
 #define PARSEC_GPU_MAX_WORKSPACE      2
 
@@ -115,6 +115,7 @@ struct parsec_gpu_task_s {
 struct parsec_device_gpu_module_s {
     parsec_device_module_t     super;
     uint8_t                    max_exec_streams;
+    uint8_t                    num_exec_streams;
     int16_t                    peer_access_mask;  /**< A bit set to 1 represent the capability of
                                                    *   the device to access directly the memory of
                                                    *   the index of the set bit device.

--- a/tests/dsl/dtd/dtd_test_cuda_task_insert.c
+++ b/tests/dsl/dtd/dtd_test_cuda_task_insert.c
@@ -56,8 +56,8 @@ int print_cuda_info_task(parsec_device_cuda_module_t *cuda_device,
     printf("  CUDA device compute capability: %d.%d\n",
            cuda_device->major, cuda_device->minor);
     printf( "  CUDA Stream: %p\n", (void*)(uintptr_t)cuda_stream->cuda_stream);
-    printf("  CUDA device max exec stream: %d\n",
-           cuda_device->super.max_exec_streams);
+    printf("  CUDA device num exec stream: %d\n",
+           cuda_device->super.num_exec_streams);
 
     return PARSEC_HOOK_RETURN_DONE;
 }


### PR DESCRIPTION
A misconfiguration on leconte makes none of the device capable of allocating a cuda stream.

This leads to a SEGFAULT, because we try to free things that have not been allocated.

With this patch, the devices are just removed (with a warning), but the execution proceeds.
