### PR TITLE
Hotfix dtd dsl and warning

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -737,7 +737,7 @@ parsec_dtd_add_profiling_info_generic(parsec_taskpool_t *tp,
 void *parsec_dtd_task_profile_info(void *dst, const void *task_, size_t size)
 {
     void *ptr;
-    parsec_dtd_task_t *task = (parsec_dtd_task_t *)task_;
+    const parsec_dtd_task_t *task = (const parsec_dtd_task_t *)task_;
     parsec_dtd_task_param_t *param = GET_HEAD_OF_PARAM_LIST(task);
 
     assert( task->super.task_class->task_class_type == PARSEC_TASK_CLASS_TYPE_DTD );
@@ -2412,7 +2412,10 @@ int parsec_dtd_task_class_add_chore(parsec_taskpool_t *tp,
     incarnations[i+1].type = PARSEC_DEV_NONE;
     incarnations[i+1].hook = NULL;
 
-    parsec_dtd_insert_task_class(dtd_tp, (parsec_dtd_task_class_t*)dtd_tc);
+    if( dtd_tc->super.task_class_id == UINT8_MAX ) {
+        /* If this is the first time we create a chore for this task, we need to insert it, otherwise we shouldn't insert it again */
+        parsec_dtd_insert_task_class(dtd_tp, (parsec_dtd_task_class_t*)dtd_tc);
+    }
 
     return PARSEC_SUCCESS;
 }

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -573,20 +573,21 @@ extern int device_delegate_begin, device_delegate_end;
                              (TASK)->taskpool, (TASK)->locals ), NULL), \
                            (TASK)->taskpool->taskpool_id,               \
                            (TASK)->task_class->profile_info,            \
-                           (TRACE_INFO) ? (void*)&(TASK)->prof_info : NULL); 
+                           (TRACE_INFO) ? (void*)(TASK) : NULL); 
 
 #define PARSEC_TASK_PROF_TRACE_IF(COND, PROFILE, KEY, TASK, TRACE_INFO)  \
     if(!!(COND)) {                                                       \
         PARSEC_TASK_PROF_TRACE((PROFILE), (KEY), (TASK), (TRACE_INFO));  \
     }
 #define PARSEC_TASK_PROF_TRACE_FLAGS(PROFILE, KEY, TASK, FLAGS, TRACE_INFO) \
-    PARSEC_PROFILING_TRACE_FLAGS((PROFILE),                                 \
+    PARSEC_PROFILING_TRACE_FLAGS_INFO_FN((PROFILE),                         \
                            (KEY),                                           \
                            (TASK)->task_class->key_functions->              \
                            key_hash((TASK)->task_class->make_key(           \
                               (TASK)->taskpool, (TASK)->locals ), NULL),    \
                            (TASK)->taskpool->taskpool_id,                   \
-                           (TRACE_INFO) ? (void*)&(TASK)->prof_info : NULL, \
+                           (TASK)->task_class->profile_info,                \
+                           (TRACE_INFO) ? (void*)(TASK) : NULL,             \
                            (FLAGS)); 
 #else
 #define PARSEC_TASK_PROF_TRACE(PROFILE, KEY, TASK, PROF_INFO)


### PR DESCRIPTION
 Two fixes for DTD:
    
       - there was a spurious warning when registering multiple chores with
         the same DTD task class, because we changed when the task class
         is inserted (and we were trying to insert it twice)
    
       - Between the various fixes for the PARSEC_TASK_PROF_TRACE_FLAGS and
         PARSEC_TASK_PROF_TRACE macros, we stopped invoking the right tracing
         function for DSLs that do not support parameters on the locals
         array.
