### PR TITLE
Fix possible access to unowned memory in `parsec_dtd_task_class_add_chore`

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2434,7 +2434,7 @@ int parsec_dtd_task_class_add_chore(parsec_taskpool_t *tp,
                                     int device_type,
                                     void *function)
 {
-    __parsec_chore_t **pincarnations;
+    __parsec_chore_t *incarnations;
     int i;
 
     if( tc->task_class_type != PARSEC_TASK_CLASS_TYPE_DTD ) {
@@ -2448,9 +2448,9 @@ int parsec_dtd_task_class_add_chore(parsec_taskpool_t *tp,
 
     /* We assume that incarnations is big enough, because it has been pre-allocated
      * with PARSEC_DEV_MAX_NB_TYPE+1 chores, as this is a DTD task class */
-    pincarnations = (__parsec_chore_t **)&dtd_tc->super.incarnations;
-    for(i = 0; i < PARSEC_DEV_MAX_NB_TYPE && (*pincarnations)[i].type != PARSEC_DEV_NONE; i++) {
-        if( (*pincarnations)[i].type == device_type ) {
+    incarnations = (__parsec_chore_t*)dtd_tc->super.incarnations;
+    for(i = 0; i < PARSEC_DEV_MAX_NB_TYPE && incarnations[i].type != PARSEC_DEV_NONE; i++) {
+        if( incarnations[i].type == device_type ) {
             parsec_warning("A chore for this device type has already been added to task class '%s'\n",
                            tc->name);
             return PARSEC_ERROR;
@@ -2462,17 +2462,17 @@ int parsec_dtd_task_class_add_chore(parsec_taskpool_t *tp,
         return PARSEC_ERR_OUT_OF_RESOURCE;
     }
 
-    (*pincarnations)[i].type = device_type;
+    incarnations[i].type = device_type;
     if(PARSEC_DEV_CUDA == device_type) {
-        (*pincarnations)[i].hook = parsec_dtd_gpu_task_submit;
+        incarnations[i].hook = parsec_dtd_gpu_task_submit;
         dtd_tc->gpu_func_ptr = (parsec_advance_task_function_t)function;
     }
     else {
         dtd_tc->cpu_func_ptr = function;
-        (*pincarnations)[i].hook = parsec_dtd_cpu_task_submit;
+        incarnations[i].hook = parsec_dtd_cpu_task_submit;
     }
-    (*pincarnations)[i+1].type = PARSEC_DEV_NONE;
-    (*pincarnations)[i+1].hook = NULL;
+    incarnations[i+1].type = PARSEC_DEV_NONE;
+    incarnations[i+1].hook = NULL;
 
     parsec_dtd_insert_task_class(dtd_tp, (parsec_dtd_task_class_t*)dtd_tc);
 

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2447,16 +2447,16 @@ int parsec_dtd_task_class_add_chore(parsec_taskpool_t *tp,
     parsec_dtd_task_class_t *dtd_tc = (parsec_dtd_task_class_t*)tc;
 
     /* We assume that incarnations is big enough, because it has been pre-allocated
-     * with 7 chores, as this is a DTD task class */
+     * with PARSEC_DEV_MAX_NB_TYPE+1 chores, as this is a DTD task class */
     pincarnations = (__parsec_chore_t **)&dtd_tc->super.incarnations;
-    for(i = 0; i < 8 && (*pincarnations)[i].type != PARSEC_DEV_NONE; i++) {
+    for(i = 0; i < PARSEC_DEV_MAX_NB_TYPE && (*pincarnations)[i].type != PARSEC_DEV_NONE; i++) {
         if( (*pincarnations)[i].type == device_type ) {
             parsec_warning("A chore for this device type has already been added to task class '%s'\n",
                            tc->name);
             return PARSEC_ERROR;
         }
     }
-    if(i == 8) {
+    if(i == PARSEC_DEV_MAX_NB_TYPE) {
         parsec_warning("Number of device type exceeded: not enough memory in task class '%s' to add another chore\n",
                        tc->name);
         return PARSEC_ERR_OUT_OF_RESOURCE;

--- a/parsec/mca/termdet/fourcounter/termdet_fourcounter.h
+++ b/parsec/mca/termdet/fourcounter/termdet_fourcounter.h
@@ -35,7 +35,7 @@ BEGIN_C_DECLS
 PARSEC_DECLSPEC extern const parsec_termdet_base_component_t parsec_termdet_fourcounter_component;
 PARSEC_DECLSPEC extern const parsec_termdet_module_t parsec_termdet_fourcounter_module;
 
-int parsec_termdet_fourcounter_msg_dispatch(parsec_comm_engine_t *ce, long unsigned int tag,  void *msg, long unsigned int size, int src,  void *module);
+int parsec_termdet_fourcounter_msg_dispatch(parsec_comm_engine_t *ce, unsigned long long tag,  void *msg, unsigned long size, int src,  void *module);
 
 typedef enum {
     PARSEC_TERMDET_FOURCOUNTER_MSG_TYPE_DOWN,

--- a/parsec/mca/termdet/fourcounter/termdet_fourcounter_module.c
+++ b/parsec/mca/termdet/fourcounter/termdet_fourcounter_module.c
@@ -147,7 +147,7 @@ static int parsec_termdet_fourcounter_msg_dispatch_taskpool(parsec_taskpool_t *t
     return PARSEC_ERROR;
 }
 
-int parsec_termdet_fourcounter_msg_dispatch(parsec_comm_engine_t *ce, long unsigned int tag,  void *msg, long unsigned int size, int src,  void *module)
+int parsec_termdet_fourcounter_msg_dispatch(parsec_comm_engine_t *ce, unsigned long long tag,  void *msg, unsigned long size, int src,  void *module)
 {
     parsec_termdet_fourcounter_delayed_msg_t *delayed_msg;
     parsec_termdet_fourcounter_msg_down_t *down_msg = (parsec_termdet_fourcounter_msg_down_t*)msg;
@@ -539,6 +539,7 @@ static int parsec_termdet_fourcounter_outgoing_message_pack(parsec_taskpool_t *t
     (void)packed_buffer;
     (void)position;
     (void)buffer_size;
+    (void)tp;
     return PARSEC_SUCCESS;
 }
 

--- a/parsec/mca/termdet/local/termdet_local_module.c
+++ b/parsec/mca/termdet/local/termdet_local_module.c
@@ -192,8 +192,10 @@ static int parsec_termdet_local_outgoing_message_start(parsec_taskpool_t *tp,
     /* Nothing to do with the message */
     (void)dst_rank;
     (void)remote_deps;
+    (void)tp;
     return 1; /* The message can go right away */
 }
+
 static int parsec_termdet_local_outgoing_message_pack(parsec_taskpool_t *tp,
                                                       int dst_rank,
                                                       char *packed_buffer,
@@ -208,6 +210,7 @@ static int parsec_termdet_local_outgoing_message_pack(parsec_taskpool_t *tp,
     (void)packed_buffer;
     (void)position;
     (void)buffer_size;
+    (void)tp;
     return PARSEC_SUCCESS;
 }
 
@@ -227,7 +230,7 @@ static int parsec_termdet_local_incoming_message_start(parsec_taskpool_t *tp,
     (void)position;
     (void)buffer_size;
     (void)msg;
-    
+    (void)tp;
     return PARSEC_SUCCESS;
 }
 

--- a/parsec/mca/termdet/user_trigger/termdet_user_trigger.h
+++ b/parsec/mca/termdet/user_trigger/termdet_user_trigger.h
@@ -39,8 +39,8 @@ PARSEC_DECLSPEC extern const parsec_termdet_module_t parsec_termdet_user_trigger
 /* static accessor */
 mca_base_component_t *termdet_user_trigger_static_component(void);
 
-int parsec_termdet_user_trigger_msg_dispatch(parsec_comm_engine_t *ce, long unsigned int tag,  void *msg,
-                                             long unsigned int size, int src,  void *module);
+int parsec_termdet_user_trigger_msg_dispatch(parsec_comm_engine_t *ce, unsigned long long tag,  void *msg,
+                                             unsigned long size, int src,  void *module);
 
 typedef struct {
     uint32_t tp_id;

--- a/parsec/mca/termdet/user_trigger/termdet_user_trigger_module.c
+++ b/parsec/mca/termdet/user_trigger/termdet_user_trigger_module.c
@@ -114,8 +114,8 @@ static int parsec_termdet_user_trigger_msg_dispatch_taskpool(parsec_taskpool_t *
     return PARSEC_SUCCESS;
 }
 
-int parsec_termdet_user_trigger_msg_dispatch(parsec_comm_engine_t *ce, long unsigned int tag,  void *msg,
-                                             long unsigned int size, int src,  void *module)
+int parsec_termdet_user_trigger_msg_dispatch(parsec_comm_engine_t *ce, unsigned long long tag,  void *msg,
+                                             unsigned long size, int src,  void *module)
 {
     parsec_termdet_user_trigger_delayed_msg_t *delayed_msg;
     parsec_termdet_user_trigger_msg_t *ut_msg = (parsec_termdet_user_trigger_msg_t*)msg;
@@ -305,6 +305,7 @@ static int parsec_termdet_user_trigger_outgoing_message_start(parsec_taskpool_t 
     /* Nothing to do with the message */
     (void)dst_rank;
     (void)remote_deps;
+    (void)tp;
     return 1; /* The message can go right away */
 }
 static int parsec_termdet_user_trigger_outgoing_message_pack(parsec_taskpool_t *tp,
@@ -321,6 +322,7 @@ static int parsec_termdet_user_trigger_outgoing_message_pack(parsec_taskpool_t *
     (void)packed_buffer;
     (void)position;
     (void)buffer_size;
+    (void)tp;
     return PARSEC_SUCCESS;
 }
 
@@ -340,7 +342,7 @@ static int parsec_termdet_user_trigger_incoming_message_start(parsec_taskpool_t 
     (void)position;
     (void)buffer_size;
     (void)msg;
-    
+    (void)tp;
     return PARSEC_SUCCESS;
 }
 

--- a/tests/class/hash.c
+++ b/tests/class/hash.c
@@ -98,7 +98,7 @@ static void *do_perf_test(void *_param)
         for(t = 0; t < nbtests; t++) {
             empty_hash_item_t *rc;
             rc = parsec_hash_table_remove(&hash_table, item_array[t].ht_item.key);
-            assert(rc == &item_array[t]);
+            assert(rc == &item_array[t]); (void)rc;
         }
         t1 = take_time();
         duration = diff_time(t0, t1);


### PR DESCRIPTION
proper count for incarnations - used defined names rather than hardcoded numbers.


Since a dtd taskpool is initialized with 7 (`PARSEC_DEV_MAX_NB_TYPE+1`) chores as space (6 if you consider that this array is null-terminated), it doesn't make sense to allow checking of up to 8 chores in `parsec_dtd_task_class_add_chore`. This could mean accessing unallocated memory. This PR is simply a patch for that issue.