### PR TITLE
Increase function name length limit in debug output

### DIFF
--- a/parsec/utils/debug.h
+++ b/parsec/utils/debug.h
@@ -149,7 +149,7 @@ extern void (*parsec_weaksym_exit)(int status);
 #else
 #define PARSEC_DEBUG_VERBOSE(LVL, OUT, FMT, ...) do {                \
     parsec_output_verbose(LVL, OUT,                                  \
-        "%.*sd@%05d%.*s " FMT " %.*s@%.30s:%-5d%.*s",                \
+        "%.*sd@%05d%.*s " FMT " %.*s@%.64s:%-5d%.*s",                \
         parsec_debug_colorize, "\x1B[0;37;44m", parsec_debug_rank,   \
         parsec_debug_colorize, "\033[0m", ##__VA_ARGS__,             \
         parsec_debug_colorize, "\x1B[36m", __func__, __LINE__,       \


### PR DESCRIPTION
No need to truncate at 30 characters, terminals can handle more than that. 64 characters should be sufficient to cover most parsec library functions. There are some functions in `libparsec.so` that seem to come from JDF but I'm not sure we care about them...

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>