### PR TITLE
bugfix for profiling without multiprocessing

### DIFF
--- a/tools/profiling/python/pbt2ptt.pyx
+++ b/tools/profiling/python/pbt2ptt.pyx
@@ -254,6 +254,7 @@ cpdef read(filenames, report_progress=False, skeleton_only=False, multiprocess=F
 
     if isinstance(builder.events, pd.DataFrame):
         events = builder.events
+        event_infos = dict()
     else:
         if len(builder.events) > 0:
             cond_print('Then we concatenate the event DataFrames....', report_progress)


### PR DESCRIPTION
While running `profile2h5` on methane, everything seems to work fine. But not on Saturn? Why? It's because `event_infos` may not be defined depending on whether or not the machine uses multiprocessing for `profile2h5`. This little fix (discussed in Slack on Sept 9, 2022) should take care of that issue.