### PR TITLE
Remove startup tasks from DTD

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -332,8 +332,6 @@ PARSEC_OBJ_CLASS_INSTANCE(parsec_dtd_tile_t, parsec_list_item_t,
 void parsec_dtd_taskpool_constructor(parsec_dtd_taskpool_t *tp)
 {
     int nb;
-    tp->startup_list = (parsec_task_t **)calloc(vpmap_get_nb_vp(), sizeof(parsec_task_t *));
-
     tp->function_counter = 0;
 
     tp->task_hash_table = PARSEC_OBJ_NEW(parsec_hash_table_t);
@@ -435,7 +433,6 @@ parsec_dtd_taskpool_destructor(parsec_dtd_taskpool_t *tp)
     /* dtd_taskpool specific */
     parsec_mempool_destruct(tp->hash_table_bucket_mempool);
     free(tp->hash_table_bucket_mempool);
-    free(tp->startup_list);
 
     parsec_hash_table_fini(tp->task_hash_table);
     PARSEC_OBJ_RELEASE(tp->task_hash_table);
@@ -697,7 +694,6 @@ parsec_dtd_taskpool_wait(parsec_taskpool_t *tp)
                                     so it can't be waited upon */
         return PARSEC_ERR_NOT_SUPPORTED;
     }
-    parsec_dtd_schedule_tasks(dtd_tp);
     /* Wait until all local tasks are done. The only thing left will then be, communications */
     dtd_tp->wait_func(tp);
     parsec_dtd_taskpool_wait_on_pending_action(tp);
@@ -1446,9 +1442,6 @@ parsec_dtd_taskpool_new(void)
         if( NULL == device ) continue;
         __tp->super.devices_index_mask |= (1 << device->device_index);
     }
-    for( i = 0; i < vpmap_get_nb_vp(); i++ ) {
-        __tp->startup_list[i] = NULL;
-    }
 
     /* Keeping track of total tasks to be executed per taskpool for the window */
     for( i = 0; i < PARSEC_DTD_NB_TASK_CLASSES; i++ ) {
@@ -1568,8 +1561,6 @@ parsec_dtd_startup(parsec_context_t *context,
             }
     }
     (void)pready_list;
-
-    parsec_dtd_schedule_tasks(dtd_tp);
 }
 
 static inline int
@@ -2698,37 +2689,6 @@ parsec_dtd_set_descendant(parsec_dtd_task_t *parent_task, uint8_t parent_flow_in
         parsec_hash_table_unlock_bucket(tp->task_hash_table, (parsec_key_t)key);
     }
 #endif
-}
-
-/* **************************************************************************** */
-/**
- * Function to push ready task in PaRSEC's scheduler
- *
- * @param[in,out]   __tp
- *                      DTD taskpool
- *
- * @ingroup         DTD_INTERFACE_INTERNAL
- */
-void
-parsec_dtd_schedule_tasks(parsec_dtd_taskpool_t *__tp)
-{
-    parsec_task_t **startup_list = __tp->startup_list;
-    parsec_list_t temp;
-
-    PARSEC_OBJ_CONSTRUCT(&temp, parsec_list_t);
-    for( int p = 0; p < vpmap_get_nb_vp(); p++ ) {
-        if( NULL == startup_list[p] ) continue;
-
-        /* Order the tasks by priority */
-        parsec_list_chain_sorted(&temp, (parsec_list_item_t *)startup_list[p],
-                                 parsec_execution_context_priority_comparator);
-        startup_list[p] = (parsec_task_t *)parsec_list_nolock_unchain(&temp);
-    }
-    /* We should add these tasks on the system queue when there is one */
-    __parsec_schedule_vp(parsec_my_execution_stream(),
-                         startup_list, 0);
-
-    PARSEC_OBJ_DESTRUCT(&temp);
 }
 
 /* **************************************************************************** */

--- a/parsec/interfaces/dtd/insert_function_internal.h
+++ b/parsec/interfaces/dtd/insert_function_internal.h
@@ -237,8 +237,6 @@ struct parsec_dtd_taskpool_s {
     parsec_mempool_t            *hash_table_bucket_mempool;
     parsec_hash_table_t         *task_hash_table;
     parsec_hash_table_t         *function_h_table;
-    /* ring of initial ready tasks */
-    parsec_task_t              **startup_list;
     /* from here to end is for the testing interface */
     struct hook_info             actual_hook[PARSEC_DTD_NB_TASK_CLASSES];
 };
@@ -321,9 +319,6 @@ parsec_dtd_ordering_correctly( parsec_execution_stream_t * es,
                                uint32_t action_mask,
                                parsec_ontask_function_t * ontask,
                                void *ontask_arg );
-
-void
-parsec_dtd_schedule_tasks( parsec_dtd_taskpool_t *__tp );
 
 /* Function to remove tile from hash_table
  */

--- a/parsec/mca/termdet/user_trigger/termdet_user_trigger_module.c
+++ b/parsec/mca/termdet/user_trigger/termdet_user_trigger_module.c
@@ -156,7 +156,7 @@ static void parsec_termdet_user_trigger_monitor_taskpool(parsec_taskpool_t *tp,
 {
     parsec_termdet_user_trigger_monitor_t *monitor;
     assert(&parsec_termdet_user_trigger_module.module == tp->tdm.module);
-    assert(NULL == tp->tdm.monitor);
+    //assert(NULL == tp->tdm.monitor);
     monitor = malloc(sizeof(parsec_termdet_user_trigger_monitor_t));
     monitor->root = PARSEC_TERMDET_USER_TRIGGER_UNKNOWN_RANK;
     monitor->state = PARSEC_TERMDET_USER_TRIGGER_NOT_READY;


### PR DESCRIPTION
This is the only commits from the 'various' set of commits in parsec-ttg that have not been merged into master yet.

I believe there is another branch/PR with a larger set of cleanup for DTD, so maybe we just want to drop this.
