### PR TITLE
Make parsec_data_t::device_copies a flexible array member

### DIFF
--- a/parsec/data_internal.h
+++ b/parsec/data_internal.h
@@ -37,7 +37,7 @@ struct parsec_data_s {
                                                   * are multiple choices. -1 means no preference. */
     struct parsec_data_collection_s*     dc;
     uint32_t                   nb_elts;          /* size in bytes of the memory layout */
-    struct parsec_data_copy_s *device_copies[1]; /* this array allocated according to the number of devices
+    struct parsec_data_copy_s *device_copies[];  /* this array allocated according to the number of devices
                                                   * (parsec_nb_devices). It points to the most recent
                                                   * version of the data.
                                                   */


### PR DESCRIPTION
This prevents developers from allocating parsec_data_t statically.