### PR TITLE
Use the profiling key macros

### DIFF
--- a/parsec/data_dist/matrix/map_operator.c
+++ b/parsec/data_dist/matrix/map_operator.c
@@ -10,6 +10,7 @@
 #include "parsec/remote_dep.h"
 #include "parsec/data_dist/matrix/matrix.h"
 #include "parsec/parsec_prof_grapher.h"
+#include "parsec/parsec_binary_profile.h"
 #include "parsec/scheduling.h"
 #include "parsec/datarepo.h"
 #include "parsec/mca/device/device.h"
@@ -326,7 +327,7 @@ static int hook_of(parsec_execution_stream_t *es,
 
 #if !defined(PARSEC_PROF_DRY_BODY)
     PARSEC_TASK_PROF_TRACE(es->es_profile,
-                           this_task->taskpool->profiling_array[2 * this_task->task_class->task_class_id],
+                           this_task->taskpool->profiling_array[START_KEY(this_task->task_class->task_class_id)],
                            (parsec_task_t *) this_task);
     rc = __tp->op( es, src_data, dest_data, __tp->op_data, m, n );
 #endif
@@ -343,7 +344,7 @@ static int complete_hook(parsec_execution_stream_t *es,
     (void)k; (void)n; (void)__tp;
 
     PARSEC_TASK_PROF_TRACE(es->es_profile,
-                           this_task->taskpool->profiling_array[2 * this_task->task_class->task_class_id+1],
+                           this_task->taskpool->profiling_array[END_KEY(this_task->task_class->task_class_id)],
                            (parsec_task_t *) this_task);
 
 #if defined(PARSEC_PROF_GRAPHER)
@@ -502,8 +503,8 @@ __parsec_map_operator_constructor(parsec_map_operator_taskpool_t* tp )
     if( -1 == parsec_map_operator_profiling_array[0] ) {
         parsec_profiling_add_dictionary_keyword("operator", "fill:CC2828",
                                                 sizeof(parsec_task_prof_info_t), PARSEC_TASK_PROF_INFO_CONVERTOR,
-                                                (int*)&tp->super.profiling_array[0 + 2 * parsec_map_operator.task_class_id],
-                                                (int*)&tp->super.profiling_array[1 + 2 * parsec_map_operator.task_class_id]);
+                                                (int*)&tp->super.profiling_array[START_KEY(parsec_map_operator.task_class_id)],
+                                                (int*)&tp->super.profiling_array[END_KEY(parsec_map_operator.task_class_id)]);
     }
 #endif /* defined(PARSEC_PROF_TRACE) */
 }

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -50,7 +50,7 @@
 #include "parsec/interfaces/interface.h"
 #include "parsec/interfaces/dtd/insert_function.h"
 #include "parsec/interfaces/dtd/insert_function_internal.h"
-#include "parsec/parsec_prof_grapher.h"
+#include "parsec/parsec_binary_profile.h"
 #include "parsec/utils/colors.h"
 #include "parsec/mca/pins/pins.h"
 #include "parsec/utils/debug.h"
@@ -715,10 +715,8 @@ parsec_dtd_add_profiling_info(parsec_taskpool_t *tp,
     char *str = fill_color(task_class_id, PARSEC_DTD_NB_TASK_CLASSES);
     parsec_profiling_add_dictionary_keyword(name, str,
                                             sizeof(parsec_task_prof_info_t), PARSEC_TASK_PROF_INFO_CONVERTOR,
-                                            (int *)&tp->profiling_array[0 +
-                                                                        2 * task_class_id]  /* start key */,
-                                            (int *)&tp->profiling_array[1 +
-                                                                        2 * task_class_id]  /*  end key */ );
+                                            (int *)&tp->profiling_array[START_KEY(task_class_id)]  /* start key */,
+                                            (int *)&tp->profiling_array[END_KEY(task_class_id)]  /*  end key */ );
     free(str);
 }
 
@@ -1751,7 +1749,7 @@ complete_hook_of_dtd(parsec_execution_stream_t *es,
 #endif /* defined(PARSEC_PROF_GRAPHER) */
 
     PARSEC_TASK_PROF_TRACE(es->es_profile,
-                           this_task->taskpool->profiling_array[2 * this_task->task_class->task_class_id + 1],
+                           this_task->taskpool->profiling_array[END_KEY(this_task->task_class->task_class_id)],
                            this_task);
 
     /* constructing action_mask for all flows of local task */

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -879,8 +879,8 @@ static char *dump_profiling_init(void **elem, void *arg)
                             "parsec_profiling_add_dictionary_keyword(\"%s::%s::internal init\", \"fill:%02X%02X%02X\",\n"
                             "                                       0,\n"
                             "                                       NULL,\n"
-                            "                                       (int*)&__parsec_tp->super.super.profiling_array[0 + 2 * %s_%s.task_class_id  + 2 * PARSEC_%s_NB_TASK_CLASSES/* %s (internal init) start key */],\n"
-                            "                                       (int*)&__parsec_tp->super.super.profiling_array[1 + 2 * %s_%s.task_class_id  + 2 * PARSEC_%s_NB_TASK_CLASSES/* %s (internal init) end key */]);\n"
+                            "                                       (int*)&__parsec_tp->super.super.profiling_array[START_KEY(%s_%s.task_class_id  + PARSEC_%s_NB_TASK_CLASSES)/* %s (internal init) start key */],\n"
+                            "                                       (int*)&__parsec_tp->super.super.profiling_array[END_KEY(%s_%s.task_class_id  + PARSEC_%s_NB_TASK_CLASSES)/* %s (internal init) end key */]);\n"
                             "#endif /* defined(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT) */\n",
                             jdf_basename, fname, 256-R, 256-G, 256-B,
                             jdf_basename, fname, jdf_basename, fname,
@@ -889,8 +889,8 @@ static char *dump_profiling_init(void **elem, void *arg)
                             "parsec_profiling_add_dictionary_keyword(\"%s::%s\", \"fill:%02X%02X%02X\",\n"
                             "                                       sizeof(parsec_task_prof_info_t)+%d*sizeof(parsec_assignment_t),\n"
                             "                                       \"%s\",\n"
-                            "                                       (int*)&__parsec_tp->super.super.profiling_array[0 + 2 * %s_%s.task_class_id /* %s start key */],\n"
-                            "                                       (int*)&__parsec_tp->super.super.profiling_array[1 + 2 * %s_%s.task_class_id /* %s end key */]);\n",
+                            "                                       (int*)&__parsec_tp->super.super.profiling_array[START_KEY(%s_%s.task_class_id) /* %s start key */],\n"
+                            "                                       (int*)&__parsec_tp->super.super.profiling_array[END_KEY(%s_%s.task_class_id) /* %s end key */]);\n",
                             jdf_basename, fname, R, G, B,
                             nb_locals,
                             string_arena_get_string(profiling_convertor_params),
@@ -1506,6 +1506,7 @@ static void jdf_minimal_code_before_prologue(const jdf_t *jdf)
             "#include \"parsec/parsec_internal.h\"\n"
             "#include \"parsec/ayudame.h\"\n"
             "#include \"parsec/execution_stream.h\"\n"
+            "#include \"parsec/parsec_binary_profile.h\"\n"
             "#include \"parsec/mca/device/device_gpu.h\"\n"
             "#if defined(PARSEC_HAVE_CUDA)\n"
             "#include \"parsec/mca/device/cuda/device_cuda.h\"\n"
@@ -3501,7 +3502,7 @@ static void jdf_generate_internal_init(const jdf_t *jdf, const jdf_function_entr
     if( profile_enabled(f->properties) ) {
         coutput("#if defined(PARSEC_PROF_TRACE) && defined(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT)\n"
                 "  PARSEC_PROFILING_TRACE(es->es_profile,\n"
-                "                         this_task->taskpool->profiling_array[2 * this_task->task_class->task_class_id],\n"
+                "                         this_task->taskpool->profiling_array[START_KEY(this_task->task_class->task_class_id)],\n"
                 "                         0,\n"
                 "                         this_task->taskpool->taskpool_id, NULL);\n"
                 "#endif /* defined(PARSEC_PROF_TRACE) && defined(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT) */\n");

--- a/parsec/mca/pins/ptg_to_dtd/pins_ptg_to_dtd_module.c
+++ b/parsec/mca/pins/ptg_to_dtd/pins_ptg_to_dtd_module.c
@@ -19,6 +19,7 @@
 #include "parsec/mca/pins/pins.h"
 #include "pins_ptg_to_dtd.h"
 #include "parsec/profiling.h"
+#include "parsec/parsec_binary_profile.h"
 #include "parsec/scheduling.h"
 #include "parsec/utils/mca_param.h"
 #include "parsec/mca/device/device.h"
@@ -191,7 +192,7 @@ testing_hook_of_dtd_task(parsec_execution_stream_t *es,
     int rc = 0;
 
     PARSEC_TASK_PROF_TRACE(es->es_profile,
-                          dtd_task->super.taskpool->profiling_array[2 * dtd_task->super.task_class->task_class_id],
+                          dtd_task->super.taskpool->profiling_array[START_KEY(dtd_task->super.task_class->task_class_id)],
                           &(dtd_task->super));
 
     /**


### PR DESCRIPTION
In order to avoid confusion always rely on the existing macros to compute the profiling keys for start and end events.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>