### PR TITLE
Fixes/tls in comm thread

### DIFF
--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -451,7 +451,11 @@ remote_dep_mpi_initialize_execution_stream(parsec_context_t *context)
     memcpy(&parsec_comm_es, context->virtual_processes[0]->execution_streams[0],
            sizeof(parsec_execution_stream_t));
     parsec_comm_es.next_task = (parsec_task_t*)0xdeadbeef;  /* should not be NULL, but it should also never be used */
-    parsec_set_my_execution_stream(&parsec_comm_es);
+    if(1 < context->nb_nodes) {
+        /* if nb_nodes==1, the parsec comm engine does not run with its own thread, so don't change the thread
+         * execution stream to parsec_comm_es. */
+        parsec_set_my_execution_stream(&parsec_comm_es);
+    }
 }
 
 void* remote_dep_dequeue_main(parsec_context_t* context)

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -286,7 +286,6 @@ __parsec_schedule(parsec_execution_stream_t* es,
                   int32_t distance)
 {
     int ret;
-    parsec_task_t *task = tasks_ring;
 
 #if defined(PARSEC_DEBUG_PARANOID) || defined(PARSEC_DEBUG_NOISIER)
     {
@@ -317,9 +316,12 @@ __parsec_schedule(parsec_execution_stream_t* es,
 #endif  /* defined(PARSEC_DEBUG_PARANOID) || defined(PARSEC_DEBUG_NOISIER) */
 
 #if defined(PARSEC_PAPI_SDE)
-    int len = 0;
-    _LIST_ITEM_ITERATOR(task, &task->super, item, {len++; });
-    PARSEC_PAPI_SDE_COUNTER_ADD(PARSEC_PAPI_SDE_TASKS_ENABLED, len);
+    {
+        int len = 0;
+        parsec_task_t *task = tasks_ring;
+        _LIST_ITEM_ITERATOR(task, &task->super, item, {len++; });
+        PARSEC_PAPI_SDE_COUNTER_ADD(PARSEC_PAPI_SDE_TASKS_ENABLED, len);
+    }
 #endif  /* defined(PARSEC_PAPI_SDE) */
 
     ret = parsec_current_scheduler->module.schedule(es, tasks_ring, distance);


### PR DESCRIPTION
Fixes an assert that triggers in debug noisier/paranoid mode after https://github.com/ICLDisco/parsec/pull/422

Also remove a warning about unused variable in scheduling.c
