### PR TITLE
GPU task completion delegated to a different thread

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_component.c
+++ b/parsec/mca/device/cuda/device_cuda_component.c
@@ -41,6 +41,7 @@ char* parsec_cuda_lib_path = NULL;
 
 static int cuda_mask, cuda_nvlink_mask;
 
+int parsec_cuda_delegate_task_completion = 0;
 
 /*
  * Instantiate the public struct with all of our public information
@@ -200,6 +201,10 @@ static int device_cuda_component_register(void)
                                         "Boolean to separate the profiling of each cuda stream into a single profiling stream",
                                         false, false, 0, &parsec_device_gpu_one_profiling_stream_per_gpu_stream);
 #endif
+
+    (void)parsec_mca_param_reg_int_name("device_cuda", "delegate_task_completion",
+                                        "Integer to choose the whether task completion should be done by a manager thread (default is no)",
+                                        false, false, 0, &parsec_cuda_delegate_task_completion);
 
     /* If CUDA was not requested avoid initializing the devices */
     return (0 == parsec_device_cuda_enabled ? MCA_ERROR : MCA_SUCCESS);

--- a/parsec/mca/device/cuda/device_cuda_internal.h
+++ b/parsec/mca/device/cuda/device_cuda_internal.h
@@ -19,6 +19,8 @@ extern int parsec_cuda_sort_pending, parsec_cuda_max_streams;
 extern int parsec_cuda_memory_block_size, parsec_cuda_memory_percentage, parsec_cuda_memory_number_of_blocks;
 extern char* parsec_cuda_lib_path;
 
+extern int parsec_cuda_delegate_task_completion; 
+
 PARSEC_DECLSPEC extern const parsec_device_module_t parsec_device_cuda_module;
 
 int parsec_cuda_module_init( int device, parsec_device_module_t** module );

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -45,8 +45,6 @@ parsec_cuda_memory_reserve( parsec_device_cuda_module_t* gpu_device,
 static int parsec_cuda_memory_release( parsec_device_cuda_module_t* gpu_device );
 static int parsec_cuda_flush_lru( parsec_device_module_t *device );
 
-extern int parsec_cuda_delegate_task_completion; 
-
 /* look up how many FMA per cycle in single/double, per cuda MP
  * precision.
  * The following table provides updated values for future archs
@@ -2737,7 +2735,9 @@ parsec_cuda_kernel_scheduler( parsec_execution_stream_t *es,
     gpu_device->super.executed_tasks++;
 
     if( parsec_cuda_delegate_task_completion == 0 )
+    {
         __parsec_complete_execution( es, gpu_task->ec );
+    }
     else
     {
         gpu_task->ec->priority = INT32_MAX;  /* Assign maximum priority */

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -487,6 +487,9 @@ int __parsec_task_progress( parsec_execution_stream_t* es,
         if(task->status <= PARSEC_TASK_STATUS_HOOK) {
             rc = __parsec_execute( es, task );
         }
+        else if(task->status == PARSEC_TASK_STATUS_COMPLETE) { // To deal with task completion of the GPU tasks
+            rc = PARSEC_HOOK_RETURN_DONE;
+        }
         /* We're good to go ... */
         switch(rc) {
         case PARSEC_HOOK_RETURN_DONE:    /* This execution succeeded */


### PR DESCRIPTION
The GPU manager thread delegates the task completion to a compute thread. Setting mca parameter `device_cuda_delegate_task_completion = 1` will enable this functionality.