### PR TITLE
Close files between operations.

### DIFF
--- a/tools/profiling/dbpreader.h
+++ b/tools/profiling/dbpreader.h
@@ -41,6 +41,7 @@ int dbp_dictionary_keylen(const dbp_dictionary_t *dico);
 
 //typedef struct dbp_file dbp_file_t;
 dbp_file_t *dbp_reader_get_file(const dbp_multifile_reader_t *dbp, int fid);
+void dbp_reader_close_file(dbp_file_t *dbp);
 
 char * dbp_file_hr_id(const dbp_file_t *file);
 char * dbp_file_get_name(const dbp_file_t *file);

--- a/tools/profiling/python/pbt2ptt.pxd
+++ b/tools/profiling/python/pbt2ptt.pxd
@@ -54,6 +54,7 @@ cdef extern from "dbpreader.h":
    int dbp_dictionary_keylen(dbp_dictionary_t * dico)
 
    dbp_file_t *dbp_reader_get_file(dbp_multifile_reader_t *dbp, int fid)
+   void dbp_reader_close_file(dbp_file_t *dbp)
 
    char *dbp_file_hr_id(dbp_file_t *file)
    char *dbp_file_get_name(dbp_file_t *file)


### PR DESCRIPTION
This will keep the number of open file descriptor at a reasonable level.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>