### PR TITLE
Use pip to build and install the python support.

### DIFF
--- a/tests/profiling/Testings.cmake
+++ b/tests/profiling/Testings.cmake
@@ -1,18 +1,14 @@
 find_package (Python COMPONENTS Interpreter)
 if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
-  execute_process(COMMAND ${Python_EXECUTABLE} -c
-    "from __future__ import print_function; import sysconfig; import sys; print('{}-{}.{}'.format(sysconfig.get_platform(),sys.version_info[0],sys.version_info[1]), end='')"
-    OUTPUT_VARIABLE SYSCONF)
   parsec_addtest_cmd(profiling/generate_profile_bw:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
 
+  set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
   parsec_addtest_cmd(profiling/generate_hdf5 ${SHM_TEST_CMD_LIST}
     ${Python_EXECUTABLE}
     ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=bw.h5 bw-0.prof bw-1.prof)
   set_property(TEST profiling/generate_hdf5 APPEND PROPERTY DEPENDS profiling/generate_profile_bw:mp)
   set_property(TEST profiling/generate_hdf5 APPEND PROPERTY ENVIRONMENT
-    LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/tools/profiling/python/build/temp.${SYSCONF}:$ENV{LD_LIBRARY_PATH})
-  set_property(TEST profiling/generate_hdf5 APPEND PROPERTY ENVIRONMENT
-    PYTHONPATH=${CMAKE_BINARY_DIR}/tools/profiling/python/build/lib.${SYSCONF}/:$ENV{PYTHONPATH})
+    PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
 
   parsec_addtest_cmd(profiling/check_hdf5 ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-comms.py)
   set_property(TEST profiling/check_hdf5 APPEND PROPERTY DEPENDS profiling/generate_hdf5)
@@ -24,9 +20,7 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
                      ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=async.h5 async-0.prof)
   set_property(TEST profiling/generate_hdf5_async APPEND PROPERTY DEPENDS profiling/generate_profile_async)
   set_property(TEST profiling/generate_hdf5_async APPEND PROPERTY ENVIRONMENT
-               LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/tools/profiling/python/build/temp.${SYSCONF}:$ENV{LD_LIBRARY_PATH})
-  set_property(TEST profiling/generate_hdf5_async APPEND PROPERTY ENVIRONMENT
-               PYTHONPATH=${CMAKE_BINARY_DIR}/tools/profiling/python/build/lib.${SYSCONF}/:$ENV{PYTHONPATH})
+    PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
 
   parsec_addtest_cmd(profiling/check_hdf5_async ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-async.py async.h5)
     set_property(TEST profiling/check_hdf5_async APPEND PROPERTY DEPENDS profiling/generate_hdf5_async)
@@ -41,9 +35,7 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
             ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=bw.h5 bw-0.prof bw-1.prof)
     set_property(TEST profiling/generate_hdf5_for_dag_and_dot APPEND PROPERTY DEPENDS profiling/generate_profile_and_dot_bw:mp)
     set_property(TEST profiling/generate_hdf5_for_dag_and_dot APPEND PROPERTY ENVIRONMENT
-            LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/tools/profiling/python/build/temp.${SYSCONF}:$ENV{LD_LIBRARY_PATH})
-    set_property(TEST profiling/generate_hdf5_for_dag_and_dot APPEND PROPERTY ENVIRONMENT
-            PYTHONPATH=${CMAKE_BINARY_DIR}/tools/profiling/python/build/lib.${SYSCONF}/:$ENV{PYTHONPATH})
+                 PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
 
     parsec_addtest_cmd(profiling/check_DAG_and_Trace ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/profiling/python/examples/example-DAG-and-Trace.py --dot bw-0.dot --dot bw-1.dot --h5 bw.h5)
     set_property(TEST profiling/check_DAG_and_Trace APPEND PROPERTY DEPENDS profiling/generate_hdf5_for_dag_and_dot)

--- a/tools/profiling/python/CMakeLists.txt
+++ b/tools/profiling/python/CMakeLists.txt
@@ -21,7 +21,7 @@ if( NOT CYTHON_EXECUTABLE )
   return()
 endif( NOT CYTHON_EXECUTABLE )
 
-set(SRC_PYTHON_SUPPORT ${CMAKE_CURRENT_SOURCE_DIR}/common_utils.py ${CMAKE_CURRENT_SOURCE_DIR}/parsec_trace_tables.py ${CMAKE_CURRENT_SOURCE_DIR}/ptt_utils.py ${CMAKE_CURRENT_SOURCE_DIR}/profile2h5.py)
+set(SRC_PYTHON_SUPPORT ${CMAKE_CURRENT_SOURCE_DIR}/common_utils.py ${CMAKE_CURRENT_SOURCE_DIR}/parsec_trace_tables.py ${CMAKE_CURRENT_SOURCE_DIR}/ptt_utils.py ${CMAKE_CURRENT_SOURCE_DIR}/profile2h5.py ${CMAKE_CURRENT_SOURCE_DIR}/pbt2ptt.pyx ${CMAKE_CURRENT_SOURCE_DIR}/pbt2ptt.pxd)
 set(SETUP_PY setup.py)
 
 set(PYTHON_TOOLS_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -38,17 +38,22 @@ endif(Python_VERSION_MAJOR EQUAL 2)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SETUP_PY}.in
                ${PYTHON_TOOLS_BIN_DIR}/${SETUP_PY} @ONLY )
 
-# and compile the python module
+# Move the files into the build directory (to prevent the pollution of the source directory
+# due to cython compilation) and compile the python module
+# Also fake a local installation of the python module to be able to use it
+# for testing purposes. With this we can simply set the PYTHONPATH to the correct
+# location and import the pbt2ptt module.
 add_custom_command(OUTPUT ${OUTPUT}
-                   COMMAND ${Python_EXECUTABLE} ${SETUP_PY} build --quiet
+                   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SRC_PYTHON_SUPPORT} ${CMAKE_CURRENT_BINARY_DIR}
+                   COMMAND ${Python_EXECUTABLE} -m pip install --quiet --prefix=${CMAKE_CURRENT_BINARY_DIR}/python.test .
                    COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
-                   DEPENDS parsec-base)
+                   DEPENDS parsec-base ${SRC_PYTHON_SUPPORT})
 add_custom_target(pbt2ptt ALL DEPENDS ${OUTPUT})
 
 # Call python distutils to install all python support in the right location
 # (aka. according to the OS demands). Prepare to reconfigure the shell
 # helper scripts to point to the right location
-install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${SETUP_PY} install --skip-build --prefix=\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}
+install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} -m pip install --quiet --prefix=\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX} .
         WORKING_DIRECTORY ${PYTHON_TOOLS_BIN_DIR})")
 
 # Create bash environment PaRSEC python support
@@ -61,8 +66,6 @@ install( FILES ${PYTHON_TOOLS_BIN_DIR}/utilities/parsec.env.sh ${PYTHON_TOOLS_BI
          DESTINATION ${PARSEC_INSTALL_BINDIR}
          PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
-# Install the files from the binary directory after being translated
-# by the 2to3 tool.
 file(GLOB pyfiles RELATIVE ${PYTHON_TOOLS_BIN_DIR} "examples/*.py" "profile2h5.py")
 foreach(file ${pyfiles})
   install( FILES ${PYTHON_TOOLS_BIN_DIR}/${file}

--- a/tools/profiling/python/setup.py.in
+++ b/tools/profiling/python/setup.py.in
@@ -7,8 +7,7 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 from Cython.Build import cythonize
-import os.path
-import sys
+import os, sys
 import socket
 
 c_compiler = '@CMAKE_C_COMPILER@'.replace('FILEPATH=', '')
@@ -44,7 +43,7 @@ if 'Debug' == build_type or 'RelWithDebInfo' == build_type:
 
 # Cython does not support VPATH, so the generated files will always reside on the
 # SOURCE_DIR, except if we explicitly move them to the build directory.
-extensions = [Extension('pbt2ptt', ['@CMAKE_CURRENT_SOURCE_DIR@/pbt2ptt.pyx',
+extensions = [Extension('pbt2ptt', ['pbt2ptt.pyx',
                                     os.path.realpath('@CMAKE_CURRENT_SOURCE_DIR@/../dbpreader.c')],
                          include_dirs=['@PROJECT_SOURCE_DIR@/parsec/include',
                                        '@PROJECT_SOURCE_DIR@',
@@ -128,9 +127,9 @@ setup(
     name = 'pbt2ptt',
     version='@PARSEC_VERSION_MAJOR@.@PARSEC_VERSION_MINOR@.@PARSEC_VERSION_RELEASE@',
     description='PaRSEC Binary Trace Interface parses and converts the PaRSEC Binary Trace format into a pandas-based Python tabular format',
-    url='http://icl.cs.utk.edu/parsec/',
-    package_dir={ '': '@PYTHON_TOOLS_BIN_DIR@'},
+    url='http://icl.utk.edu/parsec/',
     py_modules=['ptt_utils', 'parsec_trace_tables', 'common_utils'],
+    package_dir={ '': '@CMAKE_CURRENT_BINARY_DIR@'},
     cmdclass = {'build_ext': local_compiler_build_ext},
     ext_modules = cythonize(extensions,
                             compiler_directives={'language_level' : @Python_VERSION_MAJOR@},


### PR DESCRIPTION
The old approach was deprecated, this moves us to a more modern and more clean instllation process. It did require few changes:
- use pip to build and install a temporary module such that we can use it for testing purposes.
- reinstall the module again once we are in the install path.

This PR does not fix the profiling tests, it just allows them to run correctly.