### PR TITLE
Handle the tertiary case for startup tasks.

### DIFF
--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -2921,23 +2921,27 @@ static void jdf_generate_direct_input_conditions(const jdf_t *jdf, const jdf_fun
 
             assert( continue_if_true || goto_if_false || goto_if_true );
             jdf_expr_t *ld;
+            int inside_lv_loop = 0;
             if( NULL != dep->guard->guard->local_variables ) {
+                coutput("  {\n"
+                        "    int __active_dep_found = 0;\n");
+                inside_lv_loop = 1;
                 for(ld = jdf_expr_lv_first(dep->guard->guard->local_variables);
                     ld != NULL; ld = jdf_expr_lv_next(dep->guard->guard->local_variables, ld)) {
                     assert(NULL != ld->alias);
                     assert(-1 != ld->ldef_index);
-                    coutput("  int %s;\n", ld->alias);
+                    coutput("    int %s;\n", ld->alias);
                     if(JDF_RANGE == ld->op) {
-                        coutput("  for( %s = %s;",
+                        coutput("    for( %s = %s;",
                                 ld->alias, dump_expr((void**)ld->jdf_ta1, &info));
-                        coutput("%s <= %s; %s+=",
+                        coutput("(!__active_dep_found) && (%s <= %s); %s+=",
                                 ld->alias, dump_expr((void**)ld->jdf_ta2, &info), ld->alias);
                         coutput("%s) {\n"
-                                "     "JDF2C_NAMESPACE"_tmp_locals.ldef[%d].value = %s;\n",
+                                "       "JDF2C_NAMESPACE"_tmp_locals.ldef[%d].value = %s;\n",
                                 dump_expr((void**)ld->jdf_ta3, &info),
                                 ld->ldef_index, ld->alias);
                     } else {
-                        coutput("  "JDF2C_NAMESPACE"_tmp_locals.ldef[%d].value = %s = %s;\n",
+                        coutput("    "JDF2C_NAMESPACE"_tmp_locals.ldef[%d].value = %s = %s;\n",
                                 ld->ldef_index, ld->alias, dump_expr((void**)ld, &info));
                     }
                 }
@@ -2952,18 +2956,27 @@ static void jdf_generate_direct_input_conditions(const jdf_t *jdf, const jdf_fun
                         nextname);
                 write_next_label = 1;
             } if( continue_if_true) {
-                coutput("  if( %s ) continue; /* %s %s() is not a memory reference for flow %s */\n",
-                        dump_expr((void**)dep->guard->guard, &info),
-                        dep->guard->calltrue->var, dep->guard->calltrue->func_or_mem,
-                        flow->varname);
+                if(inside_lv_loop) {
+                    coutput("  if( %s ) { __active_dep_found = 1; break; /* %s %s() is not a memory reference for flow %s */ }\n",
+                            dump_expr((void**)dep->guard->guard, &info),
+                            dep->guard->calltrue->var, dep->guard->calltrue->func_or_mem,
+                            flow->varname);
+                } else {
+                    coutput("  if( %s ) continue; /* %s %s() is not a memory reference for flow %s */\n",
+                            dump_expr((void**)dep->guard->guard, &info),
+                            dep->guard->calltrue->var, dep->guard->calltrue->func_or_mem,
+                            flow->varname);
+                }
             }
-            if( NULL != dep->guard->guard->local_variables ) {
+            if( inside_lv_loop ) {
                 for(ld = jdf_expr_lv_first(dep->guard->guard->local_variables);
                     ld != NULL; ld = jdf_expr_lv_next(dep->guard->guard->local_variables, ld)) {
                     if(JDF_RANGE == ld->op) {
                         coutput("  }\n");
                     }
                 }
+                coutput("    if(__active_dep_found) continue;\n"
+                        "  }\n");
             }
         }
 

--- a/tests/dsl/ptg/local-indices/local_indices.jdf
+++ b/tests/dsl/ptg/local-indices/local_indices.jdf
@@ -31,9 +31,10 @@ even = [ i = 0 .. 4 ] 2*i
 READ A <- descA((odd/2) % descA->super.mt, (even/2) % descA->super.nt)
        -> [ i = 0 .. odd ] odd < 4 ? [ j = 0 .. %{ return even; %} .. 2 ] A tA(odd, even, %{ return i; %}, j/2) : [ j = 0 .. even .. 2 ] A tB(odd, even, i, j/2)
 
-CTL  X <- [ i = 0 .. odd ] i == -1 ? X STARTUP(0, 0)
-       -> [ i = 0 .. odd ] i == -1 ? X STARTUP(0, 0)
+CTL  X <- [ i = 0 .. odd ] i == -1 ? X STARTUP(0, 0)  // Non-existent control dependency -- only to check conditions are followed
+       -> [ i = 0 .. odd ] i == -1 ? X STARTUP(0, 0)  // Non-existent control dependency -- only to check conditions are followed
        -> Y tG(0)
+       -> Z tG(0)
 
 BODY
 {
@@ -49,9 +50,11 @@ zero = 0 .. 0
 : descA(0, 0)
 
 CTL Y <- [ i = 0 .. 4, j = 0 .. 4 ] i >= 0 ? X STARTUP(2*i+1, 2*j)
+CTL Z <- [ i = 0 .. 4, j = 0 .. 4 ] i >= 0 ? X STARTUP(2*i+1, 2*j)  // Completely redundant dependency, just to check that generated code uses proper scope for local variable declaration
 
 BODY
 {
+   assert(nb_tasks_array[0] == 25); // tG(0) can only execute after all STARTUP tasks have executed
    /* nothing */
 }
 END
@@ -212,6 +215,8 @@ int main( int argc, char** argv )
             ret++;
         }
     }
+
+    parsec_taskpool_free(&tp->super);
 
     free(descA.mat);
     parsec_del2arena( & adt );


### PR DESCRIPTION
Stop the code generation if we reach a tertiary where both sides depend on predecessor tasks.