### PR TITLE
Fix an issue about GPU statistics (Issue#505)

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -1394,13 +1394,13 @@ parsec_gpu_data_stage_in( parsec_device_cuda_module_t* cuda_device,
     if( NULL == task_data->source_repo_entry && NULL == task_data->data_in->original->dc && in_elem->version == 0 )
         transfer_from = -1;
 
+    /* Update the transferred required_data_in size */
+    gpu_device->super.required_data_in += original->nb_elts;
+
     /* Do not need to be transferred */
     if( -1 == transfer_from ) {
         gpu_elem->data_transfer_status = PARSEC_DATA_STATUS_COMPLETE_TRANSFER;
     } else {
-        /* Update the transferred required_data_in size */
-        gpu_device->super.required_data_in += original->nb_elts;
-
         /* If it is already under transfer, don't schedule the transfer again.
          * This happens if the task refers twice (or more) to the same input flow */
         if( gpu_elem->data_transfer_status == PARSEC_DATA_STATUS_UNDER_TRANSFER ) {


### PR DESCRIPTION
I checked one example of two tile sizes.  It seems only the `Required Data In` is incorrect. Here are some details of the calculation.

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/7669037/227667784-9aca2fc1-e85b-43c5-b474-33ea015304ca.png">

<img width="969" alt="image" src="https://user-images.githubusercontent.com/7669037/227667592-c073269c-aa99-4295-a961-d1fcdd7dbc8f.png">
