### PR TITLE
Allow the DSL to provide a task_snprintf function and use it when displaying the DOT

### DIFF
--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -4207,6 +4207,7 @@ static void jdf_generate_one_function( const jdf_t *jdf, jdf_function_entry_t *f
 
     string_arena_add_string(sa,
                             "  .make_key = %s,\n"
+                            "  .task_snprintf = parsec_task_snprintf,\n"
                             "  .key_functions = &%s,\n",
                             jdf_property_get_string(f->properties, JDF_PROP_UD_MAKE_KEY_FN_NAME, NULL),
                             jdf_property_get_string(f->properties, JDF_PROP_UD_HASH_STRUCT_NAME, NULL));

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -264,6 +264,12 @@ typedef void (parsec_traverse_function_t)(struct parsec_execution_stream_s *,
  */
 typedef parsec_key_t (parsec_functionkey_fn_t)(const parsec_taskpool_t *tp,
                                                const parsec_assignment_t *assignments);
+
+/**
+ * Provide a character string representation of the task.
+ * Write max buffer_size characters into buffer and return buffer.
+ */
+typedef char* (parsec_printtask_fn_t)(char *buffer, size_t buffer_size, const parsec_task_t *task);
 /**
  *
  */
@@ -374,6 +380,7 @@ struct parsec_task_class_s {
     parsec_data_ref_fn_t        *data_affinity;  /**< Populates an array of data references, of size 1 */
     parsec_key_fn_t             *key_functions;
     parsec_functionkey_fn_t     *make_key;
+    parsec_printtask_fn_t       *task_snprintf;
 #if defined(PARSEC_SIM)
     parsec_sim_cost_fct_t       *sim_cost_fct;
 #endif

--- a/parsec/parsec_prof_grapher.c
+++ b/parsec/parsec_prof_grapher.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
+#include <ctype.h>
 
 #if defined(PARSEC_PROF_GRAPHER)
 
@@ -111,6 +112,10 @@ char *parsec_prof_grapher_taskid(const parsec_task_t *task, char *tmp, int lengt
 
     assert( NULL!= task->taskpool );
     index += snprintf( tmp + index, length - index, "%s_%u", tc->name, task->taskpool->taskpool_id );
+    if(!isalpha(tmp[0])) tmp[0] = '_';
+    for( i = 1; i < index; i++ ) {
+        if(!isalnum(tmp[i])) tmp[i] = '_';
+    }
     for( i = 0; i < tc->nb_parameters; i++ ) {
         index += snprintf( tmp + index, length - index, "_%d",
                            task->locals[tc->params[i]->context_index].value );
@@ -125,7 +130,11 @@ void parsec_prof_grapher_task(const parsec_task_t *context,
     if( NULL != grapher_file ) {
         char tmp[MAX_TASK_STRLEN], nmp[MAX_TASK_STRLEN];
         char sim_date[64];
-        parsec_task_snprintf(tmp, MAX_TASK_STRLEN, context);
+        if(NULL != context->task_class->task_snprintf) {
+            context->task_class->task_snprintf(tmp, MAX_TASK_STRLEN, context);
+        } else {
+            parsec_task_snprintf(tmp, MAX_TASK_STRLEN, context);
+        }
         parsec_prof_grapher_taskid(context, nmp, MAX_TASK_STRLEN);
 #if defined(PARSEC_SIM)
         snprintf(sim_date, 64, " [%d]", context->sim_exec_date);

--- a/parsec/parsec_prof_grapher.c
+++ b/parsec/parsec_prof_grapher.c
@@ -182,7 +182,7 @@ static void parsec_prof_grapher_dataid(const parsec_data_t *dta, char *did, int 
     parsec_grapher_data_identifier_t id;
     parsec_key_t key;
     parsec_grapher_data_identifier_hash_table_item_t *it;
-    parsec_key_handle_t* kh;
+    parsec_key_handle_t kh;
 
     assert(NULL != dta);
     assert(NULL != grapher_file);

--- a/parsec/parsec_prof_grapher.c
+++ b/parsec/parsec_prof_grapher.c
@@ -130,11 +130,8 @@ void parsec_prof_grapher_task(const parsec_task_t *context,
     if( NULL != grapher_file ) {
         char tmp[MAX_TASK_STRLEN], nmp[MAX_TASK_STRLEN];
         char sim_date[64];
-        if(NULL != context->task_class->task_snprintf) {
-            context->task_class->task_snprintf(tmp, MAX_TASK_STRLEN, context);
-        } else {
-            parsec_task_snprintf(tmp, MAX_TASK_STRLEN, context);
-        }
+        assert(NULL != context->task_class->task_snprintf);
+        context->task_class->task_snprintf(tmp, MAX_TASK_STRLEN, context);
         parsec_prof_grapher_taskid(context, nmp, MAX_TASK_STRLEN);
 #if defined(PARSEC_SIM)
         snprintf(sim_date, 64, " [%d]", context->sim_exec_date);


### PR DESCRIPTION
Backport from the TTG branches...


Signed-off-by: Thomas Herault <herault@icl.utk.edu>
Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>