### PR TITLE
Topic/device naming

### DIFF
--- a/parsec/data_dist/matrix/vector_two_dim_cyclic.c
+++ b/parsec/data_dist/matrix/vector_two_dim_cyclic.c
@@ -15,9 +15,9 @@ static uint32_t vector_twoDBC_rank_of(parsec_data_collection_t* dc, ...);
 static int32_t  vector_twoDBC_vpid_of(parsec_data_collection_t* dc, ...);
 static parsec_data_t* vector_twoDBC_data_of(parsec_data_collection_t* dc, ...);
 
-#if defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_CUDA) || defined(PARSEC_HAVE_HIP)
+#if defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) || defined(PARSEC_HAVE_DEV_HIP_SUPPORT)
 static parsec_data_key_t vector_twoDBC_data_key(struct parsec_data_collection_s *desc, ...);
-#endif /* defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_CUDA) || defined(PARSEC_HAVE_HIP) */
+#endif /* defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) || defined(PARSEC_HAVE_DEV_HIP_SUPPORT) */
 
 static int      vector_twoDBC_key_to_string(struct parsec_data_collection_s * desc, parsec_data_key_t datakey, char * buffer, uint32_t buffer_size);
 
@@ -125,7 +125,7 @@ void parsec_vector_two_dim_cyclic_init( parsec_vector_two_dim_cyclic_t * dc,
     o->vpid_of = vector_twoDBC_vpid_of;
     o->data_of = vector_twoDBC_data_of;
 
-#if defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_CUDA) || defined(PARSEC_HAVE_HIP)
+#if defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) || defined(PARSEC_HAVE_DEV_HIP_SUPPORT)
     o->data_key      = vector_twoDBC_data_key;
 #endif
     o->key_to_string = vector_twoDBC_key_to_string;
@@ -269,7 +269,7 @@ static parsec_data_t* vector_twoDBC_data_of(parsec_data_collection_t *desc, ...)
 /*
  * Common functions
  */
-#if defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_CUDA) || defined(PARSEC_HAVE_HIP)
+#if defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) || defined(PARSEC_HAVE_DEV_HIP_SUPPORT)
 /* return a unique key (unique only for the specified parsec_dc) associated to a data */
 static parsec_data_key_t vector_twoDBC_data_key(struct parsec_data_collection_s *desc, ...)
 {
@@ -288,7 +288,7 @@ static parsec_data_key_t vector_twoDBC_data_key(struct parsec_data_collection_s 
 
     return m;
 }
-#endif /* defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_CUDA) || defined(PARSEC_HAVE_HIP) */
+#endif /* defined(PARSEC_PROF_TRACE) || defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) || defined(PARSEC_HAVE_DEV_HIP_SUPPORT) */
 
 /* return a string meaningful for profiling about data */
 static int

--- a/parsec/include/parsec/parsec_options.h.in
+++ b/parsec/include/parsec/parsec_options.h.in
@@ -120,16 +120,24 @@
 #define CMAKE_PARSEC_C_FLAGS      "@CMAKE_C_FLAGS@"
 #define CMAKE_PARSEC_C_INCLUDES   "@PARSEC_C_INCLUDES@"
 
+/**
+ * The following 3 defines are deprecated. Instead users should
+ * rely on the corresponding PARSEC_HAVE_DEV_XXX_SUPPORT
+ */
+
 #cmakedefine PARSEC_HAVE_HWLOC
 #cmakedefine PARSEC_HAVE_PAPI
-#cmakedefine PARSEC_HAVE_CUDA
-#cmakedefine PARSEC_HAVE_HIP
-#cmakedefine PARSEC_HAVE_OPENCL
 #cmakedefine PARSEC_HAVE_MPI
 #cmakedefine PARSEC_HAVE_MPI_20
 #cmakedefine PARSEC_HAVE_MPI_30
 #cmakedefine PARSEC_HAVE_MPI_OVERTAKE
 #cmakedefine PARSEC_HAVE_AYUDAME
+
+#cmakedefine PARSEC_HAVE_DEV_CPU_SUPPORT
+#cmakedefine PARSEC_HAVE_DEV_RECURSIVE_SUPPORT
+#cmakedefine PARSEC_HAVE_DEV_CUDA_SUPPORT
+#cmakedefine PARSEC_HAVE_DEV_HIP_SUPPORT
+#cmakedefine PARSEC_HAVE_DEV_OPENCL_SUPPORT
 
 #define PARSEC_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
 /* Default PATH to look for the CUDA .so files */

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -38,9 +38,9 @@
 #include "parsec/runtime.h"
 #include "parsec/mca/device/device.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/mca/device/cuda/device_cuda.h"
-#endif  /* defined(PARSEC_HAVE_CUDA) */
+#endif  /* defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 
 #include "parsec/mca/mca_repository.h"
 #include "parsec/constants.h"
@@ -2329,12 +2329,12 @@ static parsec_hook_return_t parsec_dtd_gpu_task_submit(parsec_execution_stream_t
     parsec_device_module_t *device = parsec_mca_device_get(dev_index);
     assert(NULL != device);
     switch(device->type) {
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     case PARSEC_DEV_CUDA:
         gpu_task->stage_in  = parsec_default_cuda_stage_in;
         gpu_task->stage_out = parsec_default_cuda_stage_out;
         return parsec_cuda_kernel_scheduler(es, gpu_task, dev_index);
-#endif
+#endif  /* PARSEC_HAVE_DEV_CUDA_SUPPORT */
     default:
         parsec_fatal("DTD scheduling on device type %d: this is not a valid GPU device type in this build", device->type);
     }
@@ -2999,11 +2999,11 @@ parsec_insert_dtd_task(parsec_task_t *__this_task)
                         FLOW_OF(last_user.task, last_user.flow_index)->flags &= ~RELEASE_OWNERSHIP_SPECIAL;
 
                         if( this_task->super.data[flow_index].data_in != NULL) {
-/* #if defined(PARSEC_HAVE_CUDA) */
+/* #if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 /*                            parsec_atomic_lock(&this_task->super.data[flow_index].data_in->original->lock); */
 /* #endif */
                             (void)parsec_atomic_fetch_dec_int32(&this_task->super.data[flow_index].data_in->readers);
-/* #if defined(PARSEC_HAVE_CUDA) */
+/* #if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 /*                            parsec_atomic_unlock(&this_task->super.data[flow_index].data_in->original->lock); */
 /* #endif */
                         }
@@ -3042,12 +3042,12 @@ parsec_insert_dtd_task(parsec_task_t *__this_task)
                 if( last_user.task == this_task ) {
                     if((last_user.op_type & PARSEC_GET_OP_TYPE) == PARSEC_INPUT ) {
                         if( this_task->super.data[last_user.flow_index].data_in != NULL) {
-/* #if defined(PARSEC_HAVE_CUDA) */
+/* #if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 /*                            parsec_atomic_lock(&this_task->super.data[last_user.flow_index].data_in->original->lock); */
 /* #endif */
                             (void)parsec_atomic_fetch_dec_int32(
                                     &this_task->super.data[last_user.flow_index].data_in->readers);
-/* #if defined(PARSEC_HAVE_CUDA) */
+/* #if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 /*                            parsec_atomic_unlock(&this_task->super.data[last_user.flow_index].data_in->original->lock); */
 /* #endif */
                         }

--- a/parsec/interfaces/dtd/insert_function_internal.h
+++ b/parsec/interfaces/dtd/insert_function_internal.h
@@ -21,9 +21,9 @@
 #include "parsec/execution_stream.h"
 #include "parsec/mca/device/device_gpu.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/mca/device/cuda/device_cuda.h"
-#endif /* PARSEC_HAVE_CUDA */
+#endif /* PARSEC_HAVE_DEV_CUDA_SUPPORT */
 
 BEGIN_C_DECLS
 

--- a/parsec/mca/device/CMakeLists.txt
+++ b/parsec/mca/device/CMakeLists.txt
@@ -8,3 +8,12 @@ set_property(TARGET parsec
              APPEND PROPERTY
                     PUBLIC_HEADER_H mca/device/device.h
                                     mca/device/device_gpu.h)
+
+set(PARSEC_HAVE_DEV_CPU_SUPPORT 1 CACHE BOOL "PaRSEC has support for CPU kernels")
+set(PARSEC_HAVE_DEV_RECURSIVE_SUPPORT 1 CACHE BOOL  "PaRSEC has support for CPU kernels")
+if(PARSEC_HAVE_CUDA)
+  set(PARSEC_HAVE_DEV_CUDA_SUPPORT 1 CACHE BOOL "PaRSEC support for CUDA")
+endif(PARSEC_HAVE_CUDA)
+if(PARSEC_HAVE_HIP)
+  set(PARSEC_HAVE_DEV_HIP_SUPPORT 1 CACHE BOOL "PaRSEC support for HIP")
+endif(PARSEC_HAVE_HIP)

--- a/parsec/mca/device/cuda/device_cuda.h
+++ b/parsec/mca/device/cuda/device_cuda.h
@@ -11,7 +11,7 @@
 #include "parsec/class/parsec_object.h"
 #include "parsec/mca/device/device.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/class/list_item.h"
 #include "parsec/class/list.h"
 #include "parsec/class/fifo.h"
@@ -121,6 +121,6 @@ parsec_default_cuda_stage_out(parsec_gpu_task_t        *gtask,
 
 END_C_DECLS
 
-#endif /* defined(PARSEC_HAVE_CUDA) */
+#endif /* defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 
 #endif  /* PARSEC_DEVICE_CUDA_H_HAS_BEEN_INCLUDED */

--- a/parsec/mca/device/cuda/device_cuda_internal.h
+++ b/parsec/mca/device/cuda/device_cuda_internal.h
@@ -9,7 +9,7 @@
 
 #include "parsec/mca/device/cuda/device_cuda.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 
 BEGIN_C_DECLS
 
@@ -26,6 +26,6 @@ int parsec_cuda_module_fini(parsec_device_module_t* device);
 
 END_C_DECLS
 
-#endif /* defined(PARSEC_HAVE_CUDA) */
+#endif /* defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 
 #endif  /* PARSEC_DEVICE_CUDA_INTERNAL_H_HAS_BEEN_INCLUDED */

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -11,7 +11,7 @@
 #include "parsec/utils/mca_param.h"
 #include "parsec/constants.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/runtime.h"
 #include "parsec/data_internal.h"
 #include "parsec/mca/device/cuda/device_cuda_internal.h"
@@ -2762,4 +2762,4 @@ parsec_cuda_kernel_scheduler( parsec_execution_stream_t *es,
     return PARSEC_HOOK_RETURN_DISABLE;
 }
 
-#endif /* PARSEC_HAVE_CUDA */
+#endif /* PARSEC_HAVE_DEV_CUDA_SUPPORT */

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -850,6 +850,7 @@ int parsec_mca_device_attach(parsec_context_t* context)
         nb_total_comp_threads += context->virtual_processes[p]->nb_cores;
     }
 
+ #if defined(PARSEC_HAVE_DEV_CPU_SUPPORT)
     /* Add the predefined devices: one device for the CPUs */
     {
         parsec_device_cpus = (parsec_device_module_t*)calloc(1, sizeof(parsec_device_module_t));
@@ -861,7 +862,9 @@ int parsec_mca_device_attach(parsec_context_t* context)
         parsec_device_cpus->taskpool_register = device_taskpool_register_static;
         parsec_mca_device_add(context, parsec_device_cpus);
     }
+ #endif  /* defined(PARSEC_HAVE_DEV_CPU_SUPPORT) */
 
+#if defined(PARSEC_HAVE_DEV_RECURSIVE_SUPPORT)
     /* and one for the recursive kernels */
     {
         parsec_device_recursive = (parsec_device_module_t*)calloc(1, sizeof(parsec_device_module_t));
@@ -876,6 +879,7 @@ int parsec_mca_device_attach(parsec_context_t* context)
         parsec_device_recursive->taskpool_register = device_taskpool_register_static;
         parsec_mca_device_add(context, parsec_device_recursive);
     }
+#endif  /* defined(PARSEC_HAVE_DEV_RECURSIVE_SUPPORT) */
 
     for( int i = 0; NULL != (component = (parsec_device_base_component_t*)device_components[i]); i++ ) {
         for( int j = 0; NULL != (module = component->modules[j]); j++ ) {
@@ -981,7 +985,7 @@ void parsec_mca_device_taskpool_restrict(parsec_taskpool_t *tp,
             continue;
 
         /* Force unregistration for this type of device. This is not correct, as some of
-         * the memory related to the taskpoool might still be registered with the
+         * the memory related to the taskpool might still be registered with the
          * devices we drop support. */
         tp->devices_index_mask &= ~(1 << device->device_index);
     }

--- a/parsec/mca/device/transfer_gpu.c
+++ b/parsec/mca/device/transfer_gpu.c
@@ -18,9 +18,9 @@
 #include "parsec/utils/output.h"
 #include "parsec/scheduling.h"
 
-#if !defined(PARSEC_HAVE_CUDA) && !defined(PARSEC_HAVE_HIP)
+#if !defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && !defined(PARSEC_HAVE_DEV_HIP_SUPPORT)
 #error This file should not be included in a non-CUDA/HIP build
-#endif  /* !defined(PARSEC_HAVE_CUDA) && !defined(PARSEC_HAVE_HIP) */
+#endif  /* !defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && !defined(PARSEC_HAVE_DEV_HIP_SUPPORT) */
 
 /**
  * Entirely local tasks that should only be used to move data between a device and the main memory. Such
@@ -128,12 +128,12 @@ flow_of_gpu_d2h_task_direct_access( const parsec_gpu_d2h_task_t* this_task,
 }
 
 static const __parsec_chore_t __gpu_d2h_task_chores[] = {
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     {.type = PARSEC_DEV_CUDA,
      .evaluate = NULL,
      .hook = (parsec_hook_t *) hook_of_gpu_d2h_task},
 #endif
-#if defined(PARSEC_HAVE_HIP)
+#if defined(PARSEC_HAVE_DEV_HIP_SUPPORT)
     {.type = PARSEC_DEV_HIP,
      .evaluate = NULL,
      .hook = (parsec_hook_t *) hook_of_gpu_d2h_task},

--- a/parsec/mca/pins/ptg_to_dtd/pins_ptg_to_dtd_module.c
+++ b/parsec/mca/pins/ptg_to_dtd/pins_ptg_to_dtd_module.c
@@ -238,7 +238,7 @@ tile_manage_for_testing(parsec_data_t *data, parsec_data_key_t key, int arena_in
         tile->rank                  = 0;
         tile->flushed               = NOT_FLUSHED;
         tile->data_copy             = data->device_copies[0];
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
         tile->data_copy->readers    = 0;
 #endif
         tile->arena_index           = arena_index;

--- a/tests/dsl/dtd/dtd_test_new_tile.c
+++ b/tests/dsl/dtd/dtd_test_new_tile.c
@@ -23,7 +23,7 @@ static int TILE_FULL;
 static int32_t nb_errors = 0;
 static int verbose=0;
 
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
 extern void dtd_test_new_tile_init(int *dev_data, int nb, int idx);
 extern void dtd_test_new_tile_sum_add(int *dev_data, int nb, int idx, int *acc, int verbose);
 extern void dtd_test_new_tile_multiply_by_two(int *dev_data, int nb, int idx);
@@ -49,7 +49,7 @@ int cpu_set_to_i( parsec_execution_stream_t *es,
     return PARSEC_HOOK_RETURN_DONE;
 }
 
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
 int cuda_set_to_i(parsec_device_gpu_module_t *gpu_device,
                   parsec_gpu_task_t *gpu_task,
                   parsec_gpu_exec_stream_t *gpu_stream)
@@ -102,7 +102,7 @@ int cpu_multiply_by_2( parsec_execution_stream_t *es,
     return PARSEC_HOOK_RETURN_DONE;
 }
 
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
 int cuda_multiply_by_2(parsec_device_gpu_module_t *gpu_device,
                        parsec_gpu_task_t *gpu_task,
                        parsec_gpu_exec_stream_t *gpu_stream)
@@ -157,7 +157,7 @@ int cpu_accumulate( parsec_execution_stream_t *es,
     return PARSEC_HOOK_RETURN_DONE;
 }
 
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
 int cuda_accumulate(parsec_device_gpu_module_t *gpu_device,
                     parsec_gpu_task_t *gpu_task,
                     parsec_gpu_exec_stream_t *gpu_stream)
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
     int nb, rc, nb_gpus = 0;
     int32_t acc, expected = 0, *pacc = &acc, **gpu_accs = NULL;
     parsec_arena_datatype_t *adt;
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
     parsec_device_cuda_module_t **gpu_devices = NULL;
 #endif
 
@@ -246,7 +246,7 @@ int main(int argc, char **argv)
     parsec_profiling_start();
 #endif
 
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
     for(unsigned int i = 0; i < parsec_nb_devices; i++) {
         parsec_device_module_t *dev = parsec_mca_device_get(i);
         if( dev->type == PARSEC_DEV_CUDA )
@@ -309,7 +309,7 @@ int main(int argc, char **argv)
                                                                  sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "nb",
                                                                  sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "idx",
                                                                  PARSEC_DTD_ARG_END);
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
     parsec_dtd_task_class_add_chore(dtd_tp, first_tc, PARSEC_DEV_CUDA, cuda_set_to_i);
 #endif
     parsec_dtd_task_class_add_chore(dtd_tp, first_tc, PARSEC_DEV_CPU, cpu_set_to_i);
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
                                                                   sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "nb",
                                                                   sizeof(int), PARSEC_VALUE | PARSEC_PROFILE_INFO, "idx",
                                                                   PARSEC_DTD_ARG_END);
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
     parsec_dtd_task_class_add_chore(dtd_tp, second_tc, PARSEC_DEV_CUDA, cuda_multiply_by_2);
 #endif
     parsec_dtd_task_class_add_chore(dtd_tp, second_tc, PARSEC_DEV_CPU, cpu_multiply_by_2);
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
                                                                   sizeof(int), PARSEC_REF,
                                                                   sizeof(int*), PARSEC_REF,
                                                                   PARSEC_DTD_ARG_END);
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
     parsec_dtd_task_class_add_chore(dtd_tp, third_tc, PARSEC_DEV_CUDA, cuda_accumulate);
 #endif
     parsec_dtd_task_class_add_chore(dtd_tp, third_tc, PARSEC_DEV_CPU, cpu_accumulate);
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
         int first_pushout = PARSEC_DTD_EMPTY_FLAG;
         int second_pushout = PARSEC_DTD_EMPTY_FLAG;
         int third_pushout = PARSEC_DTD_EMPTY_FLAG;
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
         if(first_on_gpu && !second_on_gpu) first_pushout = PARSEC_PUSHOUT;
         if(second_on_gpu && !third_on_gpu) second_pushout = PARSEC_PUSHOUT;
         if(third_on_gpu) third_pushout = PARSEC_PUSHOUT;
@@ -426,7 +426,7 @@ int main(int argc, char **argv)
 
     free(new_tiles);
 
-#if defined(PARSEC_HAVE_CUDA) && defined(PARSEC_HAVE_CU_COMPILER)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) && defined(PARSEC_HAVE_CU_COMPILER)
     for(int i = 0; i < nb_gpus; i++) {
         cudaError_t status;
         parsec_device_cuda_module_t *gpu_device = gpu_devices[i];

--- a/tests/dsl/dtd/dtd_test_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_test_simple_gemm.c
@@ -353,7 +353,7 @@ int *get_gpu_device_index()
 
 static void destroy_cublas_handle(void *_h, void *_n)
 {
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     cublasHandle_t cublas_handle = (cublasHandle_t)_h;
     cublasDestroy_v2(cublas_handle);
 #endif
@@ -363,7 +363,7 @@ static void destroy_cublas_handle(void *_h, void *_n)
 
 static void *create_cublas_handle(void *obj, void *p)
 {
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     cublasHandle_t handle;
     cublasStatus_t status;
     parsec_cuda_exec_stream_t *stream = (parsec_cuda_exec_stream_t *)obj;
@@ -384,7 +384,7 @@ static void *create_cublas_handle(void *obj, void *p)
 
 static void destroy_one_on_device(void *_h, void *_n)
 {
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     cudaFree(_h);
 #endif
     (void)_h;
@@ -395,7 +395,7 @@ static void *allocate_one_on_device(void *obj, void *p)
 {
      (void)obj;
      (void)p;
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
      void *one_device;
      double one_host = 1.0;
      cudaError_t cr;

--- a/tests/dsl/ptg/CMakeLists.txt
+++ b/tests/dsl/ptg/CMakeLists.txt
@@ -3,6 +3,9 @@ add_Subdirectory(ptgpp)
 parsec_addtest_executable(C strange)
 target_ptg_sources(strange PRIVATE "strange.jdf")
 
+parsec_addtest_executable(C recursive)
+target_ptg_sources(recursive PRIVATE "recursive.jdf")
+
 if(PARSEC_HAVE_RANDOM)
   parsec_addtest_executable(C startup)
   target_ptg_sources(startup PRIVATE "startup.jdf")

--- a/tests/dsl/ptg/cuda/cuda_test_internal.h
+++ b/tests/dsl/ptg/cuda/cuda_test_internal.h
@@ -11,7 +11,7 @@
 #include "parsec/execution_stream.h"
 #include "parsec/utils/mca_param.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/mca/device/cuda/device_cuda.h"
 #endif
 

--- a/tests/dsl/ptg/cuda/get_best_device_check.jdf
+++ b/tests/dsl/ptg/cuda/get_best_device_check.jdf
@@ -33,7 +33,7 @@ READ A <- descA(m, n)
 
 BODY
 {
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     if( nb_cuda_devices > 0 ) {
         int g = (n * descA->nt + m) % nb_cuda_devices; 
         parsec_advise_data_on_device( _f_A->original,
@@ -63,7 +63,7 @@ WRITE B <- NEW
 
 BODY [type=CUDA weight=m+n+1]
 {   
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     if( nb_cuda_devices > 0 ) { 
         int g = (n * descA->nt + m) % nb_cuda_devices;
         int my_device =  cuda_device->cuda_index;
@@ -133,7 +133,7 @@ parsec_get_best_device_check_New(parsec_tiled_matrix_t *dcA, int *info)
     taskpool = parsec_get_best_device_check_new(dcA, info); 
     get_best_device_check_taskpool = (parsec_taskpool_t*)taskpool;
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     /** Find all CUDA devices */
     int nb = 0;
     for(int i = 0; i < (int)parsec_nb_devices; i++) {
@@ -174,7 +174,7 @@ static void
 __parsec_taskpool_get_best_device_check_destructor(parsec_get_best_device_check_taskpool_t *get_best_device_check_taskpool)
 {
     parsec_del2arena(&get_best_device_check_taskpool->arenas_datatypes[PARSEC_get_best_device_check_DEFAULT_ADT_IDX]);
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     if( NULL != get_best_device_check_taskpool->_g_cuda_device_index )
         free(get_best_device_check_taskpool->_g_cuda_device_index);
 #endif

--- a/tests/dsl/ptg/cuda/nvlink.jdf
+++ b/tests/dsl/ptg/cuda/nvlink.jdf
@@ -18,7 +18,7 @@ extern "C" %{
 #if defined(PARSEC_HAVE_MPI)
 #include <mpi.h>
 #endif  /* defined(PARSEC_HAVE_MPI) */
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/mca/device/device.h"
 #include <cublas_v2.h>
 
@@ -34,7 +34,7 @@ typedef cublasStatus_t (*cublas_dgemm_v2_t) ( cublasHandle_t handle,
                                               const double *B, int ldb,
                                               const double *beta,
                                               double       *C, int ldc);
-#endif  /* defined(PARSEC_HAVE_CUDA) */
+#endif  /* defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 
 %}
 

--- a/tests/dsl/ptg/cuda/nvlink_wrapper.c
+++ b/tests/dsl/ptg/cuda/nvlink_wrapper.c
@@ -13,13 +13,13 @@
 #include "parsec/execution_stream.h"
 #include "parsec/class/info.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include <cublas_v2.h>
 #endif
 
 #include "nvlink.h"
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 static void destruct_cublas_handle(void *p)
 {
     cublasHandle_t handle = (cublasHandle_t)p;
@@ -49,7 +49,7 @@ static void *create_cublas_handle(void *obj, void *p)
 
 static void destroy_cublas_handle(void *_h, void *_n)
 {
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     cublasHandle_t cublas_handle = (cublasHandle_t)_h;
     cublasDestroy_v2(cublas_handle);
 #endif
@@ -125,7 +125,7 @@ parsec_taskpool_t* testing_nvlink_New( parsec_context_t *ctx, int depth, int mb 
         }
     }
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     parsec_info_id_t CuHI = parsec_info_register(&parsec_per_stream_infos, "CUBLAS::HANDLE",
                                                  destroy_cublas_handle, NULL,
                                                  create_cublas_handle, NULL,

--- a/tests/dsl/ptg/cuda/stage_custom.jdf
+++ b/tests/dsl/ptg/cuda/stage_custom.jdf
@@ -16,10 +16,10 @@ extern "C" %{
 #include <stdarg.h>
 #include <sys/time.h>
 #include <mpi.h>
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/mca/device/cuda/device_cuda_internal.h"
 #include <cublas.h>
-#endif  /* defined(PARSEC_HAVE_CUDA) */
+#endif  /* defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 
 #include "stage_custom.h"
 

--- a/tests/dsl/ptg/cuda/stress.jdf
+++ b/tests/dsl/ptg/cuda/stress.jdf
@@ -18,10 +18,10 @@ extern "C" %{
 #if defined(PARSEC_HAVE_MPI)
 #include <mpi.h>
 #endif  /* defined(PARSEC_HAVE_MPI) */
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include "parsec/mca/device/cuda/device_cuda_internal.h"
 #include <cublas.h>
-#endif  /* defined(PARSEC_HAVE_CUDA) */
+#endif  /* defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 
 #include "stress.h"
 

--- a/tests/dsl/ptg/cuda/testing_get_best_device.c
+++ b/tests/dsl/ptg/cuda/testing_get_best_device.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
         }
     }
 
-#if defined(PARSEC_HAVE_CUDA)
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     extern char **environ;
     char *value;
     if( nb_gpus < 1 && 0 == rank ) {

--- a/tests/dsl/ptg/recursive.jdf
+++ b/tests/dsl/ptg/recursive.jdf
@@ -1,0 +1,180 @@
+extern "C" %{
+/*
+ * Copyright (c) 2023      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation. All rights
+ *                         reserved.
+ */
+
+#include <sys/time.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include "parsec/data_dist/matrix/two_dim_rectangle_cyclic.h"
+#include "parsec/data_dist/matrix/subtile.h"
+
+#include "recursive.h" /* generated header */
+
+/**
+ * This test stresses the recursive capability of the runtime. The JDF describes
+ * a sequential process going from 0 to X, and on each task starting again a
+ * recursive process going from 0 to X-1
+ */
+
+ #if defined(PARSEC_HAVE_DEV_RECURSIVE_SUPPORT)
+ #include "parsec/recursive.h"
+/*
+ * A function to recursively complete a recursive taskpool.
+ */
+static void parsec_recursive_callback(parsec_taskpool_t* _tp, const parsec_recursive_callback_t* data)
+{
+    parsec_recursive_taskpool_t* tp = (parsec_recursive_taskpool_t*)_tp;
+    __parsec_recursive_DO_SOMETHING_task_t* task = (__parsec_recursive_DO_SOMETHING_task_t*)data->task;
+
+    /*parsec_taskpool_free(tp);*/
+    PARSEC_OBJ_RELEASE(_tp);
+ }
+ #endif  /* defined(PARSEC_HAVE_DEV_RECURSIVE_SUPPORT) */
+
+%}
+
+descA      [type = "parsec_matrix_block_cyclic_t*"]
+level      [type = int]
+NI         [type = int]
+pri        [type = int default = 0 hidden = on]
+
+DO_SOMETHING(i)
+
+  i = 0 .. NI-1
+
+  prio = %{ return pri == 2 ? (int)(random()) : ((i + NI*level)*pri); %}
+
+  : descA(i,0)
+
+  READ A <- descA(i, 0)
+         -> descA(i, 0)
+
+  ; prio
+
+BODY  [type=RECURSIVE]
+{
+    /* Last level, we're done no more recursion. Fall back onto the CPU kernel */
+    if( 0 == level )
+      return PARSEC_HOOK_RETURN_NEXT;
+
+    parsec_taskpool_t *recursive_tp;
+    subtile_desc_t *small_descT;
+
+    small_descT = subtile_desc_create( descA, level-1, 1, 5, 5, 0, 0, 1, 1 );
+
+    small_descT->mat = A;
+
+    recursive_tp = parsec_recursive_new((parsec_tiled_matrix_t *)small_descT, level-1, NI );
+
+    parsec_recursivecall((parsec_task_t*)this_task,
+                         recursive_tp, parsec_recursive_callback,
+                         1, small_descT);
+
+    return PARSEC_HOOK_RETURN_ASYNC;
+}
+END
+
+BODY  [type=CPU]
+{
+    fprintf(stderr, "do_something(level=%d, i=%d): prio=%d\n", level, i, prio );
+}
+END
+
+extern "C" %{
+
+#define NN    3
+#define TYPE  PARSEC_MATRIX_FLOAT
+
+int main( int argc, char** argv )
+{
+    parsec_recursive_taskpool_t* tp;
+    parsec_matrix_block_cyclic_t descA;
+    parsec_arena_datatype_t adt;
+    parsec_datatype_t dt;
+    parsec_context_t *parsec;
+    int ni = NN, level = 3, verbose = 0, i = 1, rc;
+    long time_elapsed;
+
+#ifdef PARSEC_HAVE_MPI
+    {
+        int provided;
+        MPI_Init_thread(NULL, NULL, MPI_THREAD_SERIALIZED, &provided);
+    }
+#endif
+
+    int pargc = 0; char **pargv = NULL;
+    for( i = 1; i < argc; i++) {
+        if( 0 == strncmp(argv[i], "--", 3) ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
+        if( 0 == strncmp(argv[i], "-i=", 3) ) {
+            ni = strtol(argv[i]+3, NULL, 10);
+            continue;
+        }
+        if( 0 == strncmp(argv[i], "-l=", 3) ) {
+            level = strtol(argv[i]+3, NULL, 10);
+            continue;
+        }
+        if( 0 == strncmp(argv[i], "-v=", 3) ) {
+            verbose = strtol(argv[i]+3, NULL, 10);
+            continue;
+        }
+    }
+
+    parsec = parsec_init(-1, &pargc, &pargv);
+    if( NULL == parsec ) {
+       exit(-1);
+    }
+
+    /**
+     * Build the data and the arena to hold it up.
+     */
+    parsec_matrix_block_cyclic_init(&descA, TYPE, PARSEC_MATRIX_TILE,
+                                    0 /*rank*/,
+                                    NN, NN, ni * NN, NN,
+                                    0, 0, ni * NN, NN, 1, 1, 1, 1, 0, 0);
+    descA.mat = parsec_data_allocate(descA.super.nb_local_tiles *
+                                     descA.super.bsiz *
+                                     parsec_datadist_getsizeoftype(TYPE));
+
+    parsec_translate_matrix_type(TYPE, &dt);
+    parsec_add2arena_rect(&adt, dt,
+                                 descA.super.mb, descA.super.nb, descA.super.mb);
+
+    /* Start the PaRSEC engine */
+    rc = parsec_context_start(parsec);
+    PARSEC_CHECK_ERROR(rc, "parsec_context_start");
+
+    /* Heat up the engine: small tasks no priority */
+    tp = parsec_recursive_new( &descA, level, ni );
+    assert( NULL != tp );
+    tp->arenas_datatypes[PARSEC_recursive_DEFAULT_ADT_IDX] = adt;
+    PARSEC_OBJ_RETAIN(adt.arena);
+
+    tp->_g_pri = 0;
+    rc = parsec_context_add_taskpool( parsec, (parsec_taskpool_t*)tp );
+    PARSEC_CHECK_ERROR(rc, "parsec_context_add_taskpool");
+    rc = parsec_context_wait(parsec);
+    parsec_taskpool_free(&tp->super);
+    PARSEC_CHECK_ERROR(rc, "parsec_context_wait");
+
+    free(descA.mat);
+    PARSEC_OBJ_RELEASE(adt.arena);
+    parsec_del2arena( & adt );
+
+    parsec_fini( &parsec);
+
+#ifdef PARSEC_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return 0;
+}
+
+%}

--- a/tests/dsl/ptg/startup.jdf
+++ b/tests/dsl/ptg/startup.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2019-2020 The Universiy of Tennessee and The Universiy
+ * Copyright (c) 2019-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  */
@@ -13,7 +13,7 @@ extern "C" %{
 
 /**
  * This test stress the startup mechanism by generating NI*NJ*NK independent
- * tasks from the begining. A sequential startup will incur a high overhead,
+ * tasks from the beginning. A sequential startup will incur a high overhead,
  * while a more parallel startup will mitigate this overhead.
  *
  * The behavior of the test is altered by the defined priority, -1 and 1 is


### PR DESCRIPTION
PARSEC_HAVE_CUDA is for CMake. In PaRSEC we should use PARSEC_HAVE_DEV_CUDA_SUPPORT. This applies to all devices, including RECURSIVE and CPU. 

This PR also allows for specifying [type=CPU] next to a body and still do the right thing.