### PR TITLE
Workaround current CUDA/HIP "solution suspicious" bug...

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -1389,8 +1389,7 @@ parsec_gpu_data_stage_in( parsec_device_cuda_module_t* cuda_device,
                              __FILE__, __LINE__);
     }
 
-    /* If data is from NEW, as we skip NULL */
-    if( NULL == task_data->source_repo_entry )
+    if( NULL == task_data->source_repo_entry && NULL == task_data->data_in->original->dc )
         transfer_from = -1;
 
     /* Do not need to be tranferred */


### PR DESCRIPTION
Introduction of the NEW optimization in CUDA introduced this bug that
makes the CUDA driver not copy data from RAM to GPU, if the data copy
comes from a direct memory access. The test to detect this is a NEW
tile is wrong in the code, and abusively confuses copies coming
directly from memory with copies coming from a NEW operation.

I'm not sure how to detect a tile is NEW at this time... This patch
is a temporary workaround that forces data copies to be copied on
the CUDA device, if they come from memory (correct), or if they
come from a NEW operation (useless overhead). But it's more correct
to do the copy all the time than to not do it at all...