### PR TITLE
Cleanup/ptgpp assignments

### DIFF
--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -3291,6 +3291,7 @@ static  void jdf_generate_deps_key_functions(const jdf_t *jdf, const jdf_functio
                 "\n",
                 sname);
     } else {
+        string_arena_t *sa1 = string_arena_new(64);
         string_arena_t *sa_format = string_arena_new(64);
         string_arena_t *sa_params = string_arena_new(64);
         string_arena_t *sa_info = string_arena_new(64);
@@ -3317,7 +3318,11 @@ static  void jdf_generate_deps_key_functions(const jdf_t *jdf, const jdf_functio
                 sname,
                 jdf_basename, jdf_basename);
         if(need_assignment)
-            coutput("  %s "JDF2C_NAMESPACE"_assignments;\n", parsec_get_name(jdf, f, "parsec_assignment_t"));
+            coutput("  %s "JDF2C_NAMESPACE"_assignments = {%s};\n",
+                parsec_get_name(jdf, f, "parsec_assignment_t"),
+                UTIL_DUMP_LIST_FIELD(sa1, f->locals, next, name, dump_string, NULL,
+                                     "  ", ".", ".value = 0, ", ".value = 0 "));
+        string_arena_free(sa1);
         
         for(vl = f->locals; vl != NULL; vl = vl->next) {
             if( local_is_parameter(f, vl) != NULL ) {
@@ -3450,13 +3455,16 @@ static void jdf_generate_internal_init(const jdf_t *jdf, const jdf_function_entr
     }
 
     if( need_to_iterate ) {
-        coutput("  %s assignments;\n", parsec_get_name(jdf, f, "parsec_assignment_t"));
+        coutput("  %s assignments = {%s};\n",
+            parsec_get_name(jdf, f, "parsec_assignment_t"),
+            UTIL_DUMP_LIST_FIELD(sa1, f->locals, next, name, dump_string, NULL,
+                                     "  ", ".", ".value = 0, ", ".value = 0 "));
         if( JDF_COMPILER_GLOBAL_ARGS.dep_management == DEP_MANAGEMENT_INDEX_ARRAY ) {
             coutput("  parsec_dependencies_t *dep = NULL;\n");
         }
         coutput("%s",
                 UTIL_DUMP_LIST_FIELD(sa1, f->locals, next, name, dump_string, NULL,
-                                     "  int32_t ", " ", ",", ";\n"));
+                                     "  int32_t ", " ", ", ", ";\n"));
         for(l2p_item = l2p; NULL != l2p_item; l2p_item = l2p_item->next) {
             vl = l2p_item->vl; assert(NULL != vl);
 

--- a/parsec/profiling.c
+++ b/parsec/profiling.c
@@ -79,7 +79,7 @@ static tl_freelist_t *default_freelist = NULL;
 static parsec_profiling_buffer_t *allocate_empty_buffer(tl_freelist_t *fl, off_t *offset, char type);
 
 /* Process-global dictionary */
-static unsigned int parsec_prof_keys_count, parsec_prof_keys_number;
+static int parsec_prof_keys_count, parsec_prof_keys_number;
 static parsec_profiling_key_t* parsec_prof_keys;
 
 static int         __already_called = 0;
@@ -799,7 +799,7 @@ int parsec_profiling_add_dictionary_keyword( const char* key_name, const char* a
                                             int* key_start, int* key_end )
 {
     int ret = 0;
-    unsigned int i;
+    int i;
     int pos = -1;
 
     if( !__profile_initialized ) return 0;
@@ -845,7 +845,7 @@ profiling_keyword_out:
 
 int parsec_profiling_dictionary_flush( void )
 {
-    unsigned int i;
+    int i;
 
     for( i = 0; i < parsec_prof_keys_count; i++ ) {
         if( NULL != parsec_prof_keys[i].name ) {
@@ -1126,7 +1126,7 @@ static int64_t dump_dictionary(int *nbdico)
     parsec_profiling_buffer_t *b, *n;
     parsec_profiling_key_buffer_t *kb;
     parsec_profiling_key_t *k;
-    unsigned int i;
+    int i;
     int nb, nbthis, cs, pos;
     off_t first_off;
 


### PR DESCRIPTION
Some minor warnings. 

This is take 2 on cleaning up assignments, code modified this time to not initialize the whole (pretty big) struct when we really have only 2 or 3 variables usually. 

