### PR TITLE
comm: set parsec_tls_execution_stream in comm thread

### DIFF
--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -2884,3 +2884,8 @@ parsec_execution_stream_t *parsec_my_execution_stream(void)
 {
     return (parsec_execution_stream_t*)PARSEC_TLS_GET_SPECIFIC(parsec_tls_execution_stream);
 }
+
+void parsec_set_my_execution_stream(parsec_execution_stream_t *es)
+{
+    PARSEC_TLS_SET_SPECIFIC(parsec_tls_execution_stream, es);
+}

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -632,6 +632,9 @@ parsec_release_local_OUT_dependencies(parsec_execution_stream_t* es,
                                       parsec_data_copy_t* target_dc,
                                       data_repo_entry_t* target_repo_entry);
 
+/* Set internal TLS variable parsec_tls_execution_stream */
+void parsec_set_my_execution_stream(parsec_execution_stream_t *es);
+
 #define parsec_execution_context_priority_comparator offsetof(parsec_task_t, priority)
 
 #if defined(PARSEC_SIM)

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -473,6 +473,7 @@ remote_dep_mpi_initialize_execution_stream(parsec_context_t *context)
     memcpy(&parsec_comm_es, context->virtual_processes[0]->execution_streams[0],
            sizeof(parsec_execution_stream_t));
     parsec_comm_es.next_task = (parsec_task_t*)0xdeadbeef;  /* should not be NULL, but it should also never be used */
+    parsec_set_my_execution_stream(&parsec_comm_es);
 }
 
 void* remote_dep_dequeue_main(parsec_context_t* context)


### PR DESCRIPTION
PR #413 fixed issues around recursive tasks by retrieving the current
execution stream via `parsec_my_execution_stream`. However, under some
circumstances, it appears that the `on_complete` callback can be called
from the communication thread. The comm thread never sets the TLS
variable needed for `parsec_my_execution_stream`, so you end up with a
NULL execution stream and everything breaks.

Ensure that `parsec_tls_execution_stream` is set by the communication
thread as well. This introduces a new internal API to do so,
`parsec_set_my_execution_stream`, since `parsec_tls_execution_stream` is
a static variable in parsec.c.

Signed-off-by: Omri Mor <omrimor2@illinois.edu>