### PR TITLE
flex: on some machines, flex cannot work if parsec/utils is not created

### DIFF
--- a/cmake_modules/pregen_flex_bison.cmake
+++ b/cmake_modules/pregen_flex_bison.cmake
@@ -49,6 +49,7 @@ if(archive)
     # Check for problems: stray files in build directory
     execute_process(
       COMMAND git ls-files --error-unmatch ${srcdir}/${source}
+      WORKING_DIRECTORY ${srcdir}
       RESULT_VARIABLE ret
       OUTPUT_VARIABLE stdout
       ERROR_VARIABLE stderr
@@ -61,6 +62,7 @@ if(archive)
     # Check for modifications
     execute_process(
       COMMAND git status --porcelain -- ${srcdir}/${source}
+      WORKING_DIRECTORY ${srcdir}
       RESULT_VARIABLE ret
       OUTPUT_VARIABLE stdout
       ERROR_VARIABLE stderr

--- a/parsec/CMakeLists.txt
+++ b/parsec/CMakeLists.txt
@@ -42,10 +42,12 @@ set(BASE_SOURCES
 
 if(FLEX_FOUND AND BISON_FOUND)
   # generate in the build dir
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/utils")
   FLEX_TARGET(keyval_flex utils/keyval_lex.l utils/keyval_lex.l.c)
   FLEX_TARGET(show_help_flex utils/show_help_lex.l utils/show_help_lex.l.c)
 
   # Generate in the pregen dir, add to the non-automated rule
+  file(MAKE_DIRECTORY "${PARSEC_PREGEN_FLEX_BISON_DIR}/parsec/utils")
   FLEX_TARGET(pregen_keyval_flex utils/keyval_lex.l ${PARSEC_PREGEN_FLEX_BISON_DIR}/parsec/utils/keyval_lex.l.c COMPILE_FLAGS --noline)
   FLEX_TARGET(pregen_show_help_flex utils/show_help_lex.l ${PARSEC_PREGEN_FLEX_BISON_DIR}/parsec/utils/show_help_lex.l.c COMPILE_FLAGS --noline)
   add_custom_target(parsec_pregen_flex_utils SOURCES ${FLEX_pregen_keyval_flex_OUTPUTS} ${FLEX_pregen_show_help_flex_OUTPUTS})

--- a/parsec/interfaces/ptg/ptg-compiler/CMakeLists.txt
+++ b/parsec/interfaces/ptg/ptg-compiler/CMakeLists.txt
@@ -9,6 +9,7 @@ IF(NOT CMAKE_CROSSCOMPILING)
     ADD_FLEX_BISON_DEPENDENCY(parsec_flex parsec_yacc)
 
     # Generate in the pregen dir, add to the non-automated rule to update the archive
+    file(MAKE_DIRECTORY "${PARSEC_PREGEN_FLEX_BISON_DIR}/parsec/interfaces/ptg/ptg-compiler")
     BISON_TARGET(pregen_parsec_yacc parsec.y ${PARSEC_PREGEN_FLEX_BISON_DIR}/parsec/interfaces/ptg/ptg-compiler/parsec.y.c COMPILE_FLAGS -l)
     FLEX_TARGET(pregen_parsec_flex parsec.l ${PARSEC_PREGEN_FLEX_BISON_DIR}/parsec/interfaces/ptg/ptg-compiler/parsec.l.c COMPILE_FLAGS --noline)
     add_custom_target(parsec_pregen_ptg SOURCES ${BISON_pregen_parsec_yacc_OUTPUTS} ${FLEX_pregen_parsec_flex_OUTPUTS})


### PR DESCRIPTION
in the build directory before invocation, so lets create it/

reference: https://gitlab.kitware.com/cmake/cmake/-/issues/19529

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>