### PR TITLE
TSL variables are not static by default.

### DIFF
--- a/parsec/include/parsec/sys/tls.h
+++ b/parsec/include/parsec/sys/tls.h
@@ -33,7 +33,7 @@
  *
  *  @param[INOUT] var the handle to use for the thread specific pointer
  */
-#define PARSEC_TLS_DECLARE(var)              static __thread void *var
+#define PARSEC_TLS_DECLARE(var)              __thread void *var
 
 /**
  * Create the key associated with a handle.
@@ -78,7 +78,7 @@
 
 #include <pthread.h>
 
-#define PARSEC_TLS_DECLARE(key)              static pthread_key_t key
+#define PARSEC_TLS_DECLARE(key)              pthread_key_t key
 #define PARSEC_TLS_KEY_CREATE(key)           pthread_key_create(&key, NULL)
 #define PARSEC_TLS_GET_SPECIFIC(key)         pthread_getspecific(key)
 #define PARSEC_TLS_SET_SPECIFIC(key, value)  pthread_setspecific(key, value)

--- a/parsec/papi_sde.c
+++ b/parsec/papi_sde.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2018-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "parsec/parsec_config.h"
 
 #include <stdlib.h>
@@ -26,7 +32,7 @@ typedef struct {
 PARSEC_OBJ_CLASS_DECLARATION(parsec_thread_sde_counters_t);
 PARSEC_OBJ_CLASS_INSTANCE(parsec_thread_sde_counters_t, parsec_list_item_t, NULL, NULL);
 
-PARSEC_TLS_DECLARE(parsec_papi_sde_basic_counters_tls);
+static PARSEC_TLS_DECLARE(parsec_papi_sde_basic_counters_tls);
 /* We protect the sde_threads list with an external rwlock,
    because most operations do not modify the list and can be done in parallel */
 static parsec_list_t sde_threads;

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -153,7 +153,7 @@ static int parsec_runtime_bind_threads     = 1;
 
 int parsec_runtime_keep_highest_priority_task = 1;
 
-PARSEC_TLS_DECLARE(parsec_tls_execution_stream);
+static PARSEC_TLS_DECLARE(parsec_tls_execution_stream);
 
 #if defined(DISTRIBUTED) && defined(PARSEC_HAVE_MPI)
 static void parsec_mpi_exit(int status) {
@@ -2882,6 +2882,11 @@ int parsec_add_fetch_runtime_task( parsec_taskpool_t *tp, int32_t nb_tasks )
     return tp->tdm.module->taskpool_addto_runtime_actions(tp, nb_tasks);
 }
 
+/**
+ * The following two accessors are necessary to provide access to the
+ * static TLS parsec_tls_execution_stream outside this file. This access
+ * includes user code (which should however not be allowed to change it).
+ */
 parsec_execution_stream_t *parsec_my_execution_stream(void)
 {
     return (parsec_execution_stream_t*)PARSEC_TLS_GET_SPECIFIC(parsec_tls_execution_stream);

--- a/parsec/profiling.c
+++ b/parsec/profiling.c
@@ -102,7 +102,7 @@ static int file_backend_extendable;
 
 static parsec_profiling_binary_file_header_t *profile_head = NULL;
 static char *bpf_filename = NULL;
-PARSEC_TLS_DECLARE(tls_profiling);
+static PARSEC_TLS_DECLARE(tls_profiling);
 
 static int parsec_profiling_show_profiling_performance = 0;
 static parsec_profiling_perf_t parsec_profiling_global_perf[PERF_MAX];

--- a/parsec/profiling_otf2.c
+++ b/parsec/profiling_otf2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 The University of Tennessee and The University
+ * Copyright (c) 2018-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -80,7 +80,7 @@ PARSEC_OBJ_CLASS_INSTANCE(parsec_profiling_info_t, parsec_list_item_t,
 
 int parsec_profile_enabled = 0;
 
-PARSEC_TLS_DECLARE(tls_profiling);
+static PARSEC_TLS_DECLARE(tls_profiling);
 static parsec_list_t threads;
 static int __profile_initialized = 0;  /* not initialized */
 static int __already_called = 0;

--- a/parsec/utils/debug.c
+++ b/parsec/utils/debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -226,7 +226,7 @@ typedef struct mark_double_buffer_s {
 /**
  * Thread Local Storage key / variable so each thread finds its own buffers
  */
-PARSEC_TLS_DECLARE(tls_debug);
+static PARSEC_TLS_DECLARE(tls_debug);
 
 /**
  * This global stores a linked list of all mark buffers (one per thread that


### PR DESCRIPTION
Completes #422.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>