### PR TITLE
Bring back support for changing the PaRSEC communicator

### DIFF
--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -265,7 +265,7 @@ static void* __parsec_thread_init( __parsec_temporary_thread_initialization_t* s
 #endif  /* defined(PARSEC_HAVE_HWLOC) */
 
     /*
-     * A single thread per VP has a little bit more responsability: allocating
+     * A single thread per VP has a little bit more responsibility: allocating
      * the memory pools.
      */
     if( startup->th_id == (startup->virtual_process->nb_cores - 1) ) {
@@ -1227,8 +1227,8 @@ int parsec_fini( parsec_context_t** pcontext )
         free(context->pthreads);
         context->pthreads = NULL;
     }
-    /* From now on all the thrteads have been shut-off, and they are supposed to
-     * have cleaned all their provate memory. Unleash the global cleaning process.
+    /* From now on all the threads have been shut-off, and they are supposed to
+     * have cleaned all their private memory. Unleash the global cleaning process.
      */
 
     PARSEC_PINS_FINI(context);

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -361,8 +361,6 @@ static void parsec_vp_init( parsec_vp_t *vp,
     }
 }
 
-static int check_overlapping_binding(parsec_context_t *context);
-
 #define DEFAULT_APP_NAME "app_name"
 
 #define GET_INT_ARGV(CMD, ARGV, VALUE) \
@@ -789,8 +787,6 @@ parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[] )
 
     /* Introduce communication engine */
     (void)parsec_remote_dep_init(context);
-
-    (void)check_overlapping_binding(context);
 
     PARSEC_PINS_INIT(context);
     if(profiling_enabled && (0 == parsec_pins_nb_modules_enabled())) {
@@ -2526,61 +2522,76 @@ int parsec_parse_binding_parameter(const char * option, parsec_context_t* contex
 #endif /* PARSEC_HAVE_HWLOC && PARSEC_HAVE_HWLOC_BITMAP */
 }
 
-static int check_overlapping_binding(parsec_context_t *context) {
+/**
+ * @brief Check that the binding is correct. However, this operation is extremely expensive
+ *        and highly unscalable so we should only do this operation when really necessary.
+ * 
+ * @param context 
+ * @return int SUCCESS if the global bindings are OK, error otherwise.
+ */
+int parsec_check_overlapping_binding(parsec_context_t *context)
+{
+    if( 1024 < context->nb_nodes ) {  /* At some point we need to assume the users are doing the right thing,
+                                       * especially when they run at scale.
+                                       */
+        return PARSEC_SUCCESS;
+    }
 #if defined(DISTRIBUTED) && defined(PARSEC_HAVE_MPI) && defined(PARSEC_HAVE_HWLOC) && defined(PARSEC_HAVE_HWLOC_BITMAP)
-    MPI_Comm comml = MPI_COMM_NULL; int i, nl = 0, rl = MPI_PROC_NULL;
-    MPI_Comm commw = (MPI_Comm)context->comm_ctx;
-    assert(-1 != context->comm_ctx);
-    MPI_Comm_split_type(commw, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &comml);
-    MPI_Comm_size(comml, &nl);
-    if( 1 < nl && slow_bind_warning ) {
-        /* Hu-ho, double check that our binding is not conflicting with other
-         * local procs */
-        MPI_Comm_rank(comml, &rl);
-        char *myset = NULL, *allsets = NULL;
+    if( slow_bind_warning ) {
+        MPI_Comm comml = MPI_COMM_NULL; int i, nl = 0, rl = MPI_PROC_NULL;
+        MPI_Comm commw = (MPI_Comm)context->comm_ctx;
+        assert(-1 != context->comm_ctx);
+        MPI_Comm_split_type(commw, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &comml);
+        MPI_Comm_size(comml, &nl);
+        if( 1 < nl ) {
+            /* Hu-ho, double check that our binding is not conflicting with other
+             * local procs */
+            MPI_Comm_rank(comml, &rl);
+            char *myset = NULL, *allsets = NULL;
 
-        if( 0 != hwloc_bitmap_list_asprintf(&myset, context->cpuset_allowed_mask) ) {
-        }
-        int setlen = strlen(myset);
-        int *setlens = NULL;
-        if( 0 == rl ) {
-            setlens = calloc(nl, sizeof(int));
-        }
-        MPI_Gather(&setlen, 1, MPI_INT, setlens, 1, MPI_INT, 0, comml);
-
-        int *displs = NULL;
-        if( 0 == rl ) {
-            displs = calloc(nl, sizeof(int));
-            displs[0] = 0;
-            for( i = 1; i < nl; i++ ) {
-                displs[i] = displs[i-1]+setlens[i-1];
+            if( 0 != hwloc_bitmap_list_asprintf(&myset, context->cpuset_allowed_mask) ) {
             }
-            allsets = calloc(displs[nl-1]+setlens[nl-1], sizeof(char));
-        }
-        MPI_Gatherv(myset, setlen, MPI_CHAR, allsets, setlens, displs, MPI_CHAR, 0, comml);
-        free(myset);
+            int setlen = strlen(myset);
+            int *setlens = NULL;
+            if( 0 == rl ) {
+                setlens = calloc(nl, sizeof(int));
+            }
+            MPI_Gather(&setlen, 1, MPI_INT, setlens, 1, MPI_INT, 0, comml);
 
-        if( 0 == rl ) {
-            int notgood = false;
-            for( i = 1; i < nl; i++ ) {
-                hwloc_bitmap_t other = hwloc_bitmap_alloc();
-                hwloc_bitmap_list_sscanf(other, &allsets[displs[i]]);
-                if(hwloc_bitmap_intersects(context->cpuset_allowed_mask, other)) {
-                    notgood = true;
+            int *displs = NULL;
+            if( 0 == rl ) {
+                displs = calloc(nl, sizeof(int));
+                displs[0] = 0;
+                for( i = 1; i < nl; i++ ) {
+                    displs[i] = displs[i-1]+setlens[i-1];
                 }
-                hwloc_bitmap_free(other);
+                allsets = calloc(displs[nl-1]+setlens[nl-1], sizeof(char));
             }
-            if( notgood ) {
-                parsec_warning("/!\\ PERFORMANCE MIGHT BE REDUCED /!\\: "
-                               "Multiple PaRSEC processes on the same node may share the same physical core(s);\n"
-                               "\tThis is often unintentional, and will perform poorly.\n"
-                               "\tNote that in managed environments (e.g., ALPS, jsrun), the launcher may set `cgroups`\n"
-                               "\tand hide the real binding from PaRSEC; if you verified that the binding is correct,\n"
-                               "\tthis message can be silenced using the MCA argument `runtime_warn_slow_binding`.\n");
+            MPI_Gatherv(myset, setlen, MPI_CHAR, allsets, setlens, displs, MPI_CHAR, 0, comml);
+            free(myset);
+
+            if( 0 == rl ) {
+                int notgood = false;
+                for( i = 1; i < nl; i++ ) {
+                    hwloc_bitmap_t other = hwloc_bitmap_alloc();
+                    hwloc_bitmap_list_sscanf(other, &allsets[displs[i]]);
+                    if(hwloc_bitmap_intersects(context->cpuset_allowed_mask, other)) {
+                        notgood = true;
+                    }
+                    hwloc_bitmap_free(other);
+                }
+                if( notgood ) {
+                    parsec_warning("/!\\ PERFORMANCE MIGHT BE REDUCED /!\\: "
+                                   "Multiple PaRSEC processes on the same node may share the same physical core(s);\n"
+                                    "\tThis is often unintentional, and will perform poorly.\n"
+                                   "\tNote that in managed environments (e.g., ALPS, jsrun), the launcher may set `cgroups`\n"
+                                   "\tand hide the real binding from PaRSEC; if you verified that the binding is correct,\n"
+                                   "\tthis message can be silenced using the MCA argument `runtime_warn_slow_binding`.\n");
+                }
+                free(setlens);
+                free(allsets);
+                free(displs);
             }
-            free(setlens);
-            free(allsets);
-            free(displs);
         }
     }
     return PARSEC_SUCCESS;

--- a/parsec/parsec_comm_engine.h
+++ b/parsec/parsec_comm_engine.h
@@ -16,6 +16,28 @@ typedef enum {
     PARSEC_MEM_TYPE_NONCONTIGUOUS = 1
 } parsec_mem_type_t;
 
+/**
+ * The maximum number of AM tags supported by this PaRSEC build.
+ * To avoid runtime conflicts, the AM tags must be manually reserved
+ * in the section below.
+ */
+#define PARSEC_MAX_REGISTERED_TAGS  32
+
+/* Internal TAG for GET and PUT activation message,
+ * for two sides to agree on a "TAG" to post Irecv and Isend on
+ */
+typedef enum {
+    PARSEC_CE_MPI_FUNNELLED_GET_TAG_INTERNAL = 0,
+    PARSEC_CE_MPI_FUNNELLED_PUT_TAG_INTERNAL = 1,
+    PARSEC_CE_REMOTE_DEP_ACTIVATE_TAG = 2,
+    PARSEC_CE_REMOTE_DEP_GET_DATA_TAG,
+    PARSEC_CE_REMOTE_DEP_PUT_END_TAG,
+    PARSEC_TERMDET_FOURCOUNTER_MSG_TAG,
+    PARSEC_TERMDET_USER_TRIGGER_MSG_TAG,
+    PARSEC_CE_REMOTE_DEP_MAX_CTRL_TAG
+} parsec_remote_dep_tag_t;
+
+
 typedef void* parsec_ce_mem_reg_handle_t;
 
 typedef struct parsec_comm_engine_capabilites_s parsec_comm_engine_capabilites_t;

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -659,6 +659,12 @@ parsec_release_local_OUT_dependencies(parsec_execution_stream_t* es,
 /* Set internal TLS variable parsec_tls_execution_stream */
 void parsec_set_my_execution_stream(parsec_execution_stream_t *es);
 
+/* Validate the process binding when multiple processes are running
+ * on the same node.
+ */
+int parsec_check_overlapping_binding(parsec_context_t *context);
+int remote_dep_mpi_on(parsec_context_t* context);
+
 #define parsec_execution_context_priority_comparator offsetof(parsec_task_t, priority)
 
 #if defined(PARSEC_SIM)

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -437,7 +437,7 @@ struct parsec_data_pair_s {
 };
 
 /**
- * Global configuration variables controling the startup mechanism
+ * Global configuration variables controlling the startup mechanism
  * and directly the startup speed.
  */
 PARSEC_DECLSPEC extern size_t parsec_task_startup_iter;
@@ -601,7 +601,7 @@ parsec_release_dep_fct(struct parsec_execution_stream_s *es,
                        void *param);
 
 /**
- * Function to create reshaping promises during iterate_succesors.
+ * Function to create reshaping promises during iterate_successors.
  */
 parsec_ontask_iterate_t
 parsec_set_up_reshape_promise(parsec_execution_stream_t *es,

--- a/parsec/profiling.h
+++ b/parsec/profiling.h
@@ -424,7 +424,7 @@ typedef struct {
     uint32_t                         data_id;
     int32_t                          task_class_id;
     int32_t                          task_return_code;
-} parsec_task_prof_info_t;    
+} parsec_task_prof_info_t;
 
 #define PARSEC_TASK_PROF_INFO_CONVERTOR "dc_key{uint64_t};priority{int32_t};dc_dataid{uint32_t};tcid{int32_t};trc{int32_t}"
 

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -185,9 +185,6 @@ typedef struct {
 
 extern parsec_remote_dep_context_t parsec_remote_dep_context;
 
-void remote_deps_allocation_init(int np, int max_deps);
-void remote_deps_allocation_fini(void);
-
 parsec_remote_deps_t* remote_deps_allocate( parsec_lifo_t* lifo );
 
 #define PARSEC_ALLOCATE_REMOTE_DEPS_IF_NULL(REMOTE_DEPS, TASK, COUNT) \
@@ -216,7 +213,7 @@ int parsec_remote_dep_activate(parsec_execution_stream_t* es,
                                parsec_remote_deps_t* remote_deps,
                                uint32_t propagation_mask);
 
-/* Memcopy a particular data using datatype specification */
+/* Memcpy a particular data using datatype specification */
 void parsec_remote_dep_memcpy(parsec_execution_stream_t* es,
                               parsec_taskpool_t* tp,
                               parsec_data_copy_t *dst,
@@ -381,6 +378,7 @@ int remote_dep_set_ctx(parsec_context_t* context, intptr_t opaque_comm_ctx );
 parsec_remote_deps_t* remote_deps_allocate( parsec_lifo_t* lifo );
 
 void remote_deps_allocation_init(int np, int max_output_deps);
+void remote_deps_allocation_fini(void);
 
 typedef struct {
     int rank_src;  // 0

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -277,7 +277,7 @@ typedef enum dep_cmd_action_t {
     DEP_PUT_DATA,
     DEP_GET_DATA,
     DEP_CTL,
-    DEP_LAST  /* always the last element. it shoud not be used */
+    DEP_LAST  /* always the last element. it should not be used */
 } dep_cmd_action_t;
 
 union dep_cmd_u {

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -38,15 +38,6 @@ typedef unsigned long remote_dep_datakey_t;
 #define PARSEC_ACTION_RESHAPE_REMOTE_ON_RELEASE  0x80000000
 #define PARSEC_ACTION_RELEASE_REMOTE_DEPS        (PARSEC_ACTION_SEND_INIT_REMOTE_DEPS | PARSEC_ACTION_SEND_REMOTE_DEPS)
 
-typedef enum {
-    REMOTE_DEP_ACTIVATE_TAG = 2,
-    REMOTE_DEP_GET_DATA_TAG,
-    REMOTE_DEP_PUT_END_TAG,
-    PARSEC_TERMDET_FOURCOUNTER_MSG_TAG,
-    PARSEC_TERMDET_USER_TRIGGER_MSG_TAG,
-    REMOTE_DEP_MAX_CTRL_TAG
-} parsec_remote_dep_tag_t;
-
 typedef struct remote_dep_wire_activate_s {
     remote_dep_datakey_t deps;         /**< a pointer to the dep structure on the source */
     remote_dep_datakey_t output_mask;  /**< the mask of the output dependencies satisfied by this activation message */
@@ -256,7 +247,7 @@ int parsec_remote_dep_propagate(parsec_execution_stream_t* es,
 
 /** @} */
 
-#define DEP_NB_CONCURENT 3
+#define DEP_NB_CONCURRENT 3
 
 extern int parsec_comm_gets_max;
 extern int parsec_comm_gets;

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -42,7 +42,7 @@ static int parsec_param_nb_tasks_extracted = 20;
 static size_t parsec_param_short_limit = RDEP_MSG_SHORT_LIMIT;
 static int parsec_param_enable_aggregate = 0;
 
-parsec_mempool_t *parsec_remote_dep_cb_data_mempool;
+parsec_mempool_t *parsec_remote_dep_cb_data_mempool = NULL;
 
 typedef struct remote_dep_cb_data_s {
     parsec_list_item_t        super;
@@ -167,8 +167,6 @@ static int remote_dep_ce_fini(parsec_context_t* context);
 static int local_dep_nothread_reshape(parsec_execution_stream_t* es,
                                       dep_cmd_item_t *item);
 
-static int remote_dep_mpi_on(parsec_context_t* context);
-
 static int remote_dep_mpi_progress(parsec_execution_stream_t* es);
 
 static void remote_dep_mpi_new_taskpool(parsec_execution_stream_t* es,
@@ -198,8 +196,6 @@ int remote_dep_set_ctx(parsec_context_t* context, intptr_t opaque_comm_ctx )
         return PARSEC_ERROR;
     }
 
-    assert(-1 != opaque_comm_ctx /* -1 reserved for non-initialized */);
-
     if( -1 != context->comm_ctx ) {
 #if 0
         /* Currently, parsec is initialized with comm world.
@@ -219,21 +215,19 @@ int remote_dep_set_ctx(parsec_context_t* context, intptr_t opaque_comm_ctx )
             return PARSEC_SUCCESS;
         }
 #endif
-        MPI_Comm_free((MPI_Comm*)&context->comm_ctx);
+        /* Drop the currently used communicator and all other state of the
+         * communication engine */
+        remote_dep_ce_fini(context);
+        assert( -1 == context->comm_ctx );
     }
     rc = MPI_Comm_dup((MPI_Comm)opaque_comm_ctx, &comm);
     context->comm_ctx = (intptr_t)comm;
-    parsec_taskpool_sync_ids_context(context->comm_ctx);
-
+    /* We need to know who we are and how many others are there, in order to
+     * correctly initialize the communication engine at the next start. */
     MPI_Comm_size( (MPI_Comm)context->comm_ctx, (int*)&(context->nb_nodes));
-    if(context->nb_nodes == 1){
-        /* Corner case when moving from WORLD!=1 to WORLD=1 after parsec_init.
-         * If MPI_COMM_WORLD=1, parsec_init ends up running remote_dep_mpi_on on
-         * the app process, otherwise, communication thread does it.
-         * When moving to WORLD=1, we need to run remote_dep_mpi_on ensure all
-         * MPI is setup as it won't be done later by the comm thread. */
-        remote_dep_mpi_on(context);
-    }
+    MPI_Comm_rank( (MPI_Comm)context->comm_ctx, (int*)&(context->my_rank));
+
+    parsec_taskpool_sync_ids_context(context->comm_ctx);
 
     return (MPI_SUCCESS == rc) ? PARSEC_SUCCESS : PARSEC_ERROR;
 }
@@ -290,13 +284,10 @@ remote_dep_dequeue_init(parsec_context_t* context)
     }
 
     if( -1 == context->comm_ctx ) {
-        MPI_Comm comm;
-        MPI_Comm_dup(MPI_COMM_WORLD, &comm);
-        context->comm_ctx = (intptr_t)comm;
+        MPI_Comm_size( MPI_COMM_WORLD, (int*)&(context->nb_nodes));
+        MPI_Comm_rank( MPI_COMM_WORLD, (int*)&(context->my_rank));
+        context->comm_ctx = (intptr_t)MPI_COMM_WORLD;
     }
-
-    assert(-1 != context->comm_ctx /* -1 reserved for non-initialized */);
-    MPI_Comm_size( (MPI_Comm)context->comm_ctx, (int*)&(context->nb_nodes));
 
     if(parsec_param_comm_thread_multiple) {
         if( thread_level_support >= MPI_THREAD_MULTIPLE ) {
@@ -308,26 +299,8 @@ remote_dep_dequeue_init(parsec_context_t* context)
         }
     }
 
-    /**
-     * Finalize the initialization of the upper level structures
-     * Worst case: one of the DAGs is going to use up to
-     * MAX_PARAM_COUNT times nb_nodes dependencies.
-     */
-    remote_deps_allocation_init(context->nb_nodes, MAX_PARAM_COUNT);
-
     PARSEC_OBJ_CONSTRUCT(&dep_cmd_queue, parsec_dequeue_t);
     PARSEC_OBJ_CONSTRUCT(&dep_cmd_fifo, parsec_list_t);
-
-    /* From now on the communication capabilities are enabled */
-    parsec_communication_engine_up = 1;
-    if(context->nb_nodes == 1) {
-        /* We're all by ourselves. In case we need to use comm engin to handle data copies
-         * between different formats let's setup it up.
-         */
-        remote_dep_ce_init(context);
-
-        goto up_and_running;
-    }
 
     /* Build the condition used to drive the MPI thread */
     pthread_mutex_init( &mpi_thread_mutex, NULL );
@@ -335,6 +308,13 @@ remote_dep_dequeue_init(parsec_context_t* context)
 
     pthread_attr_init(&thread_attr);
     pthread_attr_setscope(&thread_attr, PTHREAD_SCOPE_SYSTEM);
+
+    /* From now on the communication capabilities are enabled */
+    parsec_communication_engine_up = 1;
+    if(context->nb_nodes == 1) {
+
+        goto up_and_running;
+    }
 
    /**
     * We need to synchronize with the newly spawned thread. We will use the
@@ -362,7 +342,6 @@ int
 remote_dep_dequeue_fini(parsec_context_t* context)
 {
     if( 0 == mpi_initialized ) return 0;
-    (void)context;
 
     /**
      * We suppose the off function was called before. Then we will append a
@@ -478,12 +457,10 @@ remote_dep_mpi_initialize_execution_stream(parsec_context_t *context)
 
 void* remote_dep_dequeue_main(parsec_context_t* context)
 {
-    int whatsup;
+    int whatsup = 0;
 
     remote_dep_bind_thread(context);
     PARSEC_PAPI_SDE_THREAD_INIT();
-
-    remote_dep_ce_init(context);
 
     /* Now synchronize with the main thread */
     pthread_mutex_lock(&mpi_thread_mutex);
@@ -495,34 +472,20 @@ void* remote_dep_dequeue_main(parsec_context_t* context)
      * been done before due to the lack of other component initialization.
      */
 
-    /* Let's wait until we are awaken */
-    pthread_cond_wait(&mpi_thread_condition, &mpi_thread_mutex);
-    PARSEC_DEBUG_VERBOSE(20, parsec_comm_output_stream, "MPI: comm engine ON on process %d/%d",
-                         context->my_rank, context->nb_nodes);
-    /* The MPI thread is owning the lock */
-    assert( parsec_communication_engine_up == 2 );
-
-    /* Lazy or delayed initializations */
-    remote_dep_mpi_initialize_execution_stream(context);
-
-    remote_dep_mpi_on(context);
-    /* acknoledge the activation */
-    parsec_communication_engine_up = 3;
-    whatsup = remote_dep_dequeue_nothread_progress(&parsec_comm_es, -1 /* loop till explicitly asked to return */);
-    PARSEC_DEBUG_VERBOSE(20, parsec_comm_output_stream, "MPI: comm engine OFF on process %d/%d",
-                         context->my_rank, context->nb_nodes);
-    parsec_communication_engine_up = 1;  /* went to sleep */
-
     while( -1 != whatsup ) {
         /* Let's wait until we are awaken */
         pthread_cond_wait(&mpi_thread_condition, &mpi_thread_mutex);
+
         PARSEC_DEBUG_VERBOSE(20, parsec_comm_output_stream, "MPI: comm engine ON on process %d/%d",
                              context->my_rank, context->nb_nodes);
+
         /* The MPI thread is owning the lock */
         assert( parsec_communication_engine_up == 2 );
+
         remote_dep_mpi_on(context);
         /* acknowledge the activation */
         parsec_communication_engine_up = 3;
+
         whatsup = remote_dep_dequeue_nothread_progress(&parsec_comm_es, -1 /* loop till explicitly asked to return */);
         PARSEC_DEBUG_VERBOSE(20, parsec_comm_output_stream, "MPI: comm engine OFF on process %d/%d",
                              context->my_rank, context->nb_nodes);
@@ -1305,9 +1268,10 @@ static void remote_dep_mpi_profiling_fini(void)
 #endif  /* PARSEC_PROF_TRACE */
 
 
-static int remote_dep_mpi_on(parsec_context_t* context)
+int remote_dep_mpi_on(parsec_context_t* context)
 {
-    // TODO: make sure this is correct with revamp
+    remote_dep_ce_init(context);
+
 #if defined(PARSEC_PROF_TRACE)
     /* This is less than ideal, but remote_dep_mpi_setup
      * holds a mpi_comm_dup() which is often implemented
@@ -1317,7 +1281,7 @@ static int remote_dep_mpi_on(parsec_context_t* context)
      * a common starting time. */
     parsec_profiling_start();
 #endif
-    (void)context;
+
     return 0;
 }
 
@@ -1383,8 +1347,6 @@ static int remote_dep_mpi_pack_dep(int peer,
         }
 #endif
 
-        // TODO JS: add back short message packing
-
         expected++;
         item->cmd.activate.task.output_mask |= (1U<<k);
         PARSEC_DEBUG_VERBOSE(10, parsec_debug_output, "DATA\t%s\tparam %d\tdeps %p send on demand (increase deps counter by %d [%d])",
@@ -1407,7 +1369,7 @@ static int remote_dep_mpi_pack_dep(int peer,
 }
 
 /**
- * Perform a memcopy with datatypes by doing a local sendrecv.
+ * Perform a memcpy with datatypes by doing a local sendrecv.
  */
 static int remote_dep_nothread_memcpy(parsec_execution_stream_t* es,
                                       dep_cmd_item_t *item)
@@ -2156,6 +2118,11 @@ static int
 remote_dep_ce_init(parsec_context_t* context)
 {
     int rc;
+
+    if( NULL != parsec_remote_dep_cb_data_mempool ) {
+        /* already fully initialized */
+        return 0;
+    }
     /* Do this first to give a chance to the communication engine to define
      * who this process is by setting the corresponding info in the
      * parsec_context.
@@ -2164,6 +2131,13 @@ remote_dep_ce_init(parsec_context_t* context)
         parsec_warning("Communication engine failed to start. Additional information might be available in the corresponding error message");
         return PARSEC_ERR_NOT_FOUND;
     }
+
+    /**
+     * Finalize the initialization of the upper level structures
+     * Worst case: one of the DAGs is going to use up to
+     * MAX_PARAM_COUNT times nb_nodes dependencies.
+     */
+    remote_deps_allocation_init(context->nb_nodes, MAX_PARAM_COUNT);
 
     PARSEC_OBJ_CONSTRUCT(&dep_activates_fifo, parsec_list_t);
     PARSEC_OBJ_CONSTRUCT(&dep_activates_noobj_fifo, parsec_list_t);
@@ -2195,6 +2169,8 @@ remote_dep_ce_init(parsec_context_t* context)
                              PARSEC_OBJ_CLASS(remote_dep_cb_data_t), sizeof(remote_dep_cb_data_t),
                              offsetof(remote_dep_cb_data_t, mempool_owner),
                              1);
+    /* Lazy or delayed initializations */
+    remote_dep_mpi_initialize_execution_stream(context);
 
     remote_dep_mpi_profiling_init();
     return 0;
@@ -2211,7 +2187,7 @@ remote_dep_ce_fini(parsec_context_t* context)
     //parsec_ce.tag_unregister(REMOTE_DEP_PUT_END_TAG);
 
     parsec_mempool_destruct(parsec_remote_dep_cb_data_mempool);
-    free(parsec_remote_dep_cb_data_mempool);
+    free(parsec_remote_dep_cb_data_mempool); parsec_remote_dep_cb_data_mempool = NULL;
 
     free(parsec_mpi_same_pos_items); parsec_mpi_same_pos_items = NULL;
     parsec_mpi_same_pos_items_size = 0;

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -312,7 +312,6 @@ remote_dep_dequeue_init(parsec_context_t* context)
     /* From now on the communication capabilities are enabled */
     parsec_communication_engine_up = 1;
     if(context->nb_nodes == 1) {
-
         goto up_and_running;
     }
 

--- a/tests/runtime/multichain.jdf
+++ b/tests/runtime/multichain.jdf
@@ -27,8 +27,7 @@ static int verbose = 0;
  static int max_comms = 6;
  static MPI_Comm comms[6] = {MPI_COMM_WORLD, MPI_COMM_SELF, MPI_COMM_NULL,
                              MPI_COMM_NULL,  MPI_COMM_NULL, MPI_COMM_WORLD};
-static const char *comm_name[6] = {"MPI_COMM_WORLD", "MPI_COMM_SELF", "MPI_COMM_NULL", 
-                                   "MPI_COMM_NULL", "MPI_COMM_NULL", "MPI_COMM_WORLD"};
+ static char *comm_name[6] = {NULL};
 %}
 
 descA      [type = "parsec_matrix_block_cyclic_t*"]
@@ -74,14 +73,27 @@ static void create_communicators(void)
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    comm_name[0] = strdup("MPI_COMM_WORLD");
+    comm_name[1] = strdup("MPI_COMM_SELF");
+
     MPI_Comm_split(MPI_COMM_WORLD, 0, size-1-rank, &comms[2]);
+    asprintf(&comm_name[2], "WORLD.split(0, size-1-rank): same comm reorder ranks");
+
     MPI_Comm_split(MPI_COMM_WORLD, (rank < (size-1) ? 0 : MPI_UNDEFINED), rank, &comms[3]);
+    asprintf(&comm_name[3], "WORLD.split((rank < (size-1) ? 0 : MPI_UNDEFINED), rank): all but last same ranks");
+
     MPI_Comm_split(MPI_COMM_WORLD, rank % 2, rank, &comms[4]);
+    asprintf(&comm_name[4], "WORLD.split(rank %% 2, rank): split comm in 2 same ranks");
+
+    comm_name[5] = strdup("MPI_COMM_WORLD");
 }
+
 static void release_comms(void)
 {
     int i;
     for( i = 0; i < (int)(sizeof(comms) / sizeof(MPI_Comm)); i++ ) {
+        free(comm_name[i]);
         if( (MPI_COMM_WORLD == comms[i]) ||
             (MPI_COMM_SELF == comms[i]) ||
             (MPI_COMM_NULL == comms[i]) )
@@ -111,6 +123,7 @@ int main(int argc, char* argv[])
     parsec_context_t *parsec;
     int ni = NN, nj = NN, loops = 5, sleep_between_comms = 1, i = 1, l, rc;
     int rank = 0, size = 1, mat_size;
+    int world_rank = 0, world_size = 1;
     long time_elapsed;
     parsec_datatype_t baseType, newtype;
     MPI_Comm comm;
@@ -166,6 +179,8 @@ int main(int argc, char* argv[])
     {
         int provided;
         MPI_Init_thread(NULL, NULL, MPI_THREAD_SERIALIZED, &provided);
+        MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+        MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
     }
     create_communicators();
 #endif  /* DISTRIBUTED */
@@ -190,7 +205,8 @@ int main(int argc, char* argv[])
                                    rank /*rank*/,
                                    2*BLOCK, 1, mat_size, 1,
                                    0, 0, mat_size, 1,
-                                   1, size, 1, 1, 0, 0);
+                                   size, 1, 1, 1, 0, 0);
+        printf("Rank %d/%d has %d tiles locally\n", rank, size, descA.super.nb_local_tiles);
         descA.mat = parsec_data_allocate( descA.super.nb_local_tiles *
                                           descA.super.bsiz *
                                           parsec_datadist_getsizeoftype(TYPE) );
@@ -198,7 +214,7 @@ int main(int argc, char* argv[])
                                    rank /*rank*/,
                                    2*BLOCK, 1, mat_size, 1,
                                    0, 0, mat_size, 1,
-                                   1, size, 1, 1, 0, 0);
+                                   size, 1, 1, 1, 0, 0);
         descB.mat = parsec_data_allocate( descB.super.nb_local_tiles *
                                           descB.super.bsiz *
                                           parsec_datadist_getsizeoftype(TYPE) );
@@ -233,7 +249,8 @@ int main(int argc, char* argv[])
             PARSEC_CHECK_ERROR(rc, "parsec_context_wait");
             TIMER_STOP(time_elapsed);
 
-            printf("Comm %s (test %d) Loop %d DAG execution in %ld micro-sec\n", comm_name[i], i, l, time_elapsed);
+            printf("Comm %s (test %d) Loop %d DAG execution in %ld micro-sec [world %d/%d]\n",
+                   comm_name[i], i, l, time_elapsed, world_rank, world_size);
             if( verbose >= 5 ) {
                 printf("<DartMeasurement name=\"no_pri\" type=\"numeric/double\"\n"
                        "                 encoding=\"none\" compression=\"none\">\n"
@@ -268,7 +285,8 @@ int main(int argc, char* argv[])
             PARSEC_CHECK_ERROR(rc, "parsec_context_wait");
             TIMER_STOP(time_elapsed);
 
-            printf("Comm %s (test %d) Loop %d DAG execution in %ld micro-sec\n", comm_name[i], i, l, time_elapsed);
+            printf("Comm %s (test %d) Loop %d DAG execution in %ld micro-sec [world %d/%d]\n",
+                   comm_name[i], i, l, time_elapsed, world_rank, world_size);
         }
         free(descA.mat);
         free(descB.mat);


### PR DESCRIPTION
Allow the change of the underlying communicator for a parsec context.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>