### PR TITLE
remote_dep: rotate bcast topology around root

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -1569,13 +1569,14 @@ dtd_release_dep_fct(parsec_execution_stream_t *es,
             if( parsec_dtd_not_sent_to_rank((parsec_dtd_task_t *)oldcontext,
                                             dep->belongs_to->flow_index, dst_rank)) {
                 struct remote_dep_output_param_s *output;
-                int _array_pos, _array_mask;
+                int _array_pos, _array_bit;
+                uint32_t _array_mask;
 
 #if !defined(PARSEC_DIST_COLLECTIVES)
                 assert(src_rank == es->virtual_process->parsec_context->my_rank);
 #endif
-                _array_pos = dst_rank / (int)(8 * sizeof(uint32_t));
-                _array_mask = 1 << (dst_rank % (8 * sizeof(uint32_t)));
+                remote_dep_rank_to_bit(dst_rank, &_array_pos, &_array_bit, src_rank);
+                _array_mask = 1 << _array_bit;
                 PARSEC_ALLOCATE_REMOTE_DEPS_IF_NULL(arg->remote_deps, oldcontext, MAX_PARAM_COUNT);
                 output = &arg->remote_deps->output[dep->dep_datatype_index];
                 assert((-1 == arg->remote_deps->root) || (arg->remote_deps->root == src_rank));

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -1832,13 +1832,14 @@ parsec_release_dep_fct(parsec_execution_stream_t *es,
 
         if( arg->action_mask & PARSEC_ACTION_SEND_INIT_REMOTE_DEPS ){
             struct remote_dep_output_param_s* output;
-            int _array_pos, _array_mask;
+            int _array_pos, _array_bit;
+            uint32_t _array_mask;
 
 #if !defined(PARSEC_DIST_COLLECTIVES)
             assert(src_rank == es->virtual_process->parsec_context->my_rank);
 #endif
-            _array_pos = dst_rank / (8 * sizeof(uint32_t));
-            _array_mask = 1 << (dst_rank % (8 * sizeof(uint32_t)));
+            remote_dep_rank_to_bit(dst_rank, &_array_pos, &_array_bit, src_rank);
+            _array_mask = 1 << _array_bit;
             PARSEC_ALLOCATE_REMOTE_DEPS_IF_NULL(arg->remote_deps, oldcontext, MAX_PARAM_COUNT);
             output = &arg->remote_deps->output[dep->dep_datatype_index];
             assert( (-1 == arg->remote_deps->root) || (arg->remote_deps->root == src_rank) );

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -418,4 +418,21 @@ extern int parsec_comm_gets;
 extern int parsec_comm_puts_max;
 extern int parsec_comm_puts;
 
+static inline void
+remote_dep_rank_to_bit(int rank, int *bank, int *bit, int root)
+{
+    int nb_nodes = parsec_remote_dep_context.max_nodes_number;
+    int _rank = (rank + nb_nodes - root) % nb_nodes;
+    *bank = _rank / (8 * sizeof(uint32_t));
+    *bit =  _rank % (8 * sizeof(uint32_t));
+}
+
+static inline void
+remote_dep_bit_to_rank(int *rank, int bank, int bit, int root)
+{
+    int nb_nodes = parsec_remote_dep_context.max_nodes_number;
+    int _rank = bank * (8 * sizeof(uint32_t)) + bit;
+    *rank = (_rank + root) % nb_nodes;
+}
+
 #endif /* __USE_PARSEC_REMOTE_DEP_H__ */

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -1307,14 +1307,15 @@ static int remote_dep_mpi_pack_dep(int peer,
     parsec_remote_deps_t *deps = (parsec_remote_deps_t*)item->cmd.activate.task.source_deps;
     remote_dep_wire_activate_t* msg = &deps->msg;
     int k, dsize, saved_position = *position;
-    uint32_t peer_bank, peer_mask, expected = 0;
+    int peer_bank, peer_bit;
+    uint32_t peer_mask, expected = 0;
 #if defined(PARSEC_DEBUG) || defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
     remote_dep_cmd_to_string(&deps->msg, tmp, 128);
 #endif
 
-    peer_bank = peer / (sizeof(uint32_t) * 8);
-    peer_mask = 1U << (peer % (sizeof(uint32_t) * 8));
+    remote_dep_rank_to_bit(peer, &peer_bank, &peer_bit, deps->root);
+    peer_mask = 1U << peer_bit;
 
     parsec_ce.pack_size(&parsec_ce, dep_count, dep_dtt, &dsize);
     dsize += deps->taskpool->tdm.module->outgoing_message_piggyback_size;


### PR DESCRIPTION
The communication topology always prefers to send to lower-ranked nodes over higher-ranked nodes. This results in a significant communication imbalance regardless of how a computation is distributed, unless all communication is point-to-point.

This introduces a pair of functions, remote_dep_rank_to_bit and remote_dep_bit_to_rank, to translate between rank id 0 .. np-1 and the bank offset and bit index for the rank_bits array. This translation "rotates" the ranks around the root of a communication i.e. the source is always bank 0/bit 0 and there are different topologies depending on the root of a bcast. If an application's communications are otherwise balanced then this results in a better communication balance.

Signed-off-by: Omri Mor <omrimor2@illinois.edu>