### PR TITLE
Fix statistics management with multiple GPU.

### DIFF
--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -304,7 +304,7 @@ void dump_exec_stream(parsec_gpu_exec_stream_t* exec_stream)
 void dump_GPU_state(parsec_device_gpu_module_t* gpu_device)
 {
     int i;
-    uint64_t data_in = 0, data_in_host = 0, data_in_dev = 0;
+    uint64_t data_in, data_in_host, data_in_dev = 0;
 
     data_in = gpu_device->super.data_in_from_device[0];
     data_in_host = gpu_device->super.data_in_from_device[0];


### PR DESCRIPTION
The data_in_array_size was initialized using parsec_nb_devices, but that variable is not constant until all the devices have been added to a context. Thus, each module was having statistics arrays with different sizes. This patch delays the statistics arrays allocation until the end of the device registration, a moment where we know how many devices are overall.

Fixes #446 