### PR TITLE
Make the PUSHOUT and other DTD GPU concepts generic

### DIFF
--- a/parsec/interfaces/dtd/insert_function.h
+++ b/parsec/interfaces/dtd/insert_function.h
@@ -14,9 +14,6 @@
 
 #include "parsec/runtime.h"
 #include "parsec/data_distribution.h"
-#if defined(PARSEC_HAVE_CUDA)
-#include "parsec/mca/device/cuda/device_cuda.h"
-#endif  /* defined(PARSEC_HAVE_CUDA) */
 
 BEGIN_C_DECLS
 
@@ -70,10 +67,8 @@ typedef enum { PARSEC_INPUT =      0x100000,
                PARSEC_GET_OP_TYPE =0xf00000, /* MASK: not an actual value, used to filter the relevant enum values */
                PARSEC_AFFINITY    =1<<16, /* Data affinity */
                PARSEC_DONT_TRACK  =1<<17, /* Drop dependency tracking */
-#if defined(PARSEC_HAVE_CUDA)
                PARSEC_PUSHOUT     =1<<18, /* Push GPU data back to CPU */
                PARSEC_PULLIN      =1<<19, /* Pull data on the CPU */
-#endif
                PARSEC_GET_OTHER_FLAG_INFO=0xf0000, /* MASK: not an actual value, used to filter the relevant enum values */
                PARSEC_GET_REGION_INFO=0xffff /* MASK: not an actual value, used to filter the relevant enum values */
              } parsec_dtd_op_t;
@@ -176,14 +171,6 @@ typedef struct parsec_dtd_taskpool_s     parsec_dtd_taskpool_t;
  *
  */
 typedef parsec_hook_return_t (parsec_dtd_funcptr_t)(parsec_execution_stream_t *, parsec_task_t *);
-
-#if defined(PARSEC_HAVE_CUDA)
-// FIXME: The following macro should be removed and is only useful
-// during the development of the cuda DTD feature.
-#define PARSEC_DTD_HAVE_CUDA
-#include <cuda.h>
-#include <cuda_runtime_api.h>
-#endif /*  defined(PARSEC_HAVE_CUDA) */
 
 /**
  * This function is used to retrieve the parameters passed during insertion of a task.
@@ -294,14 +281,12 @@ parsec_dtd_insert_task(parsec_taskpool_t  *tp,
                        int device_type,
                        const char *name_of_kernel, ...);
 
-#if defined(PARSEC_HAVE_CUDA)
 /**
  * Return pointer on the device pointer associated with the i-th flow
  * of `this_task`.
  **/
 void*
 parsec_dtd_get_dev_ptr(parsec_task_t *this_task, int i);
-#endif
    
 /**
  * This function behaves exactly like parsec_dtd_insert_task()

--- a/parsec/interfaces/dtd/insert_function_internal.h
+++ b/parsec/interfaces/dtd/insert_function_internal.h
@@ -19,6 +19,7 @@
 #include "parsec/data_distribution.h"
 #include "parsec/interfaces/dtd/insert_function.h"
 #include "parsec/execution_stream.h"
+#include "parsec/mca/device/device_gpu.h"
 
 BEGIN_C_DECLS
 
@@ -252,9 +253,7 @@ struct parsec_dtd_task_class_s {
     int                        ref_count;
     parsec_dtd_param_t        *params;
     parsec_hook_t             *cpu_func_ptr;
-#if defined(PARSEC_HAVE_CUDA)
-    parsec_advance_task_function_t cuda_func_ptr;
-#endif
+    parsec_advance_task_function_t gpu_func_ptr;
 };
 
 typedef int (parsec_dtd_arg_cb)(int first_arg, void *second_arg, int third_arg, void *cb_data);


### PR DESCRIPTION
Make the PUSHOUT and other DTD GPU concepts generic so that we can compile w/o cuda (and with rocm, when rocm PR merge)

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>