### PR TITLE
Fix/deprecated support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,15 @@ int main() {
   return 0;
 }" PARSEC_HAVE_ATTRIBUTE_DEPRECATED)
 
+check_c_source_compiles("
+enum matrix_type {
+   matrix_Byte __parsec_attribute_deprecated__(\"Use PARSEC_MATRIX_BYTE instead\") =  1, /**< unsigned char  */
+   matrix_Integer __parsec_attribute_deprecated__(\"Use PARSEC_MATRIX_INTEGER instead\") = 2, /**< signed int */
+};
+int main() {
+  return 0;
+  }" PARSEC_HAVE_ENUM_ATTRIBUTE_DEPRECATED)
+
 set(EXTRA_INCLUDES "")
 #
 # Find optional packages

--- a/parsec/data_dist/matrix/CMakeLists.txt
+++ b/parsec/data_dist/matrix/CMakeLists.txt
@@ -51,3 +51,14 @@ set_property(TARGET parsec
                                      data_dist/matrix/grid_2Dcyclic.h
                                      data_dist/matrix/subtile.h)
 
+# Install the deprecated headers.
+set_property(TARGET parsec
+             APPEND PROPERTY
+                    PRIVATE_HEADER_H data_dist/matrix/deprecated/grid_2Dcyclic.h
+                                     data_dist/matrix/deprecated/sym_two_dim_rectangle_cyclic_band.h
+                                     data_dist/matrix/deprecated/two_dim_rectangle_cyclic_band.h
+                                     data_dist/matrix/deprecated/two_dim_tabular.h
+                                     data_dist/matrix/deprecated/matrix.h
+                                     data_dist/matrix/deprecated/sym_two_dim_rectangle_cyclic.h
+                                     data_dist/matrix/deprecated/two_dim_rectangle_cyclic.h
+                                     data_dist/matrix/deprecated/vector_two_dim_cyclic.h)

--- a/parsec/data_dist/matrix/deprecated/matrix.h
+++ b/parsec/data_dist/matrix/deprecated/matrix.h
@@ -13,34 +13,34 @@
 enum
 __parsec_attribute_deprecated__("Use parsec_matrix_type_t instead")
 matrix_type {
-    matrix_Byte          __parsec_attribute_deprecated__("Use PARSEC_MATRIX_BYTE instead") =  PARSEC_MATRIX_BYTE, /**< unsigned char  */
-    matrix_Integer       __parsec_attribute_deprecated__("Use PARSEC_MATRIX_INTEGER instead") = PARSEC_MATRIX_INTEGER, /**< signed int     */
-    matrix_RealFloat     __parsec_attribute_deprecated__("Use PARSEC_MATRIX_FLOAT instead") = PARSEC_MATRIX_FLOAT, /**< float          */
-    matrix_RealDouble    __parsec_attribute_deprecated__("Use PARSEC_MATRIX_DOUBLE instead") = PARSEC_MATRIX_DOUBLE, /**< double         */
-    matrix_ComplexFloat  __parsec_attribute_deprecated__("Use PARSEC_MATRIX_COMPLEX_FLOAT instead") = PARSEC_MATRIX_COMPLEX_FLOAT, /**< complex float  */
-    matrix_ComplexDouble __parsec_attribute_deprecated__("Use PARSEC_MATRIX_COMPLEX_DOUBLE instead") = PARSEC_MATRIX_COMPLEX_DOUBLE  /**< complex double */
+    matrix_Byte          __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_BYTE instead") =  PARSEC_MATRIX_BYTE, /**< unsigned char  */
+    matrix_Integer       __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_INTEGER instead") = PARSEC_MATRIX_INTEGER, /**< signed int     */
+    matrix_RealFloat     __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_FLOAT instead") = PARSEC_MATRIX_FLOAT, /**< float          */
+    matrix_RealDouble    __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_DOUBLE instead") = PARSEC_MATRIX_DOUBLE, /**< double         */
+    matrix_ComplexFloat  __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_COMPLEX_FLOAT instead") = PARSEC_MATRIX_COMPLEX_FLOAT, /**< complex float  */
+    matrix_ComplexDouble __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_COMPLEX_DOUBLE instead") = PARSEC_MATRIX_COMPLEX_DOUBLE  /**< complex double */
 };
 
 enum
 __parsec_attribute_deprecated__("Use parsec_matrix_storage_t instead")
 matrix_storage {
-    matrix_Lapack __parsec_attribute_deprecated__("Use PARSEC_MATRIX_LAPACK instead") = PARSEC_MATRIX_LAPACK, /**< LAPACK Layout or Column Major  */
-    matrix_Tile   __parsec_attribute_deprecated__("Use PARSEC_MATRIX_TILE instead") = PARSEC_MATRIX_TILE, /**< Tile Layout or Column-Column Rectangular Block (CCRB) */
+    matrix_Lapack __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_LAPACK instead") = PARSEC_MATRIX_LAPACK, /**< LAPACK Layout or Column Major  */
+    matrix_Tile   __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_TILE instead") = PARSEC_MATRIX_TILE, /**< Tile Layout or Column-Column Rectangular Block (CCRB) */
 };
 
 enum
 __parsec_attribute_deprecated__("Use parsec_matrix_uplo_t instead")
 matrix_uplo {
-    matrix_Upper      __parsec_attribute_deprecated__("Use PARSEC_MATRIX_UPPER instead") = PARSEC_MATRIX_UPPER,
-    matrix_Lower      __parsec_attribute_deprecated__("Use PARSEC_MATRIX_LOWER instead") = PARSEC_MATRIX_LOWER,
-    matrix_UpperLower __parsec_attribute_deprecated__("Use PARSEC_MATRIX_FULL instead")  = PARSEC_MATRIX_FULL
+    matrix_Upper      __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_UPPER instead") = PARSEC_MATRIX_UPPER,
+    matrix_Lower      __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_LOWER instead") = PARSEC_MATRIX_LOWER,
+    matrix_UpperLower __parsec_enum_attribute_deprecated__("Use PARSEC_MATRIX_FULL instead")  = PARSEC_MATRIX_FULL
 };
 
 enum {
-    parsec_tiled_matrix_dc_type    __parsec_attribute_deprecated__("Use parsec_matrix_type instead") = parsec_matrix_type,
-    two_dim_block_cyclic_type      __parsec_attribute_deprecated__("Use parsec_matrix_block_cyclic_type instead") = parsec_matrix_block_cyclic_type,
-    sym_two_dim_block_cyclic_type  __parsec_attribute_deprecated__("Use parsec_matrix_sym_block_cyclic_type instead") = parsec_matrix_sym_block_cyclic_type,
-    two_dim_tabular_type           __parsec_attribute_deprecated__("Use parsec_matrix_tabular_type instead") = parsec_matrix_tabular_type
+    parsec_tiled_matrix_dc_type    __parsec_enum_attribute_deprecated__("Use parsec_matrix_type instead") = parsec_matrix_type,
+    two_dim_block_cyclic_type      __parsec_enum_attribute_deprecated__("Use parsec_matrix_block_cyclic_type instead") = parsec_matrix_block_cyclic_type,
+    sym_two_dim_block_cyclic_type  __parsec_enum_attribute_deprecated__("Use parsec_matrix_sym_block_cyclic_type instead") = parsec_matrix_sym_block_cyclic_type,
+    two_dim_tabular_type           __parsec_enum_attribute_deprecated__("Use parsec_matrix_tabular_type instead") = parsec_matrix_tabular_type
 };
 
 typedef parsec_tiled_matrix_t parsec_tiled_matrix_dc_t __parsec_attribute_deprecated__("Use parsec_tiled_matrix_t instead");

--- a/parsec/include/parsec/parsec_config_bottom.h
+++ b/parsec/include/parsec/parsec_config_bottom.h
@@ -62,6 +62,12 @@
 #   define __parsec_attribute_deprecated__(a)
 #endif
 
+#if defined(PARSEC_HAVE_ENUM_ATTRIBUTE_DEPRECATED)
+#   define __parsec_enum_attribute_deprecated__(msg) __attribute__((deprecated(msg)))
+#else // PARSEC_HAVE_ENUM_ATTRIBUTE_DEPRECATED
+#   define __parsec_enum_attribute_deprecated__(a)
+#endif
+
 /***********************************************************************
  *
  * Windows library interface declaration code


### PR DESCRIPTION
Some old compilers accept the deprecate attribute for functions, structs and enums but not for the members of enums. Detect if the compiler only provides partial support for deprecated.
    