### PR TITLE
Comm engine register unregister

### DIFF
--- a/parsec/mca/termdet/fourcounter/termdet_fourcounter_component.c
+++ b/parsec/mca/termdet/fourcounter/termdet_fourcounter_component.c
@@ -69,6 +69,20 @@ mca_base_component_t *termdet_fourcounter_static_component(void)
 
 /* set to 1 when the callback is registered -- workaround current MCA interface limitation */
 static int parsec_termdet_fourcounter_msg_cb_registered = 0;
+static int32_t parsec_termdet_fourcounter_msg_cb_id = 0;
+
+static void parsec_termdet_fourcounter_ce_up(parsec_comm_engine_t *ce, void *user_data)
+{
+    int rc = ce->tag_register(PARSEC_TERMDET_FOURCOUNTER_MSG_TAG, parsec_termdet_fourcounter_msg_dispatch, user_data,
+                              PARSEC_TERMDET_FOURCOUNTER_MAX_MSG_SIZE);
+    (void)rc;
+}
+
+static void parsec_termdet_fourcounter_ce_down(parsec_comm_engine_t *ce, void *user_data)
+{
+    (void)user_data;
+    ce->tag_unregister(PARSEC_TERMDET_FOURCOUNTER_MSG_TAG);
+}
 
 static int termdet_fourcounter_component_query(mca_base_module_t **module, int *priority)
 {
@@ -78,12 +92,13 @@ static int termdet_fourcounter_component_query(mca_base_module_t **module, int *
     *module = (mca_base_module_t *)ptr;
 
     if( 0 == parsec_termdet_fourcounter_msg_cb_registered ) {
-        int rc = parsec_ce.tag_register(PARSEC_TERMDET_FOURCOUNTER_MSG_TAG, parsec_termdet_fourcounter_msg_dispatch, ptr,
-                                        PARSEC_TERMDET_FOURCOUNTER_MAX_MSG_SIZE);
-        (void)rc;
+        assert(0 == parsec_termdet_fourcounter_msg_cb_id);
+        parsec_termdet_fourcounter_msg_cb_id = 
+            parsec_comm_engine_register_callback(parsec_termdet_fourcounter_ce_up, ptr,
+                                                 parsec_termdet_fourcounter_ce_down, ptr);
         PARSEC_OBJ_CONSTRUCT(&parsec_termdet_fourcounter_delayed_messages, parsec_list_t);
-        parsec_termdet_fourcounter_msg_cb_registered++;
     }
+    parsec_termdet_fourcounter_msg_cb_registered++;
     
     return MCA_SUCCESS;
 }
@@ -92,7 +107,8 @@ static int termdet_fourcounter_component_close()
 {
     parsec_termdet_fourcounter_msg_cb_registered--;
     if( 0 == parsec_termdet_fourcounter_msg_cb_registered ) {
-        parsec_ce.tag_unregister(PARSEC_TERMDET_FOURCOUNTER_MSG_TAG);
+        parsec_comm_engine_unregister_callback(parsec_termdet_fourcounter_msg_cb_id);
+        parsec_termdet_fourcounter_msg_cb_id = 0;
         PARSEC_OBJ_DESTRUCT(&parsec_termdet_fourcounter_delayed_messages);
     }
     return MCA_SUCCESS;

--- a/parsec/parsec_comm_engine.c
+++ b/parsec/parsec_comm_engine.c
@@ -8,6 +8,17 @@
 #include "parsec/parsec_mpi_funnelled.h"
 
 parsec_comm_engine_t parsec_ce;
+static parsec_list_t *parsec_ce_callback_list = NULL;
+static int32_t parsec_ce_callback_nextid = 1;
+
+typedef struct {
+    parsec_list_item_t super;
+    int callback_id;
+    parsec_comm_engine_updown_fn_t *up;
+    void *up_data;
+    parsec_comm_engine_updown_fn_t *down;
+    void *down_data;
+} parsec_comm_engine_callback_item_t;
 
 /* This function will be called by the runtime */
 parsec_comm_engine_t *
@@ -17,12 +28,93 @@ parsec_comm_engine_init(parsec_context_t *parsec_context)
     parsec_comm_engine_t *ce = mpi_funnelled_init(parsec_context);
 
     assert(ce->capabilites.sided > 0 && ce->capabilites.sided < 3);
+
+    if(NULL == parsec_ce_callback_list)
+        parsec_ce_callback_list = PARSEC_OBJ_NEW(parsec_list_t);
+
+    for(parsec_list_item_t *item = PARSEC_LIST_ITERATOR_FIRST(parsec_ce_callback_list);
+        item != PARSEC_LIST_ITERATOR_END(parsec_ce_callback_list);
+        item = PARSEC_LIST_ITERATOR_NEXT(item)) {
+        parsec_comm_engine_callback_item_t *ce_item = (parsec_comm_engine_callback_item_t*)item;
+        if(NULL != ce_item->up) {
+            ce_item->up(ce, ce_item->up_data);
+        }
+    }
+
     return ce;
 }
 
 int
 parsec_comm_engine_fini(parsec_comm_engine_t *comm_engine)
 {
+    if(NULL != parsec_ce_callback_list) {
+        for(parsec_list_item_t *item = PARSEC_LIST_ITERATOR_FIRST(parsec_ce_callback_list);
+            item != PARSEC_LIST_ITERATOR_END(parsec_ce_callback_list);
+            item = PARSEC_LIST_ITERATOR_NEXT(item)) {
+            parsec_comm_engine_callback_item_t *ce_item = (parsec_comm_engine_callback_item_t*)item;
+            if(NULL != ce_item->down) {
+                ce_item->down(comm_engine, ce_item->down_data);
+            }
+        }
+    }
+
     /* call the selected module fini */
     return mpi_funnelled_fini(comm_engine);
+}
+
+int32_t parsec_comm_engine_register_callback(parsec_comm_engine_updown_fn_t *up,
+                                             void *up_data,
+                                             parsec_comm_engine_updown_fn_t *down,
+                                             void *down_data)
+{
+    parsec_comm_engine_callback_item_t *new_item = malloc(sizeof(parsec_comm_engine_callback_item_t));
+    PARSEC_OBJ_CONSTRUCT(new_item, parsec_list_item_t);
+    PARSEC_LIST_ITEM_SINGLETON(new_item);
+    new_item->callback_id = parsec_atomic_fetch_inc_int32(&parsec_ce_callback_nextid);
+    new_item->up = up;
+    new_item->up_data = up_data;
+    new_item->down = down;
+    new_item->down_data = down_data;
+
+    if(NULL == parsec_ce_callback_list) {
+        parsec_ce_callback_list = PARSEC_OBJ_NEW(parsec_list_t);
+    }
+
+    parsec_list_append(parsec_ce_callback_list, &new_item->super);
+
+    if(NULL != parsec_ce.tag_register && NULL != up) {
+        up(&parsec_ce, up_data);
+    }
+
+    return new_item->callback_id;
+}
+
+int parsec_comm_engine_unregister_callback(int32_t callback_id)
+{
+    parsec_list_item_t *item = NULL;
+    parsec_comm_engine_callback_item_t *ce_item = NULL;
+
+    if(NULL == parsec_ce_callback_list)
+        return PARSEC_ERR_NOT_FOUND;
+    parsec_list_lock(parsec_ce_callback_list);
+    for(item = PARSEC_LIST_ITERATOR_FIRST(parsec_ce_callback_list);
+        item != PARSEC_LIST_ITERATOR_END(parsec_ce_callback_list);
+        item = PARSEC_LIST_ITERATOR_NEXT(item)) {
+        ce_item = (parsec_comm_engine_callback_item_t*)item;
+        if(callback_id == ce_item->callback_id) {
+            parsec_list_nolock_remove(parsec_ce_callback_list, item);
+            break;
+        }
+    }
+    parsec_list_unlock(parsec_ce_callback_list);
+    if(item == PARSEC_LIST_ITERATOR_END(parsec_ce_callback_list))
+        return PARSEC_ERR_NOT_FOUND;
+    if(parsec_list_is_empty(parsec_ce_callback_list)) {
+        PARSEC_OBJ_RELEASE(parsec_ce_callback_list);
+        parsec_ce_callback_list = NULL;
+    }
+    if(NULL != ce_item->down && NULL != parsec_ce.tag_unregister) {
+        ce_item->down(&parsec_ce, ce_item->down_data);
+    }
+    return PARSEC_SUCCESS;
 }

--- a/parsec/parsec_comm_engine.h
+++ b/parsec/parsec_comm_engine.h
@@ -11,6 +11,8 @@
 #include "parsec/runtime.h"
 #include "parsec/datatype.h"
 
+BEGIN_C_DECLS
+
 typedef enum {
     PARSEC_MEM_TYPE_CONTIGUOUS = 0,
     PARSEC_MEM_TYPE_NONCONTIGUOUS = 1
@@ -34,6 +36,8 @@ typedef enum {
     PARSEC_CE_REMOTE_DEP_PUT_END_TAG,
     PARSEC_TERMDET_FOURCOUNTER_MSG_TAG,
     PARSEC_TERMDET_USER_TRIGGER_MSG_TAG,
+    PARSEC_DSL_TTG_TAG,
+    PARSEC_DSL_TTG_RMA_TAG,
     PARSEC_CE_REMOTE_DEP_MAX_CTRL_TAG
 } parsec_remote_dep_tag_t;
 
@@ -221,5 +225,21 @@ int32_t parsec_comm_engine_register_callback(parsec_comm_engine_updown_fn_t *up,
  * @note will call the down callback if there is an active parsec comm engine
  */
 int parsec_comm_engine_unregister_callback(int32_t callback_id);
+
+/**
+ * @brief The comm engine implementation calls this function after the 
+ *    pre-defined tags are registered. This function iterates over the
+ *    registered callbacks to call the 'up' one.
+ */
+void parsec_comm_engine_callbacks_up(void);
+
+/**
+ * @brief The comm engine implementation calls this function before the
+ *     pre-defined tags are unregistered. This function iterates over the
+ *     registered callback to call the 'down' one.
+ */
+void parsec_comm_engine_callbacks_down(void);
+
+END_C_DECLS
 
 #endif /* __USE_PARSEC_COMM_ENGINE_H__ */

--- a/parsec/parsec_comm_engine.h
+++ b/parsec/parsec_comm_engine.h
@@ -187,4 +187,39 @@ PARSEC_DECLSPEC extern parsec_comm_engine_t parsec_ce;
 parsec_comm_engine_t * parsec_comm_engine_init(parsec_context_t *parsec_context);
 int parsec_comm_engine_fini(parsec_comm_engine_t *comm_engine);
 
+/**
+ * @brief parsec_ce up or down callback function prototype
+ */
+typedef void (parsec_comm_engine_updown_fn_t)(parsec_comm_engine_t *comm_engine, void *user_data);
+
+/**
+ * @brief Registers a couple of callbacks to call when a communication engine is turning 
+ *   up or down. Those callbacks are appropriate places for DSLs or other modules to 
+ *   register and de-register tags. 
+ * 
+ * @param up: what function to call when the comm engine is turned on (can be NULL if 
+ *   no function is to be called)
+ * @param up_data: a user-defined object that will be passed to the up callback 
+ * @param down: what function to call when the comm engine is turned off (can be NULL if 
+ *   no function is to be called)
+ * @param down_data: a user-defined object that will be passed to the down callback 
+ * @return int32_t: a callback identifier to unregister the callbacks, or an error (negative
+ *   value) if there was an issue.
+ * @note will call the up callback if there is an active parsec comm engine
+ */
+int32_t parsec_comm_engine_register_callback(parsec_comm_engine_updown_fn_t *up,
+                                             void *up_data,
+                                             parsec_comm_engine_updown_fn_t *down,
+                                             void *down_data);
+
+/**
+ * @brief Unregisters communication engine callbacks that were registered before
+ * 
+ * @param callback_id: the identifier of the callback as returned by 
+ *    @fn parsec_comm_engine_register_callback
+ * @return int PARSEC_SUCCESS on success, or a parsec error code on failure
+ * @note will call the down callback if there is an active parsec comm engine
+ */
+int parsec_comm_engine_unregister_callback(int32_t callback_id);
+
 #endif /* __USE_PARSEC_COMM_ENGINE_H__ */

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -457,6 +457,8 @@ remote_dep_mpi_initialize_execution_stream(parsec_context_t *context)
          * execution stream to parsec_comm_es. */
         parsec_set_my_execution_stream(&parsec_comm_es);
     }
+
+    parsec_comm_engine_callbacks_up();
 }
 
 void* remote_dep_dequeue_main(parsec_context_t* context)
@@ -2195,6 +2197,8 @@ remote_dep_ce_fini(parsec_context_t* context)
 {
     remote_dep_mpi_profiling_fini();
 
+    parsec_comm_engine_callbacks_down();
+    
     // Unregister tags
     parsec_ce.tag_unregister(PARSEC_CE_REMOTE_DEP_ACTIVATE_TAG);
     parsec_ce.tag_unregister(PARSEC_CE_REMOTE_DEP_GET_DATA_TAG);


### PR DESCRIPTION
This defines a set of helper functions to register / unregister callbacks that are called when a communication engine is up or when it is teared down.

Currently, the termination detectors that use active messages do not work since the lazy initialization of the communication engine. If the user tears down a comm engine, and creates a new one, non-predefined tags are also not re-registered.

This provides a mechanism so that the different levels of software are notified that this happens, and can react by de-registering their tags and re-registering them.

It is one of the PRs that we need to consider for porting TTG over parsec master.
