### PR TITLE
Fix the branching test in distributed

### DIFF
--- a/tests/dsl/ptg/branching/branching_wrapper.c
+++ b/tests/dsl/ptg/branching/branching_wrapper.c
@@ -35,6 +35,7 @@ PARSEC_OBJ_CLASS_INSTANCE(parsec_branching_taskpool_t, parsec_taskpool_t,
 parsec_taskpool_t *branching_new(parsec_data_collection_t *A, int size, int nb)
 {
     parsec_branching_taskpool_t *tp = NULL;
+    parsec_datatype_t block;
 
     if( nb <= 0 || size <= 0 ) {
         fprintf(stderr, "To work, BRANCHING nb and size must be > 0\n");
@@ -42,6 +43,14 @@ parsec_taskpool_t *branching_new(parsec_data_collection_t *A, int size, int nb)
     }
 
     tp = parsec_branching_new(A, nb);
+    
+    ptrdiff_t lb, extent;
+    parsec_type_create_contiguous(size, parsec_datatype_int_t, &block);
+    parsec_type_extent(block, &lb, &extent);
+
+    parsec_arena_datatype_construct( &tp->arenas_datatypes[PARSEC_branching_DEFAULT_ADT_IDX],
+                                     extent, PARSEC_ARENA_ALIGNMENT_SSE,
+                                     block );
 
     return (parsec_taskpool_t*)tp;
 }

--- a/tests/dsl/ptg/branching/main.c
+++ b/tests/dsl/ptg/branching/main.c
@@ -67,16 +67,27 @@ int main(int argc, char *argv[])
     free_data(dcA);
 
     parsec_fini(&parsec);
-
-    printf("nb_taskA = %d, nb_taskB = %d, nb_taskC = %d\n", nb_taskA, nb_taskB, nb_taskC);
+#if defined(PARSEC_HAVE_MPI)
+    int gnbA, gnbB, gnbC;
+    MPI_Allreduce(&nb_taskA, &gnbA, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&nb_taskB, &gnbB, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&nb_taskC, &gnbC, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+#else
+    int gnbA = nb_taskA;
+    int gnbB = nb_taskB;
+    int gnbC = nb_taskC;
+#endif
+    printf("nb = %d, nb_taskA = %d, nb_taskB = %d, nb_taskC = %d -- %s\n", nb, 
+           gnbA, gnbB, gnbC,
+           gnbA == nb && gnbB == 2*nb && gnbC == nb ? "SUCCESS" : "FAILURE!");
 
 #ifdef PARSEC_HAVE_MPI
     MPI_Finalize();
 #endif
 
-    if( nb_taskA == nb &&
-        nb_taskB == 2*nb &&
-        nb_taskC == nb )
+    if( gnbA == nb &&
+        gnbB == 2*nb &&
+        gnbC == nb )
         return EXIT_SUCCESS;
     return EXIT_FAILURE;
 }


### PR DESCRIPTION
We still need to create the default arena datatype!

In DPLASMA, JDFs do not use the default type, and they use an external arena_datatype storage to support LAPACK+Tile format and datatype caching... However that doesn't mean that arena datatypes can be simply inherited from the data!

Also fix the exit condition to work in distributed for branching.