### PR TITLE
Fix: termination detector race condition

### DIFF
--- a/parsec/class/parsec_rwlock.c
+++ b/parsec/class/parsec_rwlock.c
@@ -239,8 +239,8 @@ void parsec_atomic_rwlock_rdlock(parsec_atomic_rwlock_t *L)
         parsec_atomic_lock(&L->w);
 #if defined(PARSEC_DEBUG_PARANOID)
     assert(L->writer == 0);
+    assert(L->nbreaders < MAX_READERS_TO_CHECK);
     L->readers[L->nbreaders] = (int)pthread_self();
-    assert(L->nbreaders < MAX_READERS);
 #endif
     L->nbreaders++;
     parsec_atomic_unlock(&L->r);

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -391,6 +391,7 @@ parsec_dtd_taskpool_destructor(parsec_dtd_taskpool_t *tp)
     free((void *)tp->super.profiling_array);
 #endif /* defined(PARSEC_PROF_TRACE) */
 
+    if(NULL != tp->super.tdm.module) { tp->super.tdm.module->unmonitor_taskpool(&tp->super); }
     parsec_taskpool_unregister( (parsec_taskpool_t*)tp );
     parsec_mempool_free( parsec_dtd_taskpool_mempool, tp );
 

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -4493,8 +4493,8 @@ static void jdf_generate_destructor( const jdf_t *jdf )
     if( JDF_COMPILER_GLOBAL_ARGS.dep_management == DEP_MANAGEMENT_INDEX_ARRAY ) {
         coutput("  size_t dependencies_size = 0;\n");
     }
-
-    coutput("  parsec_taskpool_unregister( &__parsec_tp->super.super );\n");
+    coutput("  parsec_taskpool_unregister( &__parsec_tp->super.super );\n"
+            "  if(NULL != __parsec_tp->super.super.tdm.module) __parsec_tp->super.super.tdm.module->unmonitor_taskpool(&__parsec_tp->super.super);\n");
 
     coutput("  for( i = 0; i < (uint32_t)(2 * __parsec_tp->super.super.nb_task_classes); i++ ) {  /* Extra startup function added at the end */\n"
             "    parsec_task_class_t* tc = (parsec_task_class_t*)__parsec_tp->super.super.task_classes_array[i];\n"

--- a/parsec/mca/termdet/local/termdet_local_module.c
+++ b/parsec/mca/termdet/local/termdet_local_module.c
@@ -23,6 +23,7 @@
 
 static void parsec_termdet_local_monitor_taskpool(parsec_taskpool_t *tp,
                                                   parsec_termdet_termination_detected_function_t cb);
+static void parsec_termdet_local_unmonitor_taskpool(parsec_taskpool_t *tp);
 static parsec_termdet_taskpool_state_t parsec_termdet_local_taskpool_state(parsec_taskpool_t *tp);
 static int parsec_termdet_local_taskpool_ready(parsec_taskpool_t *tp);
 static int parsec_termdet_local_taskpool_set_nb_tasks(parsec_taskpool_t *tp, int v);
@@ -50,6 +51,7 @@ const parsec_termdet_module_t parsec_termdet_local_module = {
     &parsec_termdet_local_component,
     {
         parsec_termdet_local_monitor_taskpool,
+        parsec_termdet_local_unmonitor_taskpool,
         parsec_termdet_local_taskpool_state,
         parsec_termdet_local_taskpool_ready,
         parsec_termdet_local_taskpool_addto_nb_tasks,
@@ -80,6 +82,14 @@ static void parsec_termdet_local_monitor_taskpool(parsec_taskpool_t *tp,
     assert(&parsec_termdet_local_module.module == tp->tdm.module);
     tp->tdm.callback = cb;
     tp->tdm.monitor = PARSEC_TERMDET_LOCAL_NOT_READY;
+}
+
+static void parsec_termdet_local_unmonitor_taskpool(parsec_taskpool_t *tp)
+{
+    assert(&parsec_termdet_local_module.module == tp->tdm.module);
+    assert(tp->tdm.monitor == PARSEC_TERMDET_LOCAL_TERMINATED);
+    tp->tdm.module   = NULL;
+    tp->tdm.callback = NULL;
 }
 
 static parsec_termdet_taskpool_state_t parsec_termdet_local_taskpool_state(parsec_taskpool_t *tp)

--- a/parsec/mca/termdet/termdet.h
+++ b/parsec/mca/termdet/termdet.h
@@ -100,6 +100,17 @@ typedef void (*parsec_termdet_monitor_taskpool_fn_t)(parsec_taskpool_t *tp,
                                                      parsec_termdet_termination_detected_function_t cb);
 
 /**
+ * @brief stops monitoring the termination of a taskpool
+ *
+ * @details this function should only be called once the taskpool has been
+ *    detected as terminated, and no other thread may change or read the
+ *    state of this monitor. It frees the resources associated with the monitor.
+ *
+ *    @param[INOUT] tp the taskpool on which the termination is monitored
+ */
+typedef void (*parsec_termdet_unmonitor_taskpool_fn_t)(parsec_taskpool_t *tp);
+
+/**
  * @brief gives the current state of a monitored taskpool
  *
  * @brief as an alternative to callback mechanism, the user may poll
@@ -293,6 +304,7 @@ typedef int (*parsec_termdet_write_stats_fn_t)(parsec_taskpool_t *tp, FILE *fp);
 
 struct parsec_termdet_base_module_1_0_0_t {
     parsec_termdet_monitor_taskpool_fn_t       monitor_taskpool;
+    parsec_termdet_unmonitor_taskpool_fn_t     unmonitor_taskpool;
     parsec_termdet_taskpool_state_fn_t         taskpool_state;
     parsec_termdet_taskpool_ready_fn_t         taskpool_ready;
     parsec_termdet_taskpool_load_fn_t          taskpool_addto_nb_tasks;

--- a/parsec/mca/termdet/user_trigger/termdet_user_trigger_module.c
+++ b/parsec/mca/termdet/user_trigger/termdet_user_trigger_module.c
@@ -24,6 +24,7 @@
 
 static void parsec_termdet_user_trigger_monitor_taskpool(parsec_taskpool_t *tp,
                                                          parsec_termdet_termination_detected_function_t cb);
+static void parsec_termdet_user_trigger_unmonitor_taskpool(parsec_taskpool_t *tp);
 static parsec_termdet_taskpool_state_t parsec_termdet_user_trigger_taskpool_state(parsec_taskpool_t *tp);
 static int parsec_termdet_user_trigger_taskpool_ready(parsec_taskpool_t *tp);
 static int parsec_termdet_user_trigger_taskpool_set_nb_tasks(parsec_taskpool_t *tp, int v);
@@ -51,6 +52,7 @@ const parsec_termdet_module_t parsec_termdet_user_trigger_module = {
     &parsec_termdet_user_trigger_component,
     {
         parsec_termdet_user_trigger_monitor_taskpool,
+        parsec_termdet_user_trigger_unmonitor_taskpool,
         parsec_termdet_user_trigger_taskpool_state,
         parsec_termdet_user_trigger_taskpool_ready,
         parsec_termdet_user_trigger_taskpool_addto_nb_tasks,
@@ -71,13 +73,10 @@ const parsec_termdet_module_t parsec_termdet_user_trigger_module = {
  * until they know the root */
 #define PARSEC_TERMDET_USER_TRIGGER_UNKNOWN_RANK (-1)
 
-/* In order to garbage collect when completing, and still differentiate between
- * terminated and not_monitored, we set the taskpool monitor to this constant after
- * detecting the termination. */
-#define PARSEC_TERMDET_USER_TRIGGER_TERMINATED ((void*)(0x1))
 typedef enum {
     PARSEC_TERMDET_USER_TRIGGER_NOT_READY,
-    PARSEC_TERMDET_USER_TRIGGER_BUSY
+    PARSEC_TERMDET_USER_TRIGGER_BUSY,
+    PARSEC_TERMDET_USER_TRIGGER_TERMINATED
 } parsec_termdet_user_trigger_state_t;
 
 typedef struct parsec_termdet_user_trigger_monitor_s {
@@ -95,8 +94,9 @@ static int parsec_termdet_user_trigger_msg_dispatch_taskpool(parsec_taskpool_t *
     parsec_termdet_user_trigger_msg_t *ut_msg = (parsec_termdet_user_trigger_msg_t *)msg;
     parsec_termdet_user_trigger_monitor_t *monitor;
 
-    assert((NULL != tp->tdm.monitor) && (PARSEC_TERMDET_USER_TRIGGER_TERMINATED != tp->tdm.monitor));
+    assert(NULL != tp->tdm.monitor);
     monitor = (parsec_termdet_user_trigger_monitor_t*)tp->tdm.monitor;
+    assert(PARSEC_TERMDET_USER_TRIGGER_TERMINATED != monitor->state);
     assert(PARSEC_TERMDET_USER_TRIGGER_UNKNOWN_RANK == monitor->root);
 
     (void)size;
@@ -121,7 +121,7 @@ int parsec_termdet_user_trigger_msg_dispatch(parsec_comm_engine_t *ce, parsec_ce
     parsec_termdet_user_trigger_msg_t *ut_msg = (parsec_termdet_user_trigger_msg_t*)msg;
     parsec_taskpool_t *tp = parsec_taskpool_lookup(ut_msg->tp_id);
 
-    assert((NULL == tp) || (PARSEC_TERMDET_USER_TRIGGER_TERMINATED != tp->tdm.monitor));
+    assert((NULL == tp) || (PARSEC_TERMDET_USER_TRIGGER_TERMINATED != ((parsec_termdet_user_trigger_monitor_t *)tp->tdm.monitor)->state));
 
     if( (NULL == tp) || (NULL == tp->tdm.monitor) ||
         (((parsec_termdet_user_trigger_monitor_t*)tp->tdm.monitor)->state == PARSEC_TERMDET_USER_TRIGGER_NOT_READY) ) {
@@ -165,17 +165,29 @@ static void parsec_termdet_user_trigger_monitor_taskpool(parsec_taskpool_t *tp,
     tp->nb_tasks     = PARSEC_UNDETERMINED_NB_TASKS;
 }
 
+static void parsec_termdet_user_trigger_unmonitor_taskpool(parsec_taskpool_t *tp)
+{
+    parsec_termdet_user_trigger_monitor_t *monitor;
+    assert(&parsec_termdet_user_trigger_module.module == tp->tdm.module);
+    assert(monitor->state == PARSEC_TERMDET_USER_TRIGGER_TERMINATED);
+    free(tp->tdm.monitor);
+    tp->tdm.monitor = NULL;
+    tp->tdm.module   = NULL;
+    tp->tdm.callback = NULL;
+}
+
+
 static parsec_termdet_taskpool_state_t parsec_termdet_user_trigger_taskpool_state(parsec_taskpool_t *tp)
 {
     if( tp->tdm.module == NULL )
         return PARSEC_TERM_TP_NOT_MONITORED;
     assert(tp->tdm.module == &parsec_termdet_user_trigger_module.module);
-    if( tp->tdm.monitor == PARSEC_TERMDET_USER_TRIGGER_TERMINATED )
-        return PARSEC_TERM_TP_TERMINATED;
     if( ((parsec_termdet_user_trigger_monitor_t *)tp->tdm.monitor)->state == PARSEC_TERMDET_USER_TRIGGER_BUSY )
         return PARSEC_TERM_TP_BUSY;
     if( ((parsec_termdet_user_trigger_monitor_t *)tp->tdm.monitor)->state == PARSEC_TERMDET_USER_TRIGGER_NOT_READY )
         return PARSEC_TERM_TP_NOT_READY;
+    if( ((parsec_termdet_user_trigger_monitor_t *)tp->tdm.monitor)->state == PARSEC_TERMDET_USER_TRIGGER_TERMINATED )
+        return PARSEC_TERM_TP_TERMINATED;
     assert(0);
     return -1;
 }
@@ -234,7 +246,8 @@ static void parsec_termdet_signal_termination(parsec_taskpool_t *tp)
 {
     parsec_termdet_user_trigger_monitor_t *monitor = (parsec_termdet_user_trigger_monitor_t *)tp->tdm.monitor;
     parsec_termdet_user_trigger_msg_t msg;
-    tp->tdm.monitor = PARSEC_TERMDET_USER_TRIGGER_TERMINATED;
+
+    monitor->state = PARSEC_TERMDET_USER_TRIGGER_TERMINATED;
     PARSEC_DEBUG_VERBOSE(10, parsec_debug_output, "TERMDET-USER_TRIGGER:\tBUSY -> TERMINATED. Broadcast detection");
 
     msg.tp_id = tp->taskpool_id;
@@ -252,7 +265,6 @@ static void parsec_termdet_signal_termination(parsec_taskpool_t *tp)
                           sizeof(parsec_termdet_user_trigger_msg_t));
     }
 
-    free(monitor);
     PARSEC_DEBUG_VERBOSE(10, parsec_debug_output, "TERMDET-USER_TRIGGER:\tcall callback");
     tp->tdm.callback(tp);
 }
@@ -301,7 +313,6 @@ static int parsec_termdet_user_trigger_outgoing_message_start(parsec_taskpool_t 
 {
     assert( tp->tdm.module != NULL );
     assert( tp->tdm.module == &parsec_termdet_user_trigger_module.module );
-    assert( tp->tdm.monitor != PARSEC_TERMDET_USER_TRIGGER_TERMINATED );
     /* Nothing to do with the message */
     (void)dst_rank;
     (void)remote_deps;
@@ -316,7 +327,6 @@ static int parsec_termdet_user_trigger_outgoing_message_pack(parsec_taskpool_t *
 {
     assert( tp->tdm.module != NULL );
     assert( tp->tdm.module == &parsec_termdet_user_trigger_module.module );
-    assert( tp->tdm.monitor != PARSEC_TERMDET_USER_TRIGGER_TERMINATED );
     /* No piggybacking */
     (void)dst_rank;
     (void)packed_buffer;
@@ -335,7 +345,6 @@ static int parsec_termdet_user_trigger_incoming_message_start(parsec_taskpool_t 
 {
     assert( tp->tdm.module != NULL );
     assert( tp->tdm.module == &parsec_termdet_user_trigger_module.module );
-    assert( tp->tdm.monitor != PARSEC_TERMDET_USER_TRIGGER_TERMINATED );
     /* No piggybacking */
     (void)src_rank;
     (void)packed_buffer;


### PR DESCRIPTION
This is a backport of fixes made in TESSEOrg/parsec fork. There is a race condition in the termination detector that tries to free the monitor too early. The solution consists in adding an explicit 'unmonitor taskpool' function in the termination detector API and wait that the taskpool is destroyed / recycled to unmonitor the taskpool. This should help solve the issues in the taspool_wait PR too.

  - Amend cherry-pick to fit master
  - fix conflicts during rebase with master
 
