### PR TITLE
Execution stream keeps the highest priority task for local execution.

### DIFF
--- a/parsec/data_dist/matrix/map_operator.c
+++ b/parsec/data_dist/matrix/map_operator.c
@@ -259,16 +259,7 @@ static int release_deps(parsec_execution_stream_t *es,
     iterate_successors(es, this_task, action_mask, add_task_to_list, ready_list);
 
     if(action_mask & PARSEC_ACTION_RELEASE_LOCAL_DEPS) {
-        for(i = 0; i < es->virtual_process->parsec_context->nb_vp; i++) {
-            if( NULL == ready_list[i] )
-                continue;
-            if( i == es->virtual_process->vp_id )
-                __parsec_schedule(es, ready_list[i], 0);
-            else
-                __parsec_schedule(es->virtual_process->parsec_context->virtual_processes[i]->execution_streams[0],
-                                  ready_list[i], 0);
-            ready_list[i] = NULL;
-        }
+        __parsec_schedule_vp(es, ready_list, 0);
     }
 
     if(action_mask & PARSEC_ACTION_RELEASE_LOCAL_REFS) {

--- a/parsec/include/parsec/execution_stream.h
+++ b/parsec/include/parsec/execution_stream.h
@@ -48,6 +48,11 @@ struct parsec_execution_stream_s {
 
     void *scheduler_object;
 
+    /* The task to be executed next by this execution_stream. Beware as this bypasses
+     * the scheduler decision.
+     */
+    struct parsec_task_s* next_task;
+
 #if defined(PARSEC_SIM)
     int largest_simulation_date;
 #endif

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -3092,6 +3092,8 @@ static void jdf_generate_startup_tasks(const jdf_t *jdf, const jdf_function_entr
     coutput("%s  if( NULL != ((parsec_data_collection_t*)"TASKPOOL_GLOBAL_PREFIX"_g_%s)->vpid_of ) {\n"
             "%s    vpid = ((parsec_data_collection_t*)"TASKPOOL_GLOBAL_PREFIX"_g_%s)->vpid_of((parsec_data_collection_t*)"TASKPOOL_GLOBAL_PREFIX"_g_%s, %s);\n"
             "%s    assert(context->nb_vp >= vpid);\n"
+            "%s  } else {\n"
+            "%s    vpid = (vpid + 1) %% context->nb_vp;  /* spread the initial joy */\n"
             "%s  }\n"
             "%s  new_task = (%s*)parsec_thread_mempool_allocate( context->virtual_processes[vpid]->execution_streams[0]->context_mempool );\n"
             "%s  new_task->status = PARSEC_TASK_STATUS_NONE;\n",
@@ -3100,6 +3102,8 @@ static void jdf_generate_startup_tasks(const jdf_t *jdf, const jdf_function_entr
             UTIL_DUMP_LIST(sa2, f->predicate->parameters, next,
                            dump_expr, (void*)&info1,
                            "", "", ", ", ""),
+            indent(nesting),
+            indent(nesting),
             indent(nesting),
             indent(nesting),
             indent(nesting), parsec_get_name(jdf, f, "task_t"),
@@ -3156,26 +3160,22 @@ static void jdf_generate_startup_tasks(const jdf_t *jdf, const jdf_function_entr
             "%s  pready_ring[vpid] = parsec_list_item_ring_push_sorted(pready_ring[vpid],\n"
             "%s                                                        (parsec_list_item_t*)new_task,\n"
             "%s                                                        parsec_execution_context_priority_comparator);\n"
-            "%s  nb_tasks++;\n", indent(nesting), indent(nesting), indent(nesting), indent(nesting), indent(nesting));    
+            "%s  nb_tasks++;\n", indent(nesting), indent(nesting), indent(nesting), indent(nesting), indent(nesting));
     coutput("%s restore_context_%d:  /* we jump here just so that we have code after the label */\n", indent(nesting), ctx_level);
     coutput("%s  restore_context = 0;\n"
             "%s  (void)restore_context;\n"
             "%s  if( nb_tasks > this_task->locals.reserved[0].value ) {\n"
             "%s    if( (size_t)this_task->locals.reserved[0].value < parsec_task_startup_iter ) this_task->locals.reserved[0].value <<= 1;\n"
-            "%s    for(int _i = 0; _i < context->nb_vp; _i++ ) {\n"
-            "%s      if( NULL == pready_ring[_i] ) continue;\n"
-            "%s      __parsec_schedule(context->virtual_processes[_i]->execution_streams[0], (parsec_task_t*)pready_ring[_i], 0);\n"
-            "%s      pready_ring[_i] = NULL;\n"
-            "%s    }\n"
+            "%s    __parsec_schedule_vp(es, (parsec_task_t**)pready_ring, 0);\n"
             "%s    total_nb_tasks += nb_tasks;\n"
             "%s    nb_tasks = 0;\n"
             "%s    if( total_nb_tasks > parsec_task_startup_chunk ) {  /* stop here and request to be rescheduled */\n"
             "%s      return PARSEC_HOOK_RETURN_AGAIN;\n"
             "%s    }\n"
             "%s  }\n",
-            indent(nesting), indent(nesting), indent(nesting), indent(nesting), indent(nesting),
-            indent(nesting), indent(nesting), indent(nesting), indent(nesting), indent(nesting),
-            indent(nesting), indent(nesting), indent(nesting), indent(nesting), indent(nesting));
+            indent(nesting), indent(nesting), indent(nesting), indent(nesting),
+            indent(nesting), indent(nesting), indent(nesting), indent(nesting),
+            indent(nesting), indent(nesting), indent(nesting));
 
     /* We close all variables, in reverse order to manage the local indices */
     while( NULL != inner_vl ) {
@@ -3202,12 +3202,7 @@ static void jdf_generate_startup_tasks(const jdf_t *jdf, const jdf_function_entr
 
     coutput("  (void)vpid;\n"
             "  if( 0 != nb_tasks ) {\n"
-            "    for(int _i = 0; _i < context->nb_vp; _i++ ) {\n"
-            "      if( NULL == pready_ring[_i] ) continue;\n"
-            "      __parsec_schedule(context->virtual_processes[_i]->execution_streams[0],\n"
-            "                        (parsec_task_t*)pready_ring[_i], 0);\n"
-            "      pready_ring[_i] = NULL;\n"
-            "    }\n"
+            "    __parsec_schedule_vp(es, (parsec_task_t**)pready_ring, 0);\n"
             "    nb_tasks = 0;\n"
             "  }\n"
             "  return PARSEC_HOOK_RETURN_DONE;\n"
@@ -4408,16 +4403,17 @@ static void jdf_generate_startup_hook( const jdf_t *jdf )
             "      if( !(supported_dev & chores[j].type) ) continue;\n"
             "      if( j != idx ) {\n"
             "        chores[idx] = chores[j];\n"
-            "        parsec_debug_verbose(20, parsec_debug_output, \"Device type %%i disabledfor function %%s\"\n, chores[j].type, tc->name);\n"
+            "        parsec_debug_verbose(20, parsec_debug_output, \"Device type %%i disabled for function %%s\"\n, chores[j].type, tc->name);\n"
             "      }\n"
             "      idx++;\n"
             "    }\n"
             "    chores[idx].type     = PARSEC_DEV_NONE;\n"
             "    chores[idx].evaluate = NULL;\n"
             "    chores[idx].hook     = NULL;\n"
+            "    /* Create the initialization tasks for each taskclass */\n"
             "    parsec_task_t* task = (parsec_task_t*)parsec_thread_mempool_allocate(context->virtual_processes[0]->execution_streams[0]->context_mempool);\n"
             "    task->taskpool = (parsec_taskpool_t *)__parsec_tp;\n"
-            "    task->chore_mask = PARSEC_DEV_ALL;\n"
+            "    task->chore_mask = PARSEC_DEV_CPU;\n"
             "    task->status = PARSEC_TASK_STATUS_NONE;\n"
             "    memset(&task->locals, 0, sizeof(parsec_assignment_t) * MAX_LOCAL_COUNT);\n"
             "    PARSEC_LIST_ITEM_SINGLETON(task);\n"
@@ -7170,20 +7166,11 @@ static void jdf_generate_code_release_deps(const jdf_t *jdf, const jdf_function_
                 "#endif\n"
                 "\n");
         coutput("  if(action_mask & PARSEC_ACTION_RELEASE_LOCAL_DEPS) {\n"
-                "    struct parsec_vp_s** vps = es->virtual_process->parsec_context->virtual_processes;\n");
-        coutput("    data_repo_entry_addto_usage_limit(%s_repo, arg.output_entry->ht_item.key, arg.output_usage);\n",
+                "    data_repo_entry_addto_usage_limit(%s_repo, arg.output_entry->ht_item.key, arg.output_usage);\n"
+                "    __parsec_schedule_vp(es, arg.ready_lists, 0);\n"
+                "  }\n",
                 f->fname);
 
-        coutput("    for(__vp_id = 0; __vp_id < es->virtual_process->parsec_context->nb_vp; __vp_id++) {\n"
-                "      if( NULL == arg.ready_lists[__vp_id] ) continue;\n"
-                "      if(__vp_id == es->virtual_process->vp_id) {\n"
-                "        __parsec_schedule(es, arg.ready_lists[__vp_id], 0);\n"
-                "      } else {\n"
-                "        __parsec_schedule(vps[__vp_id]->execution_streams[0], arg.ready_lists[__vp_id], 0);\n"
-                "      }\n"
-                "      arg.ready_lists[__vp_id] = NULL;\n"
-                "    }\n"
-                "  }\n");
     } else {
         coutput("  /* No successors, don't call iterate_successors and don't release any local deps */\n");
     }

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -156,6 +156,8 @@ static int parsec_runtime_max_number_of_cores = -1;
 static int parsec_runtime_bind_main_thread = 1;
 static int parsec_runtime_bind_threads     = 1;
 
+int parsec_runtime_keep_highest_priority_task = 1;
+
 PARSEC_TLS_DECLARE(parsec_tls_execution_stream);
 
 #if defined(DISTRIBUTED) && defined(PARSEC_HAVE_MPI)
@@ -521,6 +523,12 @@ parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[] )
 
     parsec_mca_param_reg_int_name("runtime", "bind_threads", "Bind main and worker threads", false, false,
                                   parsec_runtime_bind_threads, &parsec_runtime_bind_threads);
+    /* MCA param for retaining the highest priority task to be executed on the
+     * same core as the one that made the task active (aka at least one of the
+     * data is expected to be in the cache).
+     */
+    parsec_mca_param_reg_int_name("runtime", "keep_highest_priority_task", "Allow a compute thread to retain the highest priority task to be executed locally. This change makes the scheduling decision non-deterministic because some tasks will never be handled to the scheduler.", false, false,
+                                  parsec_runtime_keep_highest_priority_task, &parsec_runtime_keep_highest_priority_task);
 
     if( parsec_cmd_line_is_taken(cmd_line, "gpus") ) {
         parsec_warning("Option g (for accelerators) is deprecated as an argument. Use the MCA parameter instead.");

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020 The University of Tennessee and The University
+ * Copyright (c) 2012-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -416,6 +416,15 @@ PARSEC_DECLSPEC extern size_t parsec_task_startup_chunk;
  * Global configuration variable controlling the getrusage report.
  */
 PARSEC_DECLSPEC extern int parsec_want_rusage;
+
+/**
+ * Global configuration variable controlling what tasks are given to the
+ * scheduler. If this is enabled (the default) then the highest priority task
+ * created as a successor of a completed task, will be retained by the
+ * current execution thread as the next task to be executed. This bypasses
+ * the scheduler, but can provide a better cache reuse.
+ */
+PARSEC_DECLSPEC extern int parsec_runtime_keep_highest_priority_task;
 
 /**
  * Description of the state of the task. It indicates what will be the next

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -112,6 +112,7 @@ parsec_execution_stream_t parsec_comm_es = {
     .es_profile = NULL,
 #endif /* PARSEC_PROF_TRACE */
     .scheduler_object = NULL,
+    .next_task = NULL,
 #if defined(PARSEC_SIM)
     .largest_simulation_date = 0,
 #endif
@@ -469,7 +470,9 @@ remote_dep_dequeue_off(parsec_context_t* context)
 static void
 remote_dep_mpi_initialize_execution_stream(parsec_context_t *context)
 {
-    memcpy(&parsec_comm_es, context->virtual_processes[0]->execution_streams[0], sizeof(parsec_execution_stream_t));
+    memcpy(&parsec_comm_es, context->virtual_processes[0]->execution_streams[0],
+           sizeof(parsec_execution_stream_t));
+    parsec_comm_es.next_task = (parsec_task_t*)0xdeadbeef;  /* should not be NULL, but it should also never be used */
 }
 
 void* remote_dep_dequeue_main(parsec_context_t* context)

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -366,7 +366,7 @@ int __parsec_schedule_vp(parsec_execution_stream_t* es,
     assert( (NULL == es) || (parsec_my_execution_stream() == es) );
 #endif  /* defined(PARSEC_DEBUG_PARANOID) */
 
-    if( NULL == es ) {
+    if( NULL == es || !parsec_runtime_keep_highest_priority_task ) {
         for(int vp = 0; vp < es->virtual_process->parsec_context->nb_vp; vp++ ) {
             parsec_task_t* ring = task_rings[vp];
             if( NULL == ring ) continue;
@@ -561,7 +561,7 @@ int __parsec_context_wait( parsec_execution_stream_t* es )
     uint64_t misses_in_a_row;
     parsec_context_t* parsec_context = es->virtual_process->parsec_context;
     int32_t my_barrier_counter = parsec_context->__parsec_internal_finalization_counter;
-    parsec_task_t* task, *last_local_task = NULL /* for debug purposes */;
+    parsec_task_t* task;
     int nbiterations = 0, distance, rc;
     struct timespec rqtp;
 
@@ -633,11 +633,9 @@ int __parsec_context_wait( parsec_execution_stream_t* es )
 
         if( NULL == (task = es->next_task) ) {
             task = parsec_current_scheduler->module.select(es, &distance);
-            last_local_task = NULL;
         } else {
             es->next_task = NULL;
             distance = 1;
-            last_local_task = task;
         }
 
         if( task != NULL ) {

--- a/parsec/scheduling.h
+++ b/parsec/scheduling.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -32,13 +32,41 @@ BEGIN_C_DECLS
  *             further away the tasks will be pushed. This is a hint
  *             that the schedulers are free to ignore.
  *
- * @return PARSEC_SUCCESS    If the execution was succesful and all output
+ * @return PARSEC_SUCCESS    If the execution was successful and all output
  *                           dependencies have been correctly marked.
  * @return less than PARSEC_SUCCESS  If something went wrong.
  */
 int __parsec_schedule( parsec_execution_stream_t*,
                        parsec_task_t*,
                        int32_t distance);
+
+/**
+ * Schedule an array of rings of tasks with one entry per virtual
+ * process. Each entry contains a ring of tasks similar to __parsec_schedule.
+ * By default this version will save the highest priority task
+ * (assuming the ring is ordered or the first task in the ring otherwise)
+ * on the current execution stream virtual process as the next task to be
+ * executed on the current execution stream. Everything else gets pushed
+ * into the execution stream 0 of the corresponding virtual process.
+ *
+ * @param[in] es The execution stream where the tasks were discovered, or
+ *             generated.
+ * @param[in] tasks_ring An array of rings of tasks to be executed. The next
+ *            step in each task execution will depend on the DSL engine, but
+ *            the step will be executed on the virtual process corresponding
+ *            to the location in the array of rings.
+ * @param[in] distance Suggested distance to the current state where the tasks
+ *             are to be pushed. The larger the value (in absolute) the
+ *             further away the tasks will be pushed. This is a hint
+ *             that the schedulers are free to ignore.
+ *
+ * @return PARSEC_SUCCESS    If the execution was successful and all output
+ *                           dependencies have been correctly marked.
+ * @return less than PARSEC_SUCCESS  If something went wrong.
+ */
+int __parsec_schedule_vp( parsec_execution_stream_t*,
+                          parsec_task_t**,
+                          int32_t distance);
 
 /**
  * @brief Reschedule a task on the most appropriate resource.
@@ -51,10 +79,10 @@ int __parsec_schedule( parsec_execution_stream_t*,
  *          iterate over all existing execution units (in the current VP,
  *          then on the next VP and so on).
  *
- * @param [IN] es, the start execution_stream (normall it is the current one).
+ * @param [IN] es, the start execution_stream (normally it is the current one).
  * @param [IN] task, the task to be rescheduled.
  *
- * @return PARSEC_SUCCESS    If the execution was succesful and all output
+ * @return PARSEC_SUCCESS    If the execution was successful and all output
  *                           dependencies have been correctly marked.
  * @return less than PARSEC_SUCCESS  If something went wrong.
  */
@@ -108,7 +136,7 @@ int __parsec_complete_execution( parsec_execution_stream_t *es,
  * is to the capability of the upper level to generate tasks, activity that has
  * it's own counter, handled via parsec_taskpool_update_nbtask. Thus, once the
  * upper level knows no local tasks will be further generate it is it's
- * responsability to update the runtime counter accordingly.
+ * responsibility to update the runtime counter accordingly.
  *
  * @return 0 if the handle has not been completed.
  * @return 1 if the handle has been completed and it has been marked for release.
@@ -132,7 +160,7 @@ int parsec_check_complete_cb(parsec_taskpool_t *tp, parsec_context_t *context, i
  *  not yet inside parsec_progress, but *before* any call to
  *  parsec_progress...
  *
- *  @return 1 if the new scheduler was succesfully installed
+ *  @return 1 if the new scheduler was successfully installed
  *          0 if it failed. In this case, the previous scheduler
  *            is kept.
  */
@@ -145,6 +173,7 @@ void parsec_remove_scheduler( parsec_context_t *parsec );
 
 struct parsec_sched_module_s;
 extern struct parsec_sched_module_s *parsec_current_scheduler;
+
 
 END_C_DECLS
 


### PR DESCRIPTION
Instead of pushing the task into the scheduler and then asking for
something to execute, an execution stream will keep the highest priority
tasks as the next ready task. In general this will improve the data
reuse, but it is possible that it will prevent the scheduler to follow
the critical path (because the highest priority task might be less
important that tasks currently available in the scheduler).

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>