### PR TITLE
Remove dependency on argv[0]

### DIFF
--- a/contrib/build_with_parsec/dtd_test_allreduce.c
+++ b/contrib/build_with_parsec/dtd_test_allreduce.c
@@ -120,25 +120,27 @@ int main(int argc, char **argv)
     nt = world*10; /* total no. of tiles */
     verbose = 0;
 
-    i = 0;
-    while(NULL != argv[i]) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-n=", 3) ) {
             nt = strtol(argv[i]+3, NULL, 10);
             if( 0 >= nt ) nt = world*10;  /* set to default value */
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v", 2) ) {
             verbose = 1;
-            goto move_and_continue;
+            continue;
         }
         i++;  /* skip this one */
         continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( cores, &pargc, &pargv );
     if( NULL == parsec ) {
         return -1;
     }

--- a/contrib/build_with_parsec/write_check.jdf
+++ b/contrib/build_with_parsec/write_check.jdf
@@ -106,29 +106,30 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-n=", 3) ) {
             n = strtol(argv[i]+3, NULL, 10);
             if( 0 >= n ) n = 1000;  /* set to default value */
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-b=", 3) ) {
             block = strtol(argv[i]+3, NULL, 10);
             if( 0 >= block ) block = 10;  /* set to default value */
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v", 2) ) {
             verbose = 1;
-            goto move_and_continue;
+            continue;
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(-1, &pargc, &pargv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/parsec/CMakeLists.txt
+++ b/parsec/CMakeLists.txt
@@ -23,6 +23,7 @@ set(BASE_SOURCES
   class/parsec_future.c
   class/parsec_datacopy_future.c
   utils/argv.c
+  utils/process_name.c
   utils/cmd_line.c
   utils/colors.c
   utils/parsec_environ.c
@@ -358,6 +359,7 @@ if( PARSEC_WITH_DEVEL_HEADERS )
           ${CMAKE_CURRENT_SOURCE_DIR}/utils/parsec_environ.h
           ${CMAKE_CURRENT_SOURCE_DIR}/utils/mca_param_cmd_line.h
           ${CMAKE_CURRENT_SOURCE_DIR}/utils/os_path.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/utils/process_name.h
           ${CMAKE_CURRENT_SOURCE_DIR}/utils/output.h
           ${CMAKE_CURRENT_SOURCE_DIR}/utils/show_help.h
           ${CMAKE_CURRENT_SOURCE_DIR}/utils/zone_malloc.h

--- a/parsec/utils/process_name.c
+++ b/parsec/utils/process_name.c
@@ -1,0 +1,30 @@
+#include "parsec/parsec_config.h"
+#include <unistd.h>
+#include <string.h>
+#include <limits.h>
+#include <stdio.h>
+
+char *parsec_process_name(void) {
+    char name[PATH_MAX];
+    char *sname = NULL;
+    size_t len = PATH_MAX;
+    int ret;
+#if defined(__APPLE__)
+    ret = _NSGetExecutablePath(name, &len);
+    if(0 != ret) {
+        snprintf(name, len, "parsec-app");
+        return strdup(name);
+    }
+#else
+    ret = readlink("/proc/self/exe", name, len);
+    if(-1 == ret) {
+        snprintf(name, len, "parsec-app" );
+        return strdup(name);
+    }
+    name[ret] = '\0';
+#endif
+    sname = rindex(name, PARSEC_PATH_SEP[0]);
+    if(NULL == sname) return strdup(name);
+    else return strdup(sname+1);
+}
+

--- a/parsec/utils/process_name.h
+++ b/parsec/utils/process_name.h
@@ -1,0 +1,2 @@
+
+PARSEC_DECLSPEC char *parsec_process_name(void);

--- a/tests/api/compose.c
+++ b/tests/api/compose.c
@@ -53,16 +53,22 @@ int main(int argc, char* argv[])
     rank = 0;
 #endif
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-b=", 3) ) {
             block = strtol(argv[i]+3, NULL, 10);
             if( 0 >= block ) block = 10;
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-n=", 3) ) {
             N = strtol(argv[i]+3, NULL, 10);
             if( 0 >= N ) N = 100;
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-h", 2) ) {
             printf("-h: help\n"
@@ -71,14 +77,9 @@ int main(int argc, char* argv[])
                    "-v=<nb> the verbosity level\n");
             exit(0);
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 
-    parsec = parsec_init(1, &argc, &argv);
+    parsec = parsec_init(1, &pargc, &pargv);
     assert( NULL != parsec );
 
     parsec_matrix_block_cyclic_init( &dcA, TYPE, PARSEC_MATRIX_TILE,

--- a/tests/api/touch_ex.c
+++ b/tests/api/touch_ex.c
@@ -27,19 +27,20 @@ int main( int argc, char** argv )
     MPI_Init_thread(NULL, NULL, MPI_THREAD_SERIALIZED, &rc);
 #endif
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-v=", 3) ) {
             verbose = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 
-    parsec = parsec_init(1, &argc, &argv);
+    parsec = parsec_init(1, &pargc, &pargv);
     if( NULL == parsec ) {
         exit(-2);
     }

--- a/tests/apps/haar_tree/main.c
+++ b/tests/apps/haar_tree/main.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
     parsec_walk_taskpool_t *walker;
     parsec_arena_datatype_t adt;
     int do_checks = 0, be_verbose = 0;
-    int pargc = 0, i, dashdash = -1;
+    int pargc = 0, i;
     char **pargv;
     int ret, ch;
     uint64_t cksum = 0;
@@ -167,24 +167,12 @@ int main(int argc, char *argv[])
     for(i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
             pargc = argc - i;
-            pargv = &argv[i];
+            pargv = argv + i;
             break;
         }
     }
-    pargv = malloc( (pargc+1) * sizeof(char*));
-    if( dashdash != -1 ) {
-        if( strcmp(argv[i], "--") == 0 ) {
-            dashdash = i;
-            pargc = 0;
-        } else if( dashdash != -1 ) {
-            pargc++;
-        }
-    } else {
-        pargv[0] = NULL;
-    }
     parsec = parsec_init(1, &pargc, &pargv);
-    free(pargv);
-    
+
     while ((ch = getopt(argc, argv, "xvd:m:M:f:")) != -1) {
         switch (ch) {
         case 'x':

--- a/tests/apps/pingpong/bandwidth.jdf
+++ b/tests/apps/pingpong/bandwidth.jdf
@@ -151,8 +151,8 @@ int main(int argc, char *argv[])
     parsec_taskpool_t* bandwidth_taskpool;
     parsec_bandwidth_taskpool_t* taskpool = NULL;
     int rank, nodes, ch, i;
-    int pargc = 0, dashdash = -1;
-    char **pargv;
+    int pargc = 0;
+    char **pargv = NULL;
     struct timeval tstart, tend;
     double t, bw;
 
@@ -196,27 +196,14 @@ int main(int argc, char *argv[])
 
     for(i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
-            dashdash = i;
-            pargc = 1;
-        } else if( dashdash != -1 ) {
-            pargc++;
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
         }
     }
-    pargv = (char**)malloc( (pargc+2) * sizeof(char*));
-    if( dashdash != -1 ) {
-        pargv[0] = strdup(argv[0]);
-        for(i = dashdash+1; i < argc; i++) {
-            pargv[i-dashdash] = strdup(argv[i]);
-        }
-        pargv[i-dashdash] = NULL;
-    } else {
-        pargv[0] = NULL;
-    }
-
     /* Initialize PaRSEC */
     parsec = parsec_init(cores, &pargc, &pargv);
 
-    free(pargv);
     if( NULL == parsec ) {
         /* Failed to correctly initialize. In a correct scenario report
          * upstream, but in this particular case bail out.

--- a/tests/apps/stencil/testing_stencil_1D.c
+++ b/tests/apps/stencil/testing_stencil_1D.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     for(i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
             pargc = argc - i;
-            pargv = &argv[i];
+            pargv = argv + i;
             break;
         }
     }

--- a/tests/collections/redistribute/common.c
+++ b/tests/collections/redistribute/common.c
@@ -257,7 +257,7 @@ static void parse_arguments(int *_argc, char*** _argv, int* iparam, double *dpar
             case '?': /* getopt_long already printed an error message. */
                 exit(1);
                 break;
-                
+
             default:
                 break; /* Assume anything else is parsec/mpi stuff */
         }
@@ -393,18 +393,10 @@ parsec_context_t* setup_parsec(int argc, char **argv, int *iparam, double *dpara
     SYNC_TIME_START();
 
     /* Once we got out arguments, we should pass whatever is left down */
-    int parsec_argc, idx;
-    char** parsec_argv = (char**)calloc(argc, sizeof(char*));
-    parsec_argv[0] = argv[0];  /* the app name */
-    for( idx = parsec_argc = 1;
-         (idx < argc) && (0 != strcmp(argv[idx], "--")); idx++);
-    if( idx != argc ) {
-        for( parsec_argc = 1, idx++; idx < argc;
-             parsec_argv[parsec_argc] = argv[idx], parsec_argc++, idx++);
-    }
+    int parsec_argc = argc - optind;
+    char** parsec_argv = argv + optind;
     parsec_context_t* ctx = parsec_init(iparam[IPARAM_NCORES],
                                       &parsec_argc, &parsec_argv);
-    free(parsec_argv);
     if( NULL == ctx ) {
         /* Failed to correctly initialize. In a correct scenario report
          * upstream, but in this particular case bail out.

--- a/tests/collections/reduce.c
+++ b/tests/collections/reduce.c
@@ -55,7 +55,7 @@ int main( int argc, char* argv[] )
     for(i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
             pargc = argc - i;
-            pargv = &argv[i];
+            pargv = argv + i;
             break;
         }
     }

--- a/tests/collections/reshape/common.h
+++ b/tests/collections/reshape/common.h
@@ -114,7 +114,7 @@ int reshape_print(parsec_execution_stream_t *es,
     for(int i = 1; i < argc; i++) {                                                      \
         if( strcmp(argv[i], "--") == 0 ) {                                               \
             pargc = argc - i;                                                            \
-            pargv = &argv[i];                                                            \
+            pargv = argv + i;                                                            \
             break;                                                                       \
         }                                                                                \
     }                                                                                    \

--- a/tests/collections/two_dim_band/main.c
+++ b/tests/collections/two_dim_band/main.c
@@ -19,8 +19,8 @@ int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
     int rank, nodes, ch;
-    int pargc = 0, i, dashdash = -1;
-    char **pargv;
+    int pargc = 0, i;
+    char **pargv = NULL;
     parsec_matrix_uplo_t uplo = PARSEC_MATRIX_UPPER; //PARSEC_MATRIX_LOWER
     parsec_matrix_uplo_t full = PARSEC_MATRIX_FULL;
     /* Super */
@@ -42,20 +42,10 @@ int main(int argc, char *argv[])
 
     for(i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
-            dashdash = i;
-            pargc = 0;
-        } else if( dashdash != -1 ) {
-            pargc++;
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
         }
-    }
-    pargv = malloc( (pargc+1) * sizeof(char*));
-    if( dashdash != -1 ) {
-        for(i = dashdash+1; i < argc; i++) {
-            pargv[i-dashdash-1] = strdup(argv[i]);
-        }
-        pargv[i-dashdash-1] = NULL;
-    } else {
-        pargv[0] = NULL;
     }
 
     /* Initialize PaRSEC */

--- a/tests/dsl/dtd/dtd_test_allreduce.c
+++ b/tests/dsl/dtd/dtd_test_allreduce.c
@@ -111,25 +111,25 @@ int main(int argc, char **argv)
     nt = world*10; /* total no. of tiles */
     verbose = 0;
 
-    i = 0;
-    while(NULL != argv[i]) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-n=", 3) ) {
             nt = strtol(argv[i]+3, NULL, 10);
             if( 0 >= nt ) nt = world*10;  /* set to default value */
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v", 2) ) {
             verbose = 1;
-            goto move_and_continue;
+            continue;
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 
-    parsec = parsec_init( cores, &argc, &argv );
+    parsec = parsec_init( cores, &pargc, &pargv );
     if( NULL == parsec ) {
         return -1;
     }

--- a/tests/dsl/dtd/dtd_test_interleave_actions.c
+++ b/tests/dsl/dtd/dtd_test_interleave_actions.c
@@ -104,12 +104,8 @@ int main(int argc, char **argv) {
                 break;
         }
     }
-    pargc = argc - optind + 1;
-    pargv = (char **)malloc((pargc + 1)*sizeof(char *));
-    pargv[0] = argv[0];
-    for(int i = 0; i < argc-optind; i++)
-        pargv[i+1] = argv[optind+i];
-    pargv[pargc] = NULL;
+    pargc = argc - optind;
+    pargv = argv + optind;
 
     #if defined(PARSEC_HAVE_MPI)
    {

--- a/tests/dsl/dtd/dtd_test_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_test_simple_gemm.c
@@ -583,12 +583,8 @@ int main(int argc, char **argv)
                 break;
         }
     }
-    int pargc = argc - optind + 1;
-    char **pargv = (char **)malloc((pargc + 1) * sizeof(char *));
-    pargv[0] = argv[0];
-    for( int i = 0; i < argc - optind; i++ )
-        pargv[i + 1] = argv[optind + i];
-    pargv[pargc] = NULL;
+    int pargc = argc - optind;
+    char **pargv = argv + optind;
 
     if( -1 == P )
         P = (int)sqrt(world);

--- a/tests/dsl/ptg/choice/main.c
+++ b/tests/dsl/ptg/choice/main.c
@@ -22,11 +22,10 @@ int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
     int rank, world, cores = -1;
-    int size, nb, i, j, c, rc;
+    int size, nb, i, c, rc;
     parsec_data_collection_t *dcA;
     int *decision;
     parsec_taskpool_t *choice;
-    char **dargv, ***pargv;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -41,25 +40,18 @@ int main(int argc, char *argv[])
 #endif
 
     size = 256;
-    dargv = NULL;
-    j = 0;
+    int pargc = 0;
+    char **pargv = NULL;
     for(i = 0; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
-            dargv = (char**)calloc( (argc-i+2), sizeof(char *));
-            dargv[j++] = strdup(argv[0]);
-            continue;
-        }
-        if( NULL != dargv ) {
-            dargv[j++] = argv[i];
+            pargc = argc - i;
+            pargv = argv + i;
+            argc = i;
+            break;
         }
     }
-    if( NULL == dargv ) {
-        dargv = (char**)calloc( 2, sizeof(char *));
-        dargv[j++] = strdup(argv[0]);
-    }
-    dargv[j] = NULL;
 
-    if(argc - j <= 1) {
+    if(argc <= 1) {
         nb = 2;
     } else {
         nb = atoi(argv[1]);
@@ -69,8 +61,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    pargv = &dargv;
-    parsec = parsec_init(cores, &j, pargv);
+    parsec = parsec_init(cores, &pargc, &pargv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/complex_deps.jdf
+++ b/tests/dsl/ptg/complex_deps.jdf
@@ -118,28 +118,29 @@ int main( int argc, char** argv )
     int rank = 0, size = 1, mat_size, cores = -1;
     long time_elapsed;
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-i=", 3) ) {
             ni = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-k=", 3) ) {
             nk = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v=", 3) ) {
             verbose = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-c=", 3) ) {
             cores = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 #ifdef DISTRIBUTED
     {
@@ -149,7 +150,7 @@ int main( int argc, char** argv )
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif  /* DISTRIBUTED */
-    parsec = parsec_init(cores, &argc, &argv);
+    parsec = parsec_init(cores, &pargc, &pargv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/cuda/stage_main.c
+++ b/tests/dsl/ptg/cuda/stage_main.c
@@ -13,7 +13,7 @@ parsec_taskpool_t* testing_stage_custom_New( parsec_context_t *ctx, int M, int N
 int main(int argc, char *argv[])
 {
     int pargc = 0;
-    char **pargv;
+    char **pargv = NULL;
     parsec_context_t *parsec = NULL;
     parsec_taskpool_t *tp;
     int i;
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     for(i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
             pargc = argc - i;
-            pargv = &argv[i];
+            pargv = argv + i;
             break;
         }
     }

--- a/tests/dsl/ptg/cuda/testing_get_best_device.c
+++ b/tests/dsl/ptg/cuda/testing_get_best_device.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     for(int i = 1; i < argc; i++) {
         if( strcmp(argv[i], "--") == 0 ) {
             pargc = argc - i;
-            pargv = &argv[i];
+            pargv = argv + i;
             break;
         }
     }

--- a/tests/dsl/ptg/ptgpp/write_check.jdf
+++ b/tests/dsl/ptg/ptgpp/write_check.jdf
@@ -89,29 +89,30 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-n=", 3) ) {
             n = strtol(argv[i]+3, NULL, 10);
             if( 0 >= n ) n = 1000;  /* set to default value */
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-b=", 3) ) {
             block = strtol(argv[i]+3, NULL, 10);
             if( 0 >= block ) block = 10;  /* set to default value */
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v", 2) ) {
             verbose = 1;
-            goto move_and_continue;
+            continue;
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(-1, &pargc, &pargv);
     if( NULL == parsec ) {
         exit(-1);
     }

--- a/tests/dsl/ptg/startup.jdf
+++ b/tests/dsl/ptg/startup.jdf
@@ -103,31 +103,32 @@ int main( int argc, char** argv )
     }
 #endif
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-i=", 3) ) {
             ni = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-j=", 3) ) {
             nj = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-k=", 3) ) {
             nk = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v=", 3) ) {
             verbose = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(-1, &pargc, &pargv);
     if( NULL == parsec ) {
        exit(-1);
     }

--- a/tests/dsl/ptg/strange.jdf
+++ b/tests/dsl/ptg/strange.jdf
@@ -94,24 +94,25 @@ int main(int argc, char* argv[] )
     /* We want a non-deterministic behavior unless requested via args */
     srand(time(NULL));
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-deterministic", 7) ) {
             srand(n);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-n=", 3) ) {
             n = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v", 2) ) {
             verbose++;
-            goto move_and_continue;
+            continue;
         }
-        i++;
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
     neworder = calloc(n, sizeof(struct prev_next_s));
     for( i = 0; i < n; i++ ) {
@@ -154,7 +155,7 @@ int main(int argc, char* argv[] )
     }
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    parsec = parsec_init(-1, &pargc, &pargv);
     assert( NULL != parsec );
 
     parsec_matrix_block_cyclic_init( &descA, TYPE, PARSEC_MATRIX_TILE,

--- a/tests/profiling/async.jdf
+++ b/tests/profiling/async.jdf
@@ -177,18 +177,12 @@ int main( int argc, char** argv )
     exit(1);
 #endif
 
-    parsec_argv = (char **)malloc(parsec_argc * sizeof(char*));
-    parsec_argv[0] = argv[0];
-    parsec_argc = 1;
     for(arg = 1; arg < argc; arg++) {
         if(strcmp(argv[arg], "--") == 0)
             break;
     }
-    if( arg < argc ) {
-        for(arg = arg+1; arg < argc; arg++)
-            parsec_argv[parsec_argc++] = argv[arg];
-    }
-    parsec_argv[parsec_argc] = NULL;
+    parsec_argc = argc - arg;
+    parsec_argv = argv + arg;
 
     if( argc > 1 &&
         ( (strcmp(argv[1], "-v") == 0 ) ||

--- a/tests/runtime/multichain.jdf
+++ b/tests/runtime/multichain.jdf
@@ -128,36 +128,42 @@ int main(int argc, char* argv[])
     parsec_datatype_t baseType, newtype;
     MPI_Comm comm;
 
-    while( NULL != argv[i] ) {
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
         if( 0 == strncmp(argv[i], "-i=", 3) ) {
             ni = strtol(argv[i]+3, NULL, 10);
             if( 0 >= ni ) ni = NN;
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-j=", 3) ) {
             nj = strtol(argv[i]+3, NULL, 10);
             if( 0 >= nj ) nj = NN;
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-v=", 3) ) {
             verbose = strtol(argv[i]+3, NULL, 10);
             if( 0 > verbose ) verbose = 0;
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-s=", 3) ) {
             sleep_between_comms = strtol(argv[i]+3, NULL, 10);
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-c=", 3) ) {
             max_comms = strtol(argv[i]+3, NULL, 10);
             if(max_comms > 6) max_comms = 6;
             if(max_comms < 1) max_comms = 1;
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-l=", 3) ) {
             loops = strtol(argv[i]+3, NULL, 10);
             if( 0 >= loops ) loops = 5;
-            goto move_and_continue;
+            continue;
         }
         if( 0 == strncmp(argv[i], "-h", 2) ) {
             printf("-h: help\n"
@@ -169,11 +175,6 @@ int main(int argc, char* argv[])
                    "-v=<nb> the verbosity level\n");
             exit(0);
         }
-        i++;  /* skip this one */
-        continue;
-    move_and_continue:
-        memmove(&argv[i], &argv[i+1], (argc - 1) * sizeof(char*));
-        argc -= 1;
     }
 #ifdef DISTRIBUTED
     {
@@ -184,7 +185,7 @@ int main(int argc, char* argv[])
     }
     create_communicators();
 #endif  /* DISTRIBUTED */
-    parsec = parsec_init(2, &argc, &argv);
+    parsec = parsec_init(2, &pargc, &pargv);
     assert( NULL != parsec );
 
     for( i = 0; i < max_comms; i++ ) {

--- a/tests/runtime/scheduling/main.c
+++ b/tests/runtime/scheduling/main.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     for(int a = 1; a < argc; a++) {
         if(strcmp(argv[a], "--") == 0) {
             parsec_argc = argc - a;
-            parsec_argv = &argv[a];
+            parsec_argv = argv + a;
             break;
         }
         if(strcmp(argv[a], "-t") == 0) {


### PR DESCRIPTION
Remove the dependency on ARGV[0] by getting the app name from somewhere else. 

- [x] change the examples to not copy argv0 everywhere now that it is unnecessary. 
- [x] test on OSX
- [x] test on windows WSL
- [ ] test on windows Visual Studio/native

fixes #431 