### PR TITLE
Make sure data_in is not NULL on GPU when accessing nb_elts

### DIFF
--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -6827,6 +6827,8 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
             }
             coutput("  gpu_task->flow_nb_elts[%d] = 0;\n", di);
         }else{
+            coutput("  // A shortcut to check if the flow exists\n");
+            coutput("  if (gpu_task->ec->data[%d].data_in != NULL) {\n", di);
             if(size_property == NULL){
                 coutput("  gpu_task->flow_nb_elts[%d] = gpu_task->ec->data[%d].data_in->original->nb_elts;\n", di, di);
             }else{
@@ -6838,6 +6840,7 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
                 }
 
             }
+            coutput("}\n");
         }
 
         if (fl->flow_flags & JDF_FLOW_TYPE_WRITE) {


### PR DESCRIPTION
Some flows may be skipped for certain conditions. So, it needs to make sure the data_in is not NULL on GPU when accessing nb_elts.