### PR TITLE
Fix profile dtd

### DIFF
--- a/parsec/mca/pins/task_profiler/pins_task_profiler_module.c
+++ b/parsec/mca/pins/task_profiler/pins_task_profiler_module.c
@@ -12,6 +12,7 @@
 #include "parsec/profiling.h"
 #include "parsec/execution_stream.h"
 #include "parsec/interfaces/dtd/insert_function_internal.h"
+#include "parsec/parsec_binary_profile.h"
 
 int release_deps_trace_keyin;
 int release_deps_trace_keyout;

--- a/parsec/mca/pins/task_profiler/pins_task_profiler_module.c
+++ b/parsec/mca/pins/task_profiler/pins_task_profiler_module.c
@@ -238,7 +238,7 @@ task_profiler_exec_count_begin(struct parsec_execution_stream_s*   es,
     if (NULL != task->taskpool->profiling_array &&
         task->task_class->task_class_id < task->taskpool->nb_task_classes)
         PARSEC_TASK_PROF_TRACE_FLAGS(es->es_profile,
-                               task->taskpool->profiling_array[2*task->task_class->task_class_id+1],
+                               task->taskpool->profiling_array[START_KEY(task->task_class->task_class_id)],
                                task,
                                PARSEC_PROFILING_EVENT_TIME_AT_END);
     (void)cb_data;
@@ -252,7 +252,7 @@ task_profiler_exec_count_end(struct parsec_execution_stream_s*   es,
     if (NULL != task->taskpool->profiling_array &&
         task->task_class->task_class_id < task->taskpool->nb_task_classes)
         PARSEC_TASK_PROF_TRACE_FLAGS(es->es_profile,
-                               task->taskpool->profiling_array[2*task->task_class->task_class_id+1],
+                               task->taskpool->profiling_array[END_KEY(task->task_class->task_class_id)],
                                task,
                                PARSEC_PROFILING_EVENT_TIME_AT_START);
     (void)cb_data;

--- a/tools/profiling/python/pbt2ptt.pyx
+++ b/tools/profiling/python/pbt2ptt.pyx
@@ -331,7 +331,7 @@ cpdef read(filenames, report_progress=False, skeleton_only=False, multiprocess=F
 
 
 cpdef convert(filenames, out=None, unlink=False, multiprocess=True,
-              force_reconvert=False, validate_existing=False,
+              force_reconvert=True, validate_existing=False,
               table=False, append=False, report_progress=False,
               add_info=dict(), compress=('blosc', 0), skeleton_only=False,
               version=1):
@@ -345,11 +345,13 @@ cpdef convert(filenames, out=None, unlink=False, multiprocess=True,
 
     skeleton_only, multiprocess, report_progress, add_info -- see docs for "read()"
 
-    force_reconvert (False) -- causes conversion to happen even if a converted trace is determined to already exist.
+    force_reconvert (True) -- causes conversion to happen even if a converted trace is determined to already exist.
     This is usually determined by a simple match of the default generated output filename.
-    This (hopefully) simplifies significantly the mental/organiziational workload of the user,
-    as traces can simply be "re-converted" each time from the binary trace without performing the
-    actual conversion, while still allowing for a manual override in cases where that is necessary.
+    This was supposed to simplify the mental/organiziational workload of the user,
+    as traces could simply be "re-converted" each time from the binary trace without performing the
+    actual conversion, but it proved completely counter-intuitive with experience. We keep the possibility
+    of reconverting by letting the user pass force_reconvert=False if they want it, but it is now enabled
+    by default (meaning each target trace will be created from scratch at each invokation of the tool).
 
     validate_existing (False) -- requires a successful load of an existing converted trace, instead of just a filename match.
 


### PR DESCRIPTION
Two issues:
  - fix issue #474 by using the appropriate macros to compute the event begin and end index
  - finally disable the feature in profile2h5 that would make it not re-generate HDF5 files if they existed. This has proven confusing one time too many, I think it's time to revert the default and have a 'normal' default behavior (i.e. if we're called to generate the trace we generate the trace even if we believe the job is done already)

