### PR TITLE
Profiling dsl extension

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2718,7 +2718,6 @@ parsec_dtd_create_and_initialize_task(parsec_dtd_taskpool_t *dtd_tp,
 
     assert(this_task->super.super.super.obj_reference_count == 1);
 
-    this_task->orig_task = NULL;
     this_task->super.taskpool = (parsec_taskpool_t *)dtd_tp;
     this_task->ht_item.key = (parsec_key_t)(uintptr_t)(dtd_tp->task_id++);
     /* this is needed for grapher to work properly */

--- a/parsec/interfaces/dtd/insert_function.h
+++ b/parsec/interfaces/dtd/insert_function.h
@@ -69,7 +69,10 @@ typedef enum { PARSEC_INPUT =      0x100000,
                PARSEC_DONT_TRACK  =1<<17, /* Drop dependency tracking */
                PARSEC_PUSHOUT     =1<<18, /* Push GPU data back to CPU */
                PARSEC_PULLIN      =1<<19, /* Pull data on the CPU */
-               PARSEC_GET_OTHER_FLAG_INFO=0xf0000, /* MASK: not an actual value, used to filter the relevant enum values */
+               PARSEC_PROFILE_INFO=1<<24, /* Mark this VALUE (error if not value) to be saved as info in the profile of this task --
+                                           * !! Warning: a string with the info name is expected as the next argument,
+                                                and this parameter is not allowed in the insert_task without task class */
+               PARSEC_GET_OTHER_FLAG_INFO=0x10f0000, /* MASK: not an actual value, used to filter the relevant enum values */
                PARSEC_GET_REGION_INFO=0xffff /* MASK: not an actual value, used to filter the relevant enum values */
              } parsec_dtd_op_t;
 typedef enum { PASSED_BY_REF=-2,
@@ -80,6 +83,7 @@ typedef enum { PASSED_BY_REF=-2,
 typedef struct {
     parsec_dtd_op_t op;
     long            size;
+    char *          profile_info;
 } parsec_dtd_param_t;
 
 typedef struct parsec_dtd_task_class_s  parsec_dtd_task_class_t;

--- a/parsec/interfaces/dtd/insert_function_internal.h
+++ b/parsec/interfaces/dtd/insert_function_internal.h
@@ -180,8 +180,6 @@ struct parsec_dtd_task_s {
     parsec_thread_mempool_t     *mempool_owner;
     int32_t                      rank;
     int32_t                      flow_count;
-    /* for testing PTG inserting task in DTD */
-    parsec_task_t  *orig_task;
 };
 
 /* For creating objects of class parsec_dtd_task_t */

--- a/parsec/interfaces/dtd/insert_function_internal.h
+++ b/parsec/interfaces/dtd/insert_function_internal.h
@@ -180,6 +180,8 @@ struct parsec_dtd_task_s {
     parsec_thread_mempool_t     *mempool_owner;
     int32_t                      rank;
     int32_t                      flow_count;
+    /* for testing PTG inserting task in DTD */
+    parsec_task_t  *orig_task;
 };
 
 /* For creating objects of class parsec_dtd_task_t */

--- a/parsec/interfaces/interface.c
+++ b/parsec/interfaces/interface.c
@@ -147,3 +147,11 @@ const parsec_task_class_t __parsec_generic_startup = {
     .sim_cost_fct = (parsec_sim_cost_fct_t *) NULL,
 #endif
 };
+
+#if defined(PARSEC_PROF_TRACE)
+void *parsec_task_profile_info(void *dst, const void *task_, size_t size)
+{
+    parsec_task_t *task = (parsec_task_t *)task_;
+    return memcpy(dst, &task->prof_info, size);
+}
+#endif

--- a/parsec/interfaces/interface.h
+++ b/parsec/interfaces/interface.h
@@ -59,6 +59,10 @@ parsec_hook_return_t
 parsec_release_task_to_mempool_and_count_as_runtime_tasks(parsec_execution_stream_t *es,
                                                           parsec_task_t *this_task);
 
+
+#if defined(PARSEC_PROF_TRACE)
+void *parsec_task_profile_info(void *dst, const void *task, size_t size);
+#endif
 /**
  * @}
  */

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -4218,6 +4218,9 @@ static void jdf_generate_one_function( const jdf_t *jdf, jdf_function_entry_t *f
     string_arena_add_string(sa,
                             "  .make_key = %s,\n"
                             "  .task_snprintf = parsec_task_snprintf,\n"
+                            "#if defined(PARSEC_PROF_TRACE)\n"
+                            "  .profile_info = &parsec_task_profile_info,\n"
+                            "#endif\n"
                             "  .key_functions = &%s,\n",
                             jdf_property_get_string(f->properties, JDF_PROP_UD_MAKE_KEY_FN_NAME, NULL),
                             jdf_property_get_string(f->properties, JDF_PROP_UD_HASH_STRUCT_NAME, NULL));

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -1242,6 +1242,12 @@ int parsec_fini( parsec_context_t** pcontext )
 
     PARSEC_PINS_FINI(context);
 
+    PARSEC_AYU_FINI();
+#ifdef PARSEC_PROF_TRACE
+    (void)parsec_profiling_fini( );  /* we're leaving, ignore errors */
+#endif  /* PARSEC_PROF_TRACE */
+
+
 #ifdef PARSEC_PROF_TRACE
     parsec_mempool_stats(context);
 #endif  /* PARSEC_PROF_TRACE */
@@ -1263,11 +1269,6 @@ int parsec_fini( parsec_context_t** pcontext )
         free(context->virtual_processes[p]);
         context->virtual_processes[p] = NULL;
     }
-
-    PARSEC_AYU_FINI();
-#ifdef PARSEC_PROF_TRACE
-    (void)parsec_profiling_fini( );  /* we're leaving, ignore errors */
-#endif  /* PARSEC_PROF_TRACE */
 
     if(parsec_enable_dot) {
 #if defined(PARSEC_PROF_GRAPHER)

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -416,6 +416,9 @@ struct parsec_task_class_s {
     parsec_key_fn_t             *key_functions;
     parsec_functionkey_fn_t     *make_key;
     parsec_printtask_fn_t       *task_snprintf;
+#if defined(PARSEC_PROF_TRACE)
+    parsec_profiling_info_fn_t  *profile_info;
+#endif
 #if defined(PARSEC_SIM)
     parsec_sim_cost_fct_t       *sim_cost_fct;
 #endif
@@ -558,12 +561,14 @@ extern int device_delegate_begin, device_delegate_end;
     (tp)->profiling_array[1 + 2 * (tc_index)]
 
 #define PARSEC_TASK_PROF_TRACE(PROFILE, KEY, TASK)                      \
-    PARSEC_PROFILING_TRACE((PROFILE),                                   \
+    PARSEC_PROFILING_TRACE_INFO_FN((PROFILE),                           \
                            (KEY),                                       \
                            (TASK)->task_class->key_functions->          \
                            key_hash((TASK)->task_class->make_key(       \
-                              (TASK)->taskpool, (TASK)->locals ), NULL), \
-                              (TASK)->taskpool->taskpool_id, (void*)&(TASK)->prof_info); 
+                             (TASK)->taskpool, (TASK)->locals ), NULL), \
+                           (TASK)->taskpool->taskpool_id,               \
+                           (TASK)->task_class->profile_info,            \
+                           (void*)(TASK)); 
 
 #define PARSEC_TASK_PROF_TRACE_IF(COND, PROFILE, KEY, TASK)  \
     if(!!(COND)) {                                           \

--- a/parsec/profiling.c
+++ b/parsec/profiling.c
@@ -959,6 +959,12 @@ static int switch_event_buffer( parsec_profiling_stream_t *context )
 int parsec_profiling_ts_trace_flags(int key, uint64_t event_id, uint32_t taskpool_id,
                                     const void *info, uint16_t flags )
 {
+    return parsec_profiling_ts_trace_flags_info_fn(key, event_id, taskpool_id, memcpy, info, flags);
+}
+
+int parsec_profiling_ts_trace_flags_info_fn(int key, uint64_t event_id, uint32_t taskpool_id,
+                                            parsec_profiling_info_fn_t *info_fn, const void *info_data, uint16_t flags )
+{
     parsec_profiling_stream_t* ctx;
 
     if( (-1 == file_backend_fd) || (!start_called) ) {
@@ -967,7 +973,7 @@ int parsec_profiling_ts_trace_flags(int key, uint64_t event_id, uint32_t taskpoo
 
     ctx = PARSEC_TLS_GET_SPECIFIC(tls_profiling);
     if( NULL != ctx )
-        return parsec_profiling_trace_flags(ctx, key, event_id, taskpool_id, info, flags);
+        return parsec_profiling_trace_flags_info_fn(ctx, key, event_id, taskpool_id, info_fn, info_data, flags);
 
     set_last_error("Profiling system: error: called parsec_profiling_ts_trace_flags"
                    " from a thread that did not call parsec_profiling_stream_init\n");
@@ -979,6 +985,14 @@ parsec_profiling_trace_flags(parsec_profiling_stream_t* context, int key,
                             uint64_t event_id, uint32_t taskpool_id,
                             const void *info, uint16_t flags)
 {
+    return parsec_profiling_trace_flags_info_fn(context, key, event_id, taskpool_id, memcpy, info, flags);
+}
+
+int
+parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key,
+                                     uint64_t event_id, uint32_t taskpool_id,
+                                     parsec_profiling_info_fn_t *info_fn, const void *info_data, uint16_t flags)
+{
     parsec_profiling_output_t *this_event;
     size_t this_event_length;
     parsec_time_t now;
@@ -989,7 +1003,7 @@ parsec_profiling_trace_flags(parsec_profiling_stream_t* context, int key,
 
     assert( key >= 2 );
 
-    this_event_length = EVENT_LENGTH( key, (NULL != info) );
+    this_event_length = EVENT_LENGTH( key, (NULL != info_data) );
     assert( this_event_length < event_avail_space );
     if( context->next_event_position + this_event_length > event_avail_space ) {
         int rc = switch_event_buffer(context);
@@ -1009,8 +1023,8 @@ parsec_profiling_trace_flags(parsec_profiling_stream_t* context, int key,
     this_event->event.taskpool_id = taskpool_id;
     this_event->event.flags = 0;
 
-    if( NULL != info ) {
-        memcpy(this_event->info, info, parsec_prof_keys[ BASE_KEY(key) ].info_length);
+    if( NULL != info_data ) {
+        info_fn(this_event->info, info_data, parsec_prof_keys[ BASE_KEY(key) ].info_length);
         this_event->event.flags = PARSEC_PROFILING_EVENT_HAS_INFO;
     }
     this_event->event.flags |= flags;

--- a/parsec/profiling.h
+++ b/parsec/profiling.h
@@ -312,10 +312,49 @@ int parsec_profiling_trace_flags(parsec_profiling_stream_t* context, int key,
                                  const void *info, uint16_t flags );
 
 /**
+ * @brief Type of user functions to write info in pre-allocated event
+ * 
+ * @details
+ *    @param[out] dst  address into which to write the info
+ *    @param[in] data  pointer passed to parsec_profiling_trace_flags_fn_info
+ *    @param[in] size  number of bytes that can be written at this address
+ *    @return dst
+ */
+typedef void *(parsec_profiling_info_fn_t)(void *dst, const void *data, size_t size);
+
+/**
+ * @brief Trace one event
+ *
+ * @details Event is added to the series of events related to the context passed as argument.
+ *
+ * @param[in] context a thread profiling context (should be the thread profiling context of the
+ *                      calling thread).
+ * @param[in] key     the key (as returned by add_dictionary_keyword) of the event to log
+ * @param[in] event_id a (possibly unique) event identifier. Events are coupled together: start/end.
+ *                      a couple (start, end) has
+ *                        - the same key
+ *                        - end is the next "end" event with the same key and the same non-null event_id and
+ *                          non OBJECT_ID_NULL taskpool_id as start in the event buffer of the thread context
+ *                        - if no matching end is found, this is an error
+ * @param[in] taskpool_id unique object/handle identifier (use PROFILE_OBJECT_ID_NULL if N/A)
+ * @param[in] info_fn a pointer to a function that will write the info of the event in the allocated event
+ *                    that memory is of size defined during the creation of the event
+ * @param[in] info_data an opaque pointer passed back to info_fn when it is called.
+ * @param[in] flags   flags related to the event
+ * @return 0 if success, negative otherwise.
+ * @remark not thread safe (if two threads share a same thread_context. Safe per thread_context)
+ */
+int parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key,
+                                         uint64_t event_id, uint32_t taskpool_id,
+                                         parsec_profiling_info_fn_t *info_fn, const void *info_data, uint16_t flags );
+
+/**
  * @brief Convenience macro used to trace events without flags
  */
 #define parsec_profiling_trace(CTX, KEY, EVENT_ID, TASKPOOL_ID, INFO)     \
     parsec_profiling_trace_flags( (CTX), (KEY), (EVENT_ID), (TASKPOOL_ID), (INFO), 0 )
+#define parsec_profiling_trace_info_fn(CTX, KEY, EVENT_ID, TASKPOOL_ID, INFO_FN, INFO_FN_DATA) \
+    parsec_profiling_trace_flags_info_fn( (CTX), (KEY), (EVENT_ID), (TASKPOOL_ID), (INFO_FN), (INFO_FN_DATA), 0)
 
 /**
  * @brief Trace one event on the implicit thread context.
@@ -342,10 +381,35 @@ int parsec_profiling_ts_trace_flags(int key, uint64_t event_id, uint32_t taskpoo
                                     const void *info, uint16_t flags );
 
 /**
+ * @brief Trace one event on the implicit thread context.
+ *
+ * @details Event is added to the series of events related to the context passed as argument.
+ *
+ * @param[in] key     the key (as returned by add_dictionary_keyword) of the event to log
+ * @param[in] event_id a (possibly unique) event identifier. Events are coupled together: start/end.
+ *                      a couple (start, end) has
+ *                        - the same key
+ *                        - end is the next "end" event with the same key and the same non-null event_id and
+ *                          non OBJECT_ID_NULL taskpool_id as start in the event buffer of the thread context
+ *                        - if no matching end is found, this is an error
+ * @param[in] taskpool_id unique object/handle identifier (use PROFILE_OBJECT_ID_NULL if N/A)
+ * @param[in] info_fn a pointer to a function that will write the info of the event in the allocated event
+ *                    that memory is of size defined during the creation of the event
+ * @param[in] info_data an opaque pointer passed back to info_fn when it is called.
+ * @param[in] flags   flags related to the event
+ * @return 0 if success, negative otherwise.
+ * @remark not thread safe (if two threads share a same thread_context. Safe per thread_context)
+ */
+int parsec_profiling_ts_trace_flags_info_fn(int key, uint64_t event_id, uint32_t taskpool_id,
+                                            parsec_profiling_info_fn_t *info_fn, const void *info_data, uint16_t flags );
+
+/**
  * @brief Convenience macro when no flag needs to be passed
  */
 #define parsec_profiling_ts_trace(key, event_id, object_id, info) \
     parsec_profiling_ts_trace_flags((key), (event_id), (object_id), (info), 0)
+#define parsec_profiling_ts_trace_info_fn(key, event_id, object_id, info_fn, info_fn_data) \
+    parsec_profiling_ts_trace_flags_info_fn((key), (event_id), (object_id), (info_fn), (info_fn_data), 0)
 
 /**
  * @brief Creates the profile file given as a parameter to store the
@@ -465,7 +529,7 @@ void parsec_profiling_disable(void);
  */
 #define PARSEC_PROFILING_TRACE(context, key, event_id, object_id, info ) \
     if( parsec_profile_enabled ) {                                       \
-        parsec_profiling_trace(context, key, event_id, object_id, info ); \
+        parsec_profiling_trace((context), (key), (event_id), (object_id), (info) ); \
     }
 
 /**
@@ -473,7 +537,23 @@ void parsec_profiling_disable(void);
  */
 #define PARSEC_PROFILING_TRACE_FLAGS(context, key, event_id, object_id, info, flags ) \
     if( parsec_profile_enabled ) {                                       \
-        parsec_profiling_trace_flags(context, key, event_id, object_id, info, flags ); \
+        parsec_profiling_trace_flags((context), (key), (event_id), (object_id), (info), (flags) ); \
+    }
+
+/**
+ * @brief Convenience macro to trace events only if profiling is enabled
+ */
+#define PARSEC_PROFILING_TRACE_INFO_FN(context, key, event_id, object_id, info_fn, info_data ) \
+    if( parsec_profile_enabled ) {                                       \
+        parsec_profiling_trace_info_fn((context), (key), (event_id), (object_id), (info_fn), (info_data) ); \
+    }
+
+/**
+ * @brief Convenience macro to trace events with flags only if profiling is enabled
+ */
+#define PARSEC_PROFILING_TRACE_FLAGS_INFO_FN(context, key, event_id, object_id, info_fn, info_data, flags ) \
+    if( parsec_profile_enabled ) {                                       \
+        parsec_profiling_trace_flags_info_fn((context), (key), (event_id), (object_id), (info_fn), (info_data), (flags) ); \
     }
 
 /**

--- a/parsec/profiling_otf2.c
+++ b/parsec/profiling_otf2.c
@@ -688,9 +688,14 @@ int parsec_profiling_dictionary_flush( void )
     return 0;
 }
 
-
 int parsec_profiling_ts_trace_flags(int key, uint64_t event_id, uint32_t taskpool_id,
                                     const void *info, uint16_t flags )
+{
+    return parsec_profiling_ts_trace_flags_info_fn(key, event_id, taskpool_id, memcpy, info, flags);
+}
+
+int parsec_profiling_ts_trace_flags_info_fn(int key, uint64_t event_id, uint32_t taskpool_id,
+                                            parsec_profiling_info_fn_t *info_fn, const void *info_data, uint16_t flags )
 {
     parsec_profiling_stream_t* ctx;
 
@@ -700,7 +705,7 @@ int parsec_profiling_ts_trace_flags(int key, uint64_t event_id, uint32_t taskpoo
 
     ctx = PARSEC_TLS_GET_SPECIFIC(tls_profiling);
     if( NULL != ctx )
-        return parsec_profiling_trace_flags(ctx, key, event_id, taskpool_id, info, flags);
+        return parsec_profiling_trace_flags_info_fn(ctx, key, event_id, taskpool_id, info_fn, info_data, flags);
 
     set_last_error("Profiling system: error: called parsec_profiling_ts_trace_flags"
                    " from a thread that did not call parsec_profiling_stream_init\n");
@@ -709,8 +714,16 @@ int parsec_profiling_ts_trace_flags(int key, uint64_t event_id, uint32_t taskpoo
 
 int
 parsec_profiling_trace_flags(parsec_profiling_stream_t* context, int key,
-                             uint64_t event_id, uint32_t taskpool_id,
-                             const void *info, uint16_t flags )
+                            uint64_t event_id, uint32_t taskpool_id,
+                            const void *info, uint16_t flags)
+{
+    return parsec_profiling_trace_flags_info_fn(context, key, event_id, taskpool_id, memcpy, info, flags);
+}
+
+int
+parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key,
+                                     uint64_t event_id, uint32_t taskpool_id,
+                                     parsec_profiling_info_fn_t *info_fn, const void *info_data, uint16_t flags)
 {
     parsec_time_t now;
     int region;
@@ -739,9 +752,11 @@ parsec_profiling_trace_flags(parsec_profiling_stream_t* context, int key,
     timestamp = diff_time(parsec_start_time, now);
 
     region = key < 0 ? -key : key;
-    region -= REGION_ID_OFFSET;
 
-    if( NULL != info ) {
+    if( NULL != info_data ) {
+        size_t info_length = regions[region].info_length;
+        char *info = alloca(info_length);
+        info_fn(info, info_data, info_length);
         attribute_list = OTF2_AttributeList_New();
         const char *ptr = info;
         for(int t = 0; t < regions[region].otf2_nb_attributes; t++) {
@@ -797,6 +812,7 @@ parsec_profiling_trace_flags(parsec_profiling_stream_t* context, int key,
         }
     }
 
+    region -= REGION_ID_OFFSET;
     if( key > 0 )
         rc = OTF2_EvtWriter_Enter( context->evt_writer,
                                    attribute_list,

--- a/tests/dsl/dtd/dtd_test_new_tile.c
+++ b/tests/dsl/dtd/dtd_test_new_tile.c
@@ -242,6 +242,9 @@ int main(int argc, char **argv)
     nb = NB; /* tile_size */
 
     parsec = parsec_init( cores, &argc, &argv );
+#if defined(PARSEC_PROF_TRACE)
+    parsec_profiling_start();
+#endif
 
 #if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
     for(unsigned int i = 0; i < parsec_nb_devices; i++) {
@@ -303,8 +306,8 @@ int main(int argc, char **argv)
     parsec_task_class_t *first_tc = parsec_dtd_create_task_class(dtd_tp, "set_to_i",
                                                                  sizeof(int), PARSEC_VALUE,
                                                                  PASSED_BY_REF, PARSEC_OUTPUT | TILE_FULL,
-                                                                 sizeof(int), PARSEC_VALUE,
-                                                                 sizeof(int), PARSEC_VALUE,
+                                                                 sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "nb",
+                                                                 sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "idx",
                                                                  PARSEC_DTD_ARG_END);
 #if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
     parsec_dtd_task_class_add_chore(dtd_tp, first_tc, PARSEC_DEV_CUDA, cuda_set_to_i);
@@ -313,8 +316,8 @@ int main(int argc, char **argv)
 
     parsec_task_class_t *second_tc = parsec_dtd_create_task_class(dtd_tp, "multiply_by_2",
                                                                   PASSED_BY_REF, PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                                                  sizeof(int), PARSEC_VALUE,
-                                                                  sizeof(int), PARSEC_VALUE,
+                                                                  sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "nb",
+                                                                  sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "idx",
                                                                   PARSEC_DTD_ARG_END);
 #if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
     parsec_dtd_task_class_add_chore(dtd_tp, second_tc, PARSEC_DEV_CUDA, cuda_multiply_by_2);
@@ -323,8 +326,8 @@ int main(int argc, char **argv)
 
     parsec_task_class_t *third_tc = parsec_dtd_create_task_class(dtd_tp, "accumulate",
                                                                   PASSED_BY_REF, PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                                                  sizeof(int), PARSEC_VALUE,
-                                                                  sizeof(int), PARSEC_VALUE,
+                                                                  sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "nb",
+                                                                  sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "idx",
                                                                   sizeof(int), PARSEC_REF,
                                                                   sizeof(int*), PARSEC_REF,
                                                                   PARSEC_DTD_ARG_END);
@@ -336,9 +339,9 @@ int main(int argc, char **argv)
     parsec_task_class_t *fourth_tc = parsec_dtd_create_task_class(dtd_tp, "reduce",
                                                                  PASSED_BY_REF, PARSEC_OUTPUT | TILE_FULL | PARSEC_AFFINITY,
                                                                  PASSED_BY_REF, PARSEC_INPUT | TILE_FULL,
+                                                                 sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "nb",
                                                                  sizeof(int), PARSEC_VALUE,
-                                                                 sizeof(int), PARSEC_VALUE,
-                                                                 sizeof(int), PARSEC_VALUE,
+                                                                 sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "t",
                                                                  sizeof(int), PARSEC_REF,
                                                                  PARSEC_DTD_ARG_END);
     parsec_dtd_task_class_add_chore(dtd_tp, fourth_tc, PARSEC_DEV_CPU, cpu_reduce);

--- a/tests/dsl/ptg/strange.jdf
+++ b/tests/dsl/ptg/strange.jdf
@@ -157,6 +157,10 @@ int main(int argc, char* argv[] )
     parsec = parsec_init(-1, &argc, &argv);
     assert( NULL != parsec );
 
+#if defined(PARSEC_PROF_TRACE)
+    parsec_profiling_start();
+#endif
+
     parsec_matrix_block_cyclic_init( &descA, TYPE, PARSEC_MATRIX_TILE,
                                0 /*rank*/,
                                1, 1, n, 1,

--- a/tools/profiling/dbpreader.c
+++ b/tools/profiling/dbpreader.c
@@ -382,6 +382,12 @@ static const dbp_event_t *dbp_iterator_next_buffer(dbp_event_iterator_t *it)
     assert( it->current_events_buffer->buffer_type == PROFILING_BUFFER_TYPE_EVENTS );
 
     next_off = it->current_events_buffer->next_buffer_file_offset;
+    if(next_off == -1) {
+        it->current_event.native = NULL;
+        it->current_events_buffer = NULL;
+        return NULL;
+    }
+
     return dbp_iterator_set_offset(it, next_off);
 }
 


### PR DESCRIPTION
 - Extend the parsec_task_class to make the DSLs define what data to profile for tasks
 - Extend the profiling interface to allow writing the infos related to an event directly in an event buffer instead of assuming infos are always a contiguous block
 - Use the extended task class interface to have programmer-defined parameters profiled as infos for a task in DTD
 - Port PTG to the extended task class interface
 - Enable a couple of tests for PTG and DTD
