### PR TITLE
Fix profiling tests

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -106,7 +106,7 @@ jobs:
       matrix:
         build_type : [ Release ]
         shared_type : [ ON ]
-        profiling : [ OFF ]
+        profiling : [ OFF, ON ]
 
     name: "Type = ${{ matrix.build_type }} shared=${{ matrix.shared_type }} profiling=${{matrix.profiling}}"
     env:

--- a/parsec/class/parsec_hash_table.c
+++ b/parsec/class/parsec_hash_table.c
@@ -479,7 +479,7 @@ static void *parsec_hash_table_nolock_find_in_old_tables(parsec_hash_table_t *ht
         hash = parsec_hash_table_universal_rehash(hash64, head->nb_bits);
         // We need the lock on the old tables, as some other thread might
         // be removing elements in this bucket, through remove_from_old_tables
-        // and that thread relies on the lowlevel table locks
+        // and that thread relies on the low-level table locks
         parsec_atomic_lock( &head->buckets[hash].lock );
         for(current_item = head->buckets[hash].first_item;
             NULL != current_item;
@@ -491,7 +491,7 @@ static void *parsec_hash_table_nolock_find_in_old_tables(parsec_hash_table_t *ht
                                      BASEADDROF(current_item, ht), ht->key_functions.key_print(estr, 64, key, ht->hash_data), ht, head, hash);
 #endif
                 // We already have the lock on the toplevel table bucket,
-                // and we have the lock on the lowlevel table bucket... So
+                // and we have the lock on the low-level table bucket... So
                 // use the opportunity to move the element in the toplevel
                 if(NULL == prev_item) {
                     head->buckets[hash].first_item = current_item->next_item;

--- a/parsec/data_dist/matrix/map_operator.c
+++ b/parsec/data_dist/matrix/map_operator.c
@@ -383,6 +383,12 @@ static parsec_key_fn_t __parsec_map_operator_key_functions = {
     .key_hash  = parsec_hash_table_generic_64bits_key_hash
 };
 
+static char* parsec_map_operator_printtask(char *buffer, size_t buffer_size, const parsec_task_t *task)
+{
+    snprintf(buffer, buffer_size, "MapOperator(%d, %d)", task->locals[0].value, task->locals[1].value);
+    return buffer;
+}
+
 static const parsec_task_class_t parsec_map_operator = {
     .name = "map_operator",
     .flags = 0x0,
@@ -399,6 +405,10 @@ static const parsec_task_class_t parsec_map_operator = {
     .in = { &flow_of_map_operator },
     .out = { &flow_of_map_operator },
     .make_key = map_operator_make_key,
+    .task_snprintf = &parsec_map_operator_printtask,
+#if defined(PARSEC_PROF_TRACE)
+    .profile_info = &parsec_task_profile_info,
+#endif
     .key_functions = &__parsec_map_operator_key_functions,
     .prepare_input = data_lookup,
     .incarnations = __parsec_map_operator_chores,

--- a/parsec/dictionary.h
+++ b/parsec/dictionary.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 The University of Tennessee and The University
+ * Copyright (c) 2018-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -16,14 +16,14 @@
 #include "parsec/class/parsec_hash_table.h"
 
 /**
- * @defgroup parsec_dictionnary_profiling Profiling: Dictionary
+ * @defgroup parsec_dictionary_profiling Profiling: Dictionary
  * @ingroup parsec_public_profiling
  * @{
  *
  * @brief The PaRSEC dictionary profiling system allows to expose properties
  *    at runtime through a shared memory region.
  * @details
- *    The dictionnary system explores the submitted taskpools and the PINS modules,
+ *    The dictionary system explores the submitted taskpools and the PINS modules,
  *    collects properties exposed by those entities.
  *    It then compare this list with the list of requested properties submitted
  *    by the user through mca parameters:
@@ -39,9 +39,9 @@
  *
  * One shared memory region is opened per node on the node. The memory region
  * starts with 3 integers specifying the number of pages of the memory region,
- * the running state of the memory region, and the dictionnary version.
+ * the running state of the memory region, and the dictionary version.
  *
- * Dictionnary version increases when the producers adds or removes properties. It
+ * Dictionary version increases when the producers adds or removes properties. It
  * also increases when the consumers change their list of requested properties.
  *
  * After reading the three integers, it is advised to re-open the shared memory region
@@ -108,13 +108,14 @@
 #define DICT_PAGE_SIZE 4096
 
 /**
- *  Profiling shmem is a container with a list of reference to the properties requested by the user, a buffer to write into, sizes, nb of prop, offset array, etc
- *  Page is
+ *  Profiling shmem is a container with a list of reference to the properties
+ *  requested by the user, a buffer to write into, sizes, nb of prop, offset array, etc
  **/
 typedef struct parsec_profiling_shmem_s parsec_profiling_shmem_t;
 
 /**
- *  Dictionary is the hashtable container for the properties defined by the taskpools or the platform and exposed to the user for dump
+ *  Dictionary is the hashtable container for the properties defined by the
+ *  taskpools or the platform and exposed to the user for dump
  *  Each entry, a property, expose a type and a function pointer.
  **/
 
@@ -123,15 +124,15 @@ typedef struct parsec_property_function_s parsec_property_function_t;
 
 /* Item from the properties hashtable */
 typedef struct parsec_profiling_property_s parsec_profiling_property_t;
-/* Item from the namespace hashtable, contains a hastable for properties */
+/* Item from the namespace hashtable, contains a hashtable for properties */
 typedef struct parsec_profiling_task_class_s parsec_profiling_task_class_t;
-/* Item from the dictionary hashtable, contains a hastable for task_classes */
+/* Item from the dictionary hashtable, contains a hashtable for task_classes */
 typedef struct parsec_profiling_namespace_s parsec_profiling_namespace_t;
 /* at the intersection between consumers and producers */
 typedef struct parsec_profiling_dictionary_s parsec_profiling_dictionary_t;
 /* a node in a tree */
 typedef struct parsec_profiling_node_s parsec_profiling_node_t;
-/* the tree to map on top of namespace, task_class, and property to determineif a property is available and/or requested */
+/* the tree to map on top of namespace, task_class, and property to determine if a property is available and/or requested */
 typedef struct parsec_profiling_tree_s parsec_profiling_tree_t;
 /* special function pointer to request the creation of a bucket in each node */
 typedef parsec_hash_table_item_t *(*create_bucket_fn)(char *);
@@ -171,7 +172,7 @@ typedef enum {
 
 /**
  * @brief Structure description of the Shared Memory Region
- * @details Gives sizes for each section, and offset for quick dispacement in it
+ * @details Gives sizes for each section, and offset for quick displacement in it
  */
 struct parsec_profiling_shmem_s {
     int                                 nb_xml_pages;  /**< Number of pages for the XML header */
@@ -251,10 +252,10 @@ struct parsec_profiling_namespace_s {
 };
 
 /**
- * @brief Dictionnary is a hashtable of namespaces
- * @details Dictionnary is versioned to signal to observers that the XML
+ * @brief Dictionary is a hashtable of namespaces
+ * @details Dictionary is versioned to signal to observers that the XML
  *        description changed and has to be reloaded.
- *        running depicts if the dictionnary is ready, in initialization,
+ *        running depicts if the dictionary is ready, in initialization,
  *        or disabled.
  */
 struct parsec_profiling_dictionary_s {
@@ -296,7 +297,7 @@ struct parsec_profiling_tree_s {
 extern parsec_profiling_dictionary_t *parsec_profiling_dictionary;
 
 /**
- * @brief Initialize the dictionnary by exploring the context.
+ * @brief Initialize the dictionary by exploring the context.
  * @details Exploring the PINS modules is not yet supported.
  */
 int parsec_profiling_dictionary_init(parsec_context_t *master_context,
@@ -309,24 +310,22 @@ int parsec_profiling_dictionary_init(parsec_context_t *master_context,
 int parsec_profiling_dictionary_free(void);
 
 /**
- * @brief Explore the dictionnary to find a namespace
+ * @brief Find the profiling task_class, a first step before iterating over the
+ *        task_class properties.
  */
-parsec_profiling_namespace_t *find_namespace(const char *ns);
-
-/**
- * @brief Explore the namespace to find a task_class
- */
-parsec_profiling_task_class_t  *find_task_class(parsec_profiling_namespace_t *ns, const char *tc);
+const parsec_profiling_task_class_t*
+parsec_profiling_find_profiling_task_class(const char *ns_name, const char *tc_name);
 
 /**
  * @brief Explore the task_class to find a property
  */
-parsec_profiling_property_t  *find_property(parsec_profiling_task_class_t* tc, const char *pr);
+const parsec_profiling_property_t*
+parsec_profiling_find_property(const parsec_profiling_task_class_t* tc, const char *pr);
 
 /**
  * @brief Extract the provided properties from the taskpool
  *
- * @details Call this ONCE per per taskpool. Will increase the version of the dictionnary
+ * @details Call this ONCE per per taskpool. Will increase the version of the dictionary
  * @return PARSEC_SUCCESS    if success, never fails!
  *
  * @remark not thread safe
@@ -334,9 +333,9 @@ parsec_profiling_property_t  *find_property(parsec_profiling_task_class_t* tc, c
 int parsec_profiling_add_taskpool_properties(parsec_taskpool_t *h);
 
 /**
- * @brief Manually forge a property and add it to the dictionnary
+ * @brief Manually forge a property and add it to the dictionary
  *
- * @details Modules can use this function to add their own property to the dictionnary
+ * @details Modules can use this function to add their own property to the dictionary
  * @return PARSEC_SUCCESS    if success, never fails!
  *
  * @remark not thread safe

--- a/parsec/mca/pins/alperf/pins_alperf_module.c
+++ b/parsec/mca/pins/alperf/pins_alperf_module.c
@@ -94,17 +94,16 @@ static void alperf_exec_count_end(struct parsec_execution_stream_s *es,
     (void)es;
 
     if (parsec_profiling_dictionary->shmem) {
-      /* Identify the calling task_class */
-      parsec_taskpool_t *taskpool = task->taskpool; /* taskpool_name */
-      parsec_profiling_namespace_t *ns = find_namespace(taskpool->taskpool_name);
-      if (!ns) return; /* It would be weird if we exited here. Meaning that we got an event for an undiscovered taskpool */
+        /* Identify the calling task_class */
+        const parsec_profiling_task_class_t *fc
+            = parsec_profiling_find_profiling_task_class(task->taskpool->taskpool_name,
+                                                         task->task_class->name);
+        if (!fc) return; /* Unknown task_class for the profiling subsystem. This should not happen,
+                          * however it is safe to just return.
+                          */
 
-      const parsec_task_class_t *task_class = task->task_class; /* name */
-      parsec_profiling_task_class_t *fc = find_task_class(ns, task_class->name);
-      if (!fc) return; /* Same for an undiscovered task_class */
-
-      /* Let's explore all the properties and evaluate them */
-      void *tmp[2] = { (void*)es, (void*)task };
-      parsec_hash_table_for_all(&fc->properties, parsec_profiling_evaluate_property, tmp);
+        /* Let's explore all the properties and evaluate them */
+        void *tmp[2] = { (void*)es, (void*)task };
+        parsec_hash_table_for_all((parsec_hash_table_t*)&fc->properties, parsec_profiling_evaluate_property, tmp);
     }
 }

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -845,7 +845,7 @@ int parsec_context_add_taskpool( parsec_context_t* context, parsec_taskpool_t* t
         tp->tdm.module->monitor_taskpool(tp, parsec_taskpool_termination_detected);
         tp->tdm.module->taskpool_ready(tp);
     }
-    
+
     /* Update the number of pending taskpools */
     (void)parsec_atomic_fetch_inc_int32( &context->active_taskpools );
 
@@ -858,6 +858,10 @@ int parsec_context_add_taskpool( parsec_context_t* context, parsec_taskpool_t* t
     parsec_list_lock(context->taskpool_list);
     parsec_list_nolock_push_back(context->taskpool_list, &tp->super);
     if( context->flags & PARSEC_CONTEXT_FLAG_WAITING ) {
+        /* TODO: Why is this called here ? According to the callback name
+         * it should be called upon entry in the taskpool_wait, which is
+         * which is clearly not what is happening here.
+         */
         if(NULL != tp->on_enter_wait)
             tp->on_enter_wait(tp, tp->on_enter_wait_data);
     }

--- a/parsec/termdet.c
+++ b/parsec/termdet.c
@@ -85,8 +85,8 @@ int parsec_termdet_open_module(parsec_taskpool_t *tp, char *name)
         omod->module = mca_component_query(omod->component);
         if(NULL == omod->module) {
             free(omod->name);
-            free(omod);
             mca_component_close(omod->component);
+            free(omod);
             parsec_fatal("Component of name '%s' of type termdet exists, but could not load (query failed)",
                          name);
             parsec_hash_table_unlock_bucket(&parsec_termdet_opened_modules, (parsec_key_t)name);

--- a/tests/profiling/Testings.cmake
+++ b/tests/profiling/Testings.cmake
@@ -2,6 +2,9 @@ find_package (Python COMPONENTS Interpreter)
 if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
   parsec_addtest_cmd(profiling/generate_profile_bw:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
 
+  set_property(TEST profiling/generate_profile_bw:mp PROPERTY RESOURCE_LOCK bw_file)
+  set_property(TEST profiling/generate_profile_bw:mp PROPERTY FIXTURES_SETUP bw_file_base)
+
   set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
   parsec_addtest_cmd(profiling/generate_hdf5 ${SHM_TEST_CMD_LIST}
     ${Python_EXECUTABLE}
@@ -9,11 +12,18 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
   set_property(TEST profiling/generate_hdf5 APPEND PROPERTY DEPENDS profiling/generate_profile_bw:mp)
   set_property(TEST profiling/generate_hdf5 APPEND PROPERTY ENVIRONMENT
     PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
+  set_property(TEST profiling/generate_hdf5 PROPERTY RESOURCE_LOCK bw_file)
+  set_property(TEST profiling/generate_hdf5 PROPERTY FIXTURES_REQUIRED bw_file_base)
+  set_property(TEST profiling/generate_hdf5 PROPERTY FIXTURES_SETUP bw_file_base)
 
   parsec_addtest_cmd(profiling/check_hdf5 ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-comms.py)
   set_property(TEST profiling/check_hdf5 APPEND PROPERTY DEPENDS profiling/generate_hdf5)
+  set_property(TEST profiling/generate_hdf5 PROPERTY RESOURCE_LOCK bw_file)
+  set_property(TEST profiling/generate_hdf5 PROPERTY FIXTURES_REQUIRED bw_file)
 
   parsec_addtest_cmd(profiling/generate_profile_async ${SHM_TEST_CMD_LIST} profiling/async 100 -- --mca profile_filename async  --mca mca_pins task_profiler)
+  set_property(TEST profiling/generate_profile_async PROPERTY RESOURCE_LOCK async_file)
+  set_property(TEST profiling/generate_profile_async PROPERTY FIXTURES_SETUP async_file_base)
 
   parsec_addtest_cmd(profiling/generate_hdf5_async ${SHM_TEST_CMD_LIST}
                      ${Python_EXECUTABLE}
@@ -21,14 +31,21 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
   set_property(TEST profiling/generate_hdf5_async APPEND PROPERTY DEPENDS profiling/generate_profile_async)
   set_property(TEST profiling/generate_hdf5_async APPEND PROPERTY ENVIRONMENT
     PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
+  set_property(TEST profiling/generate_hdf5_async PROPERTY RESOURCE_LOCK async_file)
+  set_property(TEST profiling/generate_hdf5_async PROPERTY FIXTURES_REQUIRED async_file_base)
+  set_property(TEST profiling/generate_hdf5_async PROPERTY FIXTURES_SETUP async_file)
 
   parsec_addtest_cmd(profiling/check_hdf5_async ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-async.py async.h5)
     set_property(TEST profiling/check_hdf5_async APPEND PROPERTY DEPENDS profiling/generate_hdf5_async)
+  set_property(TEST profiling/check_hdf5_async PROPERTY RESOURCE_LOCK async_file)
+  set_property(TEST profiling/check_hdf5_async PROPERTY FIXTURES_REQUIRED async_file)
 
-  parsec_addtest_cmd(profiling/cleanup_profile_files ${SHM_TEST_CMD_LIST} rm -f bw-0.prof bw-1.prof bw.h5 async-0.prof async.h5)
+  #  parsec_addtest_cmd(profiling/cleanup_profile_files ${SHM_TEST_CMD_LIST} rm -f bw-0.prof bw-1.prof bw.h5 async-0.prof async.h5)
 
   if(PARSEC_PROF_GRAPHER)
     parsec_addtest_cmd(profiling/generate_profile_and_dot_bw:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 3 -f 2 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler --dot bw)
+  set_property(TEST profiling/generate_profile_and_dot_bw:mp PROPERTY RESOURCE_LOCK bw_file_and_dot)
+  set_property(TEST profiling/generate_profile_and_dot_bw:mp PROPERTY FIXTURES_SETUP bw_file_base_and_dot)
 
     parsec_addtest_cmd(profiling/generate_hdf5_for_dag_and_dot ${SHM_TEST_CMD_LIST}
             ${Python_EXECUTABLE}
@@ -36,9 +53,14 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
     set_property(TEST profiling/generate_hdf5_for_dag_and_dot APPEND PROPERTY DEPENDS profiling/generate_profile_and_dot_bw:mp)
     set_property(TEST profiling/generate_hdf5_for_dag_and_dot APPEND PROPERTY ENVIRONMENT
                  PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
+    set_property(TEST profiling/generate_hdf5_for_dag_and_dot PROPERTY RESOURCE_LOCK bw_file_and_dot)
+    set_property(TEST profiling/generate_hdf5_for_dag_and_dot PROPERTY FIXTURES_REQUIRED bw_file_base_and_dot)
+    set_property(TEST profiling/generate_hdf5_for_dag_and_dot PROPERTY FIXTURES_SETUP bw_file)
 
     parsec_addtest_cmd(profiling/check_DAG_and_Trace ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/profiling/python/examples/example-DAG-and-Trace.py --dot bw-0.dot --dot bw-1.dot --h5 bw.h5)
     set_property(TEST profiling/check_DAG_and_Trace APPEND PROPERTY DEPENDS profiling/generate_hdf5_for_dag_and_dot)
+    set_property(TEST profiling/check_DAG_and_Trace PROPERTY RESOURCE_LOCK bw_file_and_dot)
+    set_property(TEST profiling/check_DAG_and_Trace PROPERTY FIXTURES_REQUIRED bw_file)
 
     parsec_addtest_cmd(profiling/cleanup_dot_files ${SHM_TEST_CMD_LIST} rm -f bw-0.prof bw-1.prof bw.h5 bw-0.dot bw-1.dot)
   endif(PARSEC_PROF_GRAPHER)

--- a/tests/profiling/async.jdf
+++ b/tests/profiling/async.jdf
@@ -249,6 +249,8 @@ int main( int argc, char** argv )
     free(descA.mat);
     parsec_del2arena( & adt );
 
+    parsec_taskpool_free( (parsec_taskpool_t*)tp );
+
     parsec_fini( &parsec);
 
 #ifdef PARSEC_HAVE_MPI

--- a/tests/profiling/check-async.py
+++ b/tests/profiling/check-async.py
@@ -8,9 +8,9 @@ t = pd.HDFStore(sys.argv[1])
 try:
     FULL_ASYNC = t.event_types['FULL_ASYNC']
     FULL_RESCHED = t.event_types['FULL_RESCHED']
-    ASYNC = t.event_types['ASYNC']
-    RESCHED = t.event_types['RESCHED']
-    STARTUP = t.event_types['STARTUP']
+    ASYNC = t.event_types['async::ASYNC']
+    RESCHED = t.event_types['async::RESCHED']
+    STARTUP = t.event_types['async::STARTUP']
 except KeyError:
     print("One of keys FULL_ASYNC, FULL_RESCHED, ASYNC, RESCHED, or STARTUP is not defined in the trace",
           file=sys.stderr)

--- a/tests/profiling/check-async.py
+++ b/tests/profiling/check-async.py
@@ -1,9 +1,11 @@
 #!python
 
 import pandas as pd
-import sys
+import os, sys
 
-t = pd.HDFStore(sys.argv[1])
+filename = sys.argv[1]
+assert os.path.isfile(filename)
+t = pd.HDFStore(filename)
 
 try:
     FULL_ASYNC = t.event_types['FULL_ASYNC']
@@ -11,6 +13,9 @@ try:
     ASYNC = t.event_types['async::ASYNC']
     RESCHED = t.event_types['async::RESCHED']
     STARTUP = t.event_types['async::STARTUP']
+except AttributeError:
+        print("HDF5 file {} does not contains the event_types attribute. The file might be empty, corrupted or it was incorrectly generated".format(filename), file=sys.stderr)
+        sys.exit(2)
 except KeyError:
     print("One of keys FULL_ASYNC, FULL_RESCHED, ASYNC, RESCHED, or STARTUP is not defined in the trace",
           file=sys.stderr)
@@ -25,44 +30,53 @@ except KeyError:
 
 error = 0
 
-if len(t.events[t.events.type == STARTUP]) != 1:
-    print("Error: there should be exactly one STARTUP task.",
-          file=sys.stderr)
-    error += 1
-else:
-    startup = t.events[t.events.type == STARTUP].iloc[0]
-    print("There is one STARTUP task.")
+try:
+    if len(t.events[t.events.type == STARTUP]) != 1:
+        print("Error: there should be exactly one STARTUP task.",
+              file=sys.stderr)
+        error += 1
+    else:
+        startup = t.events[t.events.type == STARTUP].iloc[0]
+        print("There is one STARTUP task.")
 
-if len(t.events[t.events.type == FULL_RESCHED]) != 1:
-    print("Error: there should be exactly one FULL_RESCHED event.",
-          file=sys.stderr)
-    error += 1
-else:
-    print("There is one FULL_RESCHED event")
-    full_resched = t.events[t.events.type == FULL_RESCHED].iloc[0]
+    if len(t.events[t.events.type == FULL_RESCHED]) != 1:
+        print("Error: there should be exactly one FULL_RESCHED event.",
+              file=sys.stderr)
+        error += 1
+    else:
+        print("There is one FULL_RESCHED event")
+        full_resched = t.events[t.events.type == FULL_RESCHED].iloc[0]
 
-if len(t.events[t.events.type == FULL_ASYNC]) != NB:
-    print("Error: there should be exactly {} FULL_ASYNC events, there are {}"
-          .format(NB, t.events[t.events.type == FULL_ASYNC]),
-          file=sys.stderr)
-    error += 1
-else:
-    print("There are exactly {} FULL_ASYNC events".format(NB))
+    if len(t.events[t.events.type == FULL_ASYNC]) != NB:
+        print("Error: there should be exactly {} FULL_ASYNC events, there are {}"
+              .format(NB, t.events[t.events.type == FULL_ASYNC]),
+              file=sys.stderr)
+        error += 1
+    else:
+        print("There are exactly {} FULL_ASYNC events".format(NB))
 
-if len(t.events[t.events.type == ASYNC]) != 2*NB:
-    print("Error: there should be exactly {} ASYNC events, there are {}"
-          .format(2*NB, len(t.events[t.events.type == ASYNC])),
-          file=sys.stderr)
-    error += 1
-else:
-    print("There are exactly {} ASYNC events".format(2*NB))
+    if len(t.events[t.events.type == ASYNC]) != 2*NB:
+        print("Error: there should be exactly {} ASYNC events, there are {}"
+              .format(2*NB, len(t.events[t.events.type == ASYNC])),
+              file=sys.stderr)
+        error += 1
+    else:
+        print("There are exactly {} ASYNC events".format(2*NB))
 
-if error > 0:
-    print("Errors when counting tasks... Cannot continue",
-          file=sys.stderr)
-    print("Trace file fails the tests",
+    if error > 0:
+        print("Errors when counting tasks... Cannot continue",
+              file=sys.stderr)
+        print("Trace file fails the tests",
+              file=sys.stderr)
+        sys.exit(1)
+except AttributeError:
+        print("HDF5 file {} does not contains the events attribute. The file might be empty, corrupted or it was incorrectly generated".format(filename), file=sys.stderr)
+        sys.exit(2)
+except KeyError:
+    print("One of keys FULL_ASYNC, FULL_RESCHED, ASYNC, RESCHED, or STARTUP is not defined in the trace",
           file=sys.stderr)
     sys.exit(1)
+
 
 nb_begin_before = 0
 nb_end_after = 0

--- a/tests/profiling/check-comms.py
+++ b/tests/profiling/check-comms.py
@@ -1,8 +1,10 @@
 
 import pandas as pd
-import sys
+import os, sys
 
-t = pd.HDFStore('bw.h5')
+filename = 'bw.h5'
+assert os.path.isfile(filename)
+t = pd.HDFStore(filename)
 
 result = {
     'MPI_ACTIVATE': { 'nb': 100, 'lensum': 11200 },
@@ -36,7 +38,11 @@ for mt in list(result.keys()):
             else:
                 print(f"Sum of msg_size of events of type {mt} is {result[mt]['lensum']} -- correct")
         except KeyError:
-            fatal_error("Column 'msg_size' is not defined in this trace, something went wrong.")
+            print("Column 'msg_size' is not defined in this trace, something went wrong.")
+            sys.exit(1)
+    except AttributeError:
+        print("HDF5 file {} does not contains the events or event_types attribute. The file might be empty, corrupted or it was incorrectly generated".format(filename), file=sys.stderr)
+        sys.exit(2)
     except KeyError:
         fatal_error(f"Key {mt} is not present in the trace. You are using a different communication system or something went wrong")
 

--- a/tests/profiling/check-comms.py
+++ b/tests/profiling/check-comms.py
@@ -5,8 +5,8 @@ import sys
 t = pd.HDFStore('bw.h5')
 
 result = {
-    'MPI_ACTIVATE': { 'nb': 100, 'lensum': 12000 },
-    'MPI_DATA_CTL': { 'nb': 100, 'lensum': 2400 },
+    'MPI_ACTIVATE': { 'nb': 100, 'lensum': 11200 },
+    'MPI_DATA_CTL': { 'nb': 100, 'lensum': 209715200 },
     'MPI_DATA_PLD_SND': { 'nb': 100, 'lensum': 209715200 },
     'MPI_DATA_PLD_RCV': { 'nb': 100, 'lensum': 209715200 }
 }

--- a/tools/profiling/python/pbt2ptt.pyx
+++ b/tools/profiling/python/pbt2ptt.pyx
@@ -44,7 +44,7 @@ import traceback
 from parsec_trace_tables import * # the pure Python classes
 from common_utils import *
 
-multiprocess_io_cap = 9 # this seems to be a good default on ICL machines
+multiprocess_io_cap = 1 # this seems to be a good default on ICL machines
 microsleep = 0.05
 
 logging.basicConfig(level=10, format='%(message)s')
@@ -90,7 +90,7 @@ cpdef read(filenames, report_progress=False, skeleton_only=False, multiprocess=F
     cdef char ** c_filenames = string_list_to_c_strings(filenames)
     cdef dbp_multifile_reader_t * dbp = dbp_reader_open_files(len(filenames), c_filenames)
 
-    if dbp == NULL:
+    if (dbp == NULL) or (0 == dbp_reader_nb_files(dbp)):
         print("None of the following files can be opened {0}".format(filenames))
         return None
 


### PR DESCRIPTION
Fix the current profiling tests.

Those should also be augmented to include checking the name and values of infos, and a DTD test. This PR only fixes the current tests to adapt to new naming schemes,  the parsec_taskpool_t lifecycle and the new communication engine properties.
