### PR TITLE
Termdet callback order

### DIFF
--- a/parsec/compound.c
+++ b/parsec/compound.c
@@ -57,6 +57,7 @@ parsec_compound_taskpool_startup( parsec_context_t *context,
     for( int i = 0; i < compound->nb_taskpools; i++ ) {
         parsec_taskpool_t* o = compound->taskpool_array[i];
         assert( NULL != o );
+        assert( NULL == o->on_complete );
         o->on_complete      = parsec_composed_taskpool_cb;
         o->on_complete_data = compound;
     }

--- a/parsec/data_dist/matrix/map_operator.c
+++ b/parsec/data_dist/matrix/map_operator.c
@@ -532,6 +532,7 @@ parsec_map_operator_New(const parsec_tiled_matrix_t* src,
     tp->dest    = dest;
     tp->op      = op;
     tp->op_data = op_data;
+    tp->next_n  = 0;
     tp->super.taskpool_id = 1111;
     tp->super.nb_tasks = src->nb_local_tiles;
     tp->super.task_classes_array = (const parsec_task_class_t **)


### PR DESCRIPTION
Fixes one bug in operator_map.c (found during testing campaign), and rollback some changes in termdet_local, to address issue 464