### PR TITLE
hotfix: duplicate variable d2h_max_flows

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_component.c
+++ b/parsec/mca/device/cuda/device_cuda_component.c
@@ -40,7 +40,7 @@ int parsec_cuda_output_stream = -1;
 
 int32_t parsec_CUDA_sort_pending_list = 0;
 
-int32_t parsec_CUDA_d2h_max_flows;
+int32_t parsec_CUDA_d2h_max_flows = 0;
 char* cuda_lib_path = NULL;
 
 #if defined(PARSEC_PROF_TRACE)

--- a/parsec/mca/device/cuda/transfer.c
+++ b/parsec/mca/device/cuda/transfer.c
@@ -165,7 +165,7 @@ static const parsec_symbol_t symb_CUDA_d2h_task_param = {
     .flags = 0x0
 };
 
-int32_t parsec_CUDA_d2h_max_flows = 0;
+extern int32_t parsec_CUDA_d2h_max_flows;
 
 static const parsec_task_class_t parsec_CUDA_d2h_task_class = {
     .name = "CUDA D2H data transfer",


### PR DESCRIPTION
https://github.com/spack/spack/issues/32125

We will need to produce a new v3.x release for this bug to appear fixed on the upstream Spack channel


Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>