### PR TITLE
Gpu workspace fix

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -809,6 +809,7 @@ parsec_cuda_flush_lru( parsec_device_module_t *device )
     /* Free all memory on GPU */
     parsec_cuda_memory_release_list(cuda_device, &gpu_device->gpu_mem_lru);
     parsec_cuda_memory_release_list(cuda_device, &gpu_device->gpu_mem_owned_lru);
+    parsec_gpu_free_workspace(gpu_device);
 #if !defined(PARSEC_GPU_CUDA_ALLOC_PER_TILE) && !defined(_NDEBUG)
     if( (in_use = zone_in_use(gpu_device->memory)) != 0 ) {
         parsec_warning("GPU[%s] memory leak detected: %lu bytes still allocated on GPU",

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -195,7 +195,10 @@ void* parsec_gpu_pop_workspace(parsec_device_gpu_module_t* gpu_device,
 #endif
         }
     }
-    assert (gpu_stream->workspace->stack_head >= 0);
+    if (gpu_stream->workspace->stack_head < 0) {
+        parsec_fatal("parsec_gpu_pop_workspace: user requested more than %d GPU workspaces which is the current hard-coded limit per GPU stream\n", PARSEC_GPU_MAX_WORKSPACE);
+        return NULL;
+    }
     work = gpu_stream->workspace->workspace[gpu_stream->workspace->stack_head];
     gpu_stream->workspace->stack_head --;
 #endif /* !defined(PARSEC_GPU_ALLOC_PER_TILE) */


### PR DESCRIPTION
See two commits:
  - issue an error when the user code requires more than the limit in number of workspace per stream, instead of checking only in debug mode
  - garbage collect workspace memory when we free the GPU memory
