### PR TITLE
Make the ParsecCompilerFlags.cmake self contained

### DIFF
--- a/cmake_modules/ParsecCompilerFlags.cmake
+++ b/cmake_modules/ParsecCompilerFlags.cmake
@@ -1,4 +1,6 @@
 include (CheckCCompilerFlag)
+include (CheckCXXCompilerFlag)
+include (CheckFortranCompilerFlag)
 
 #
 # This is a convenience function that will check a given option


### PR DESCRIPTION
Make the ParsecCompilerFlags.cmake self contained  by having all the necessary 'checkXYZCompilerFlags' include done inside

Signed-off-by: Aurélien Bouteiller <bouteill@icl.utk.edu>