### PR TITLE
Gpu fix load balancing

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013-2022 The University of Tennessee and The University
+ * Copyright (c) 2013-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2297,12 +2297,12 @@ static parsec_hook_return_t parsec_dtd_gpu_task_submit(parsec_execution_stream_t
 {
     (void) es;
     int dev_index;
-    double ratio = 1.0;
+    int64_t load;
     parsec_gpu_task_t *gpu_task;
     parsec_dtd_task_t *dtd_task = (parsec_dtd_task_t *)this_task;
     parsec_dtd_task_class_t *dtd_tc = (parsec_dtd_task_class_t*)this_task->task_class;
 
-    dev_index = parsec_get_best_device(this_task, ratio);
+    dev_index = parsec_get_best_device(this_task, &load);
     assert(dev_index >= 0);
     if (dev_index < 2) {
         return PARSEC_HOOK_RETURN_NEXT; /* Fall back */
@@ -2314,7 +2314,7 @@ static parsec_hook_return_t parsec_dtd_gpu_task_submit(parsec_execution_stream_t
     gpu_task->ec = (parsec_task_t *) this_task;
     gpu_task->submit = dtd_tc->gpu_func_ptr;
     gpu_task->task_type = 0;
-    gpu_task->load = ratio * parsec_device_sweight[dev_index];
+    gpu_task->load = load;
     gpu_task->last_data_check_epoch = -1;       /* force at least one validation for the task */
     gpu_task->pushout = 0;
     for(int i = 0; i < dtd_tc->super.nb_flows; i++) {
@@ -2324,7 +2324,6 @@ static parsec_hook_return_t parsec_dtd_gpu_task_submit(parsec_execution_stream_t
         gpu_task->flow[i] = dtd_tc->super.in[i];
         gpu_task->flow_nb_elts[i] = this_task->data[i].data_in->original->nb_elts;
     }
-    parsec_device_load[dev_index] += (float)gpu_task->load;
 
     parsec_device_module_t *device = parsec_mca_device_get(dev_index);
     assert(NULL != device);

--- a/parsec/interfaces/ptg/ptg-compiler/jdf.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 The University of Tennessee and The University
+ * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/parsec/interfaces/ptg/ptg-compiler/jdf.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf.c
@@ -31,6 +31,7 @@ static char *FUNCTION_PROPERTY_KEYWORDS[] = {
     JDF_PROP_UD_FIND_DEPS_FN_NAME,
     JDF_PROP_UD_ALLOC_DEPS_FN_NAME,
     JDF_PROP_UD_FREE_DEPS_FN_NAME,
+    "time_estimate",
     NULL
 };
 

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -40,6 +40,7 @@ static const char *jdf_cfilename;
 /* Optional declarations of local functions */
 static int jdf_expr_depends_on_symbol(const char *varname, const jdf_expr_t *expr);
 static void jdf_generate_code_hooks(const jdf_t *jdf, const jdf_function_entry_t *f, const char *fname);
+static void jdf_generate_code_time_estimate(const jdf_t *jdf, const jdf_function_entry_t *f, char *name);
 static void jdf_generate_code_data_lookup(const jdf_t *jdf, const jdf_function_entry_t *f, const char *fname);
 static void jdf_generate_code_release_deps(const jdf_t *jdf, const jdf_function_entry_t *f, const char *fname);
 static void jdf_generate_code_iterate_successors_or_predecessors(const jdf_t *jdf, const jdf_function_entry_t *f,
@@ -4299,6 +4300,9 @@ static void jdf_generate_one_function( const jdf_t *jdf, jdf_function_entry_t *f
     jdf_generate_code_data_lookup(jdf, f, prefix);
     string_arena_add_string(sa, "  .prepare_output = (parsec_hook_t*)%s,\n", "NULL");
     string_arena_add_string(sa, "  .prepare_input = (parsec_hook_t*)%s,\n", prefix);
+    sprintf(prefix, "time_estimate_of_%s_%s", jdf_basename, f->fname);
+    jdf_generate_code_time_estimate(jdf, f, prefix);
+    string_arena_add_string(sa, "  .time_estimate = %s,\n", prefix);
     sprintf(prefix, "datatype_lookup_of_%s_%s", jdf_basename, f->fname);
     jdf_generate_code_datatype_lookup(jdf, f, prefix);
     string_arena_add_string(sa, "  .get_datatype = (parsec_datatype_lookup_t*)%s,\n", prefix);
@@ -6394,6 +6398,24 @@ jdf_generate_code_datatype_lookup(const jdf_t *jdf,
 }
 
 static void
+jdf_generate_code_time_estimate(const jdf_t *jdf,
+                                const jdf_function_entry_t *f,
+                                char *name) 
+{
+    jdf_def_list_t *prop = NULL;
+
+    (void)jdf;
+
+    jdf_find_property(f->properties, "time_estimate", &prop);
+    if(NULL != prop) {
+        sprintf(name, "%s", prop->expr->jdf_var);
+        return;
+    }
+
+    sprintf(name, "NULL");
+}
+
+static void
 jdf_generate_code_data_lookup(const jdf_t *jdf,
                               const jdf_function_entry_t *f,
                               const char *name)
@@ -6529,12 +6551,11 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
     jdf_def_list_t *stage_out_property;
     jdf_def_list_t *size_property;
     jdf_def_list_t *desc_property;
-    jdf_def_list_t *weight_property;
     jdf_def_list_t *device_property;
+    jdf_def_list_t *prop;
     const char *dyld;
     const char *dyldtype;
     const char *device;
-    const char *weight;
     string_arena_t *sa, *sa2, *sa3;
     assignment_info_t ai;
     init_from_data_info_t ai2;
@@ -6549,6 +6570,15 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
     jdf_find_property(body->properties, "type", &type_property);
     char* dev_upper = strdup_upper(type_property->expr->jdf_var);
     char* dev_lower = strdup_lower(type_property->expr->jdf_var);
+
+    jdf_find_property(body->properties, "weight", &prop);
+    if(NULL != prop) {
+        jdf_warn(JDF_OBJECT_LINENO(body), 
+                "Parameterized Task '%s' defines the obsolete property 'weight' in its %s body to guide the selection of devices.\n"
+                "This has been superseded by the more flexible property 'time_estimate'. Please fix your JDF file.\n"
+                "-- Property 'weight' ignored.",
+                f->fname, dev_upper);
+    }
 
     /* Get the dynamic function properties */
     dyld = jdf_property_get_string(body->properties, "dyld", NULL);
@@ -6694,7 +6724,7 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
             "{\n"
             "  __parsec_%s_internal_taskpool_t *__parsec_tp = (__parsec_%s_internal_taskpool_t *)this_task->taskpool;\n"
             "  parsec_gpu_task_t *gpu_task;\n"
-            "  double ratio;\n"
+            "  int64_t __load;\n"
             "  int dev_index;\n"
             "  %s\n"
             "  (void)es; (void)__parsec_tp;\n"
@@ -6708,15 +6738,6 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
     info.suffix = "";
     info.assignments = "&this_task->locals";
 
-    /* Get the ratio to  apply on the weight for this task */
-    jdf_find_property( body->properties, "weight", &weight_property );
-    if ( NULL != weight_property ) {
-        weight = dump_expr((void**)weight_property->expr, &info);
-    } else {
-        weight = "1.";
-    }
-    coutput("  ratio = %s;\n", weight);
-
     /* Get the hint for static and/or external gpu scheduling */
     jdf_find_property( body->properties, "device", &device_property );
     if ( NULL != device_property ) {
@@ -6725,13 +6746,13 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
                 "  if (dev_index < -1) {\n"
                 "    return PARSEC_HOOK_RETURN_NEXT;\n"
                 "  } else if (dev_index == -1) {\n"
-                "    dev_index = parsec_get_best_device((parsec_task_t*)this_task, ratio);\n"
+                "    dev_index = parsec_get_best_device((parsec_task_t*)this_task, &__load);\n"
                 "  } else {\n"
                 "    dev_index = (dev_index %% (parsec_mca_device_enabled()-2)) + 2;\n"
                 "  }\n",
                 device);
     } else {
-        coutput("  dev_index = parsec_get_best_device((parsec_task_t*)this_task, ratio);\n");
+        coutput("  dev_index = parsec_get_best_device((parsec_task_t*)this_task, &__load);\n");
     }
     coutput("  assert(dev_index >= 0);\n"
             "  if( dev_index < 2 ) {\n"
@@ -6743,7 +6764,7 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
             "  gpu_task->ec = (parsec_task_t*)this_task;\n"
             "  gpu_task->submit = &%s_kernel_submit_%s_%s;\n"
             "  gpu_task->task_type = 0;\n"
-            "  gpu_task->load = ratio * parsec_device_sweight[dev_index];\n"
+            "  gpu_task->load = __load;\n"
             "  gpu_task->last_data_check_epoch = -1;  /* force at least one validation for the task */\n",
             dev_lower, jdf_basename, f->fname);
 
@@ -6866,8 +6887,7 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
     }
     string_arena_free(info.sa);
 
-    coutput("  parsec_device_load[dev_index] += gpu_task->load;\n"
-            "\n"
+    coutput("\n"
             "  return parsec_%s_kernel_scheduler( es, gpu_task, dev_index );\n"
             "}\n\n",
             dev_lower);

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -6400,7 +6400,7 @@ jdf_generate_code_datatype_lookup(const jdf_t *jdf,
 static void
 jdf_generate_code_time_estimate(const jdf_t *jdf,
                                 const jdf_function_entry_t *f,
-                                char *name) 
+                                char *name)
 {
     jdf_def_list_t *prop = NULL;
 
@@ -6573,7 +6573,7 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
 
     jdf_find_property(body->properties, "weight", &prop);
     if(NULL != prop) {
-        jdf_warn(JDF_OBJECT_LINENO(body), 
+        jdf_warn(JDF_OBJECT_LINENO(body),
                 "Parameterized Task '%s' defines the obsolete property 'weight' in its %s body to guide the selection of devices.\n"
                 "This has been superseded by the more flexible property 'time_estimate'. Please fix your JDF file.\n"
                 "-- Property 'weight' ignored.",

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -363,7 +363,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
     cuda_device->cuda_index = (uint8_t)dev_id;
     cuda_device->major      = (uint8_t)major;
     cuda_device->minor      = (uint8_t)minor;
-    len = asprintf(&gpu_device->super.name, "%s: cuda(%d)", szName, dev_id);
+    len = asprintf(&gpu_device->super.name, "cuda(%d)", dev_id);
     if(-1 == len) { gpu_device->super.name = NULL; goto release_device; }
     gpu_device->data_avail_epoch = 0;
 
@@ -489,7 +489,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
     }
 
     if( show_caps ) {
-        parsec_inform("GPU Device %d (capability %d.%d): %s\n"
+        parsec_inform("GPU Device %-8s: %s (capability %d.%d)\n"
                       "\tLocation (PCI Bus/Device/Domain): %x:%x.%x\n"
                       "\tSM                 : %d\n"
                       "\tFrequency (GHz)    : %f\n"
@@ -497,7 +497,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
                       "\tPeak Mem Bw (GB/s) : %.2f [Clock Rate (Ghz) %.2f | Bus Width (bits) %d]\n"
                       "\tconcurrency        : %s\n"
                       "\tcomputeMode        : %d\n",
-                      cuda_device->cuda_index, cuda_device->major, cuda_device->minor, device->name,
+                      device->name, szName, cuda_device->major, cuda_device->minor,
                       prop.pciBusID, prop.pciDeviceID, prop.pciDomainID,
                       streaming_multiprocessor,
                       freqHz*1e-9f,
@@ -931,7 +931,7 @@ parsec_gpu_data_reserve_device_space( parsec_device_cuda_module_t* cuda_device,
 #if !defined(PARSEC_GPU_CUDA_ALLOC_PER_TILE)
         gpu_elem = PARSEC_OBJ_NEW(parsec_data_copy_t);
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:%s: Allocate CUDA copy %p sz %d[ref_count %d] for data %p",
+                             "GPU[%s]:%s: Allocate CUDA copy %p sz %d [ref_count %d] for data %p",
                              gpu_device->super.name, task_name,
                              gpu_elem, gpu_task->flow_nb_elts[i], gpu_elem->super.super.obj_reference_count, master);
         gpu_elem->flags = PARSEC_DATA_FLAG_PARSEC_OWNED | PARSEC_DATA_FLAG_PARSEC_MANAGED;

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -226,6 +226,11 @@ PARSEC_DECLSPEC parsec_device_module_t* parsec_mca_device_get(uint32_t);
 PARSEC_DECLSPEC int parsec_mca_device_remove(parsec_device_module_t* device);
 
 /**
+ * Reset the current device statistics.
+ */
+PARSEC_DECLSPEC void parsec_mca_device_reset_statistics(parsec_context_t* parsec_context);
+
+/**
  * Dump and reset the current device statistics.
  */
 PARSEC_DECLSPEC void parsec_mca_device_dump_and_reset_statistics(parsec_context_t* parsec_context);

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -135,10 +135,11 @@ struct parsec_device_module_s {
     uint64_t  required_data_out;
     uint64_t  executed_tasks;
     uint64_t  nb_data_faults;
-    float device_hweight;  /**< Number of half precision operations per second */
-    float device_sweight;  /**< Number of single precision operations per second */
-    float device_dweight;  /**< Number of double precision operations per second */
-    float device_tweight;  /**< Number of tensor operations per second */
+    int64_t   device_hweight;  /**< Number of half precision operations per nanosecond */
+    int64_t   device_sweight;  /**< Number of single precision operations per nanosecond */
+    int64_t   device_dweight;  /**< Number of double precision operations per nanosecond */
+    int64_t   device_tweight;  /**< Number of tensor operations per nanosecond */
+    int64_t   device_load;     /**< Number of nanoseconds of work submitted to the device, and not completed now */
 #if defined(PARSEC_PROF_TRACE)
     parsec_profiling_stream_t *profiling;
 #endif  /* defined(PROFILING) */
@@ -154,12 +155,12 @@ extern int parsec_device_output;
 extern parsec_atomic_lock_t parsec_devices_mutex;
 
 /**
- * Temporary variables used for load-balancing purposes.
+ * @brief Returns the parsec device index selected to run @p this_task,
+ *    using this_task->task_class->time_estimate function to compute
+ *    the load (estimate of number of ns @p this_task will take on this
+ *    device). Also returns the load on the selected device in @p load.
  */
-extern float *parsec_device_load;
-extern float *parsec_device_sweight;
-extern float *parsec_device_dweight;
-PARSEC_DECLSPEC extern int parsec_get_best_device( parsec_task_t* this_task, double ratio );
+PARSEC_DECLSPEC extern int parsec_get_best_device( parsec_task_t* this_task, int64_t *load );
 
 /**
  * Initialize the internal structures for managing external devices such as

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021      The University of Tennessee and The University
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -93,7 +93,7 @@ struct parsec_gpu_task_s {
         struct {
             parsec_task_t           *ec;
             uint64_t                 last_data_check_epoch;
-            double                   load;  /* computational load imposed on the device */
+            uint64_t                 load;  /* computational load imposed on the device */
             const parsec_flow_t     *flow[MAX_PARAM_COUNT];
             uint32_t                 flow_nb_elts[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
                                                                      * on the GPU.

--- a/parsec/mca/device/template/device_template_module.c
+++ b/parsec/mca/device/template/device_template_module.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019      The University of Tennessee and The University
+ * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -168,10 +168,10 @@ parsec_device_template_module_init( int deviceid, parsec_device_module_t** modul
     device->super.taskpool_register   = parsec_template_taskpool_register;
     device->super.taskpool_unregister = parsec_template_taskpool_unregister;
 
-    device->super.device_hweight = 0;  /* no computational capacity */
-    device->super.device_tweight = 0;
-    device->super.device_sweight = 0;
-    device->super.device_dweight = 0;
+    device->super.gflops_fp16 = 0;  /* no computational capacity */
+    device->super.gflops_tf32 = 0;
+    device->super.gflops_fp32 = 0;
+    device->super.gflops_fp64 = 0;
 
     if( show_caps ) {
         parsec_inform("TEMPLATE Device %d enabled\n", device->super.device_index);

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -276,6 +276,12 @@ typedef parsec_key_t (parsec_functionkey_fn_t)(const parsec_taskpool_t *tp,
                                                const parsec_assignment_t *assignments);
 
 /**
+ * @brief Estimates the number of nanoseconds the task might run on the given device
+ *
+ */
+typedef int64_t (parsec_time_estimate_fct_t)(const parsec_task_t *this_task, parsec_device_module_t *dev);
+
+/**
  * Provide a character string representation of the task.
  * Write max buffer_size characters into buffer and return buffer.
  */
@@ -427,6 +433,7 @@ struct parsec_task_class_s {
 #if defined(PARSEC_SIM)
     parsec_sim_cost_fct_t       *sim_cost_fct;
 #endif
+    parsec_time_estimate_fct_t  *time_estimate;
     parsec_datatype_lookup_t    *get_datatype;
     parsec_hook_t               *prepare_input;
     const __parsec_chore_t      *incarnations;

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -7,6 +7,7 @@
 #include "parsec/runtime.h"
 #include "parsec/mca/mca_repository.h"
 #include "parsec/mca/sched/sched.h"
+#include "parsec/mca/device/device.h"
 #include "parsec/profiling.h"
 #include "datarepo.h"
 #include "parsec/execution_stream.h"
@@ -184,6 +185,15 @@ int __parsec_execute( parsec_execution_stream_t* es,
             if( PARSEC_HOOK_RETURN_ASYNC != rc ) {
                 /* Let's assume everything goes just fine */
                 task->status = PARSEC_TASK_STATUS_COMPLETE;
+                parsec_device_module_t *dev = NULL;
+                if(PARSEC_DEV_CPU == tc->incarnations[chore_id].type) {
+                    dev = parsec_mca_device_get(0);
+                    parsec_atomic_fetch_inc_int64((int64_t*)&dev->executed_tasks);
+                }
+                else if(PARSEC_DEV_RECURSIVE == tc->incarnations[chore_id].type) {
+                    dev = parsec_mca_device_get(1);
+                    parsec_atomic_fetch_inc_int64((int64_t*)&dev->executed_tasks);
+                }
             }
             /* Record EXEC_END event only for incarnation that succeeds */
             PARSEC_PINS(es, EXEC_END, task);

--- a/tests/dsl/dtd/dtd_test_new_tile.c
+++ b/tests/dsl/dtd/dtd_test_new_tile.c
@@ -32,6 +32,15 @@ extern void dtd_test_new_tile_multiply_by_two(int *dev_data, int nb, int idx);
 #define NCASE 8
 #define NB    8
 
+static int64_t first_tc_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev)
+{
+    int rank, idx, nb;
+    int *data;
+    parsec_task_t *this_task = (parsec_task_t *)task;
+    parsec_dtd_unpack_args(this_task, &rank, &data, &nb, &idx);
+    return ( (int64_t)nb + dev->device_sweight - (int64_t)1 ) / dev->device_sweight;
+}
+
 int cpu_set_to_i( parsec_execution_stream_t *es,
                   parsec_task_t *this_task )
 {
@@ -78,6 +87,15 @@ int cuda_set_to_i(parsec_device_gpu_module_t *gpu_device,
     return PARSEC_HOOK_RETURN_DONE;
 }
 #endif
+
+static int64_t second_tc_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev)
+{
+    int idx, nb;
+    int *data;
+    parsec_task_t *this_task = (parsec_task_t *)task;
+    parsec_dtd_unpack_args(this_task, &data, &nb, &idx);
+    return ( (int64_t)nb + dev->device_sweight - (int64_t)1 ) / dev->device_sweight;
+}
 
 int cpu_multiply_by_2( parsec_execution_stream_t *es,
                        parsec_task_t *this_task )
@@ -128,6 +146,16 @@ int cuda_multiply_by_2(parsec_device_gpu_module_t *gpu_device,
     return PARSEC_HOOK_RETURN_DONE;
 }
 #endif
+
+static int64_t third_tc_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev)
+{
+    int *data;
+    int nb, idx;
+    int32_t *acc, **gpu_accs;
+    parsec_task_t *this_task = (parsec_task_t *)task;
+    parsec_dtd_unpack_args(this_task, &data, &nb, &idx, &acc, &gpu_accs);
+    return ( (int64_t)nb + dev->device_sweight - (int64_t)1 ) / dev->device_sweight;
+}
 
 int cpu_accumulate( parsec_execution_stream_t *es,
                     parsec_task_t *this_task )
@@ -313,6 +341,7 @@ int main(int argc, char **argv)
     parsec_dtd_task_class_add_chore(dtd_tp, first_tc, PARSEC_DEV_CUDA, cuda_set_to_i);
 #endif
     parsec_dtd_task_class_add_chore(dtd_tp, first_tc, PARSEC_DEV_CPU, cpu_set_to_i);
+    first_tc->time_estimate = first_tc_time_estimate;
 
     parsec_task_class_t *second_tc = parsec_dtd_create_task_class(dtd_tp, "multiply_by_2",
                                                                   PASSED_BY_REF, PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
@@ -323,6 +352,7 @@ int main(int argc, char **argv)
     parsec_dtd_task_class_add_chore(dtd_tp, second_tc, PARSEC_DEV_CUDA, cuda_multiply_by_2);
 #endif
     parsec_dtd_task_class_add_chore(dtd_tp, second_tc, PARSEC_DEV_CPU, cpu_multiply_by_2);
+    second_tc->time_estimate = second_tc_time_estimate;
 
     parsec_task_class_t *third_tc = parsec_dtd_create_task_class(dtd_tp, "accumulate",
                                                                   PASSED_BY_REF, PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
@@ -335,6 +365,7 @@ int main(int argc, char **argv)
     parsec_dtd_task_class_add_chore(dtd_tp, third_tc, PARSEC_DEV_CUDA, cuda_accumulate);
 #endif
     parsec_dtd_task_class_add_chore(dtd_tp, third_tc, PARSEC_DEV_CPU, cpu_accumulate);
+    third_tc->time_estimate = third_tc_time_estimate;
 
     parsec_task_class_t *fourth_tc = parsec_dtd_create_task_class(dtd_tp, "reduce",
                                                                  PASSED_BY_REF, PARSEC_OUTPUT | TILE_FULL | PARSEC_AFFINITY,

--- a/tests/dsl/dtd/dtd_test_new_tile.c
+++ b/tests/dsl/dtd/dtd_test_new_tile.c
@@ -38,7 +38,7 @@ static int64_t first_tc_time_estimate(const parsec_task_t *task, parsec_device_m
     int *data;
     parsec_task_t *this_task = (parsec_task_t *)task;
     parsec_dtd_unpack_args(this_task, &rank, &data, &nb, &idx);
-    return ( (int64_t)nb + dev->device_sweight - (int64_t)1 ) / dev->device_sweight;
+    return (nb + dev->gflops_fp32 - 1) / dev->gflops_fp32;
 }
 
 int cpu_set_to_i( parsec_execution_stream_t *es,
@@ -94,7 +94,7 @@ static int64_t second_tc_time_estimate(const parsec_task_t *task, parsec_device_
     int *data;
     parsec_task_t *this_task = (parsec_task_t *)task;
     parsec_dtd_unpack_args(this_task, &data, &nb, &idx);
-    return ( (int64_t)nb + dev->device_sweight - (int64_t)1 ) / dev->device_sweight;
+    return (nb + dev->gflops_fp32 - 1) / dev->gflops_fp32;
 }
 
 int cpu_multiply_by_2( parsec_execution_stream_t *es,
@@ -154,7 +154,7 @@ static int64_t third_tc_time_estimate(const parsec_task_t *task, parsec_device_m
     int32_t *acc, **gpu_accs;
     parsec_task_t *this_task = (parsec_task_t *)task;
     parsec_dtd_unpack_args(this_task, &data, &nb, &idx, &acc, &gpu_accs);
-    return ( (int64_t)nb + dev->device_sweight - (int64_t)1 ) / dev->device_sweight;
+    return (nb + dev->gflops_fp32 - 1) / dev->gflops_fp32;
 }
 
 int cpu_accumulate( parsec_execution_stream_t *es,

--- a/tests/dsl/ptg/cuda/get_best_device_check.jdf
+++ b/tests/dsl/ptg/cuda/get_best_device_check.jdf
@@ -1,8 +1,8 @@
 extern "C" %{
 /*
- * Copyright (c) 2021 The Universiy of Tennessee and The Universiy
- *                    of Tennessee Research Foundation. All rights
- *                    reserved.
+ * Copyright (c) 2021-2023 The Universiy of Tennessee and The Universiy
+ *                         of Tennessee Research Foundation. All rights
+ *                         reserved.
  */
 #include "cuda_test_internal.h"
 
@@ -127,8 +127,8 @@ static int64_t task_time_estimate(const parsec_task_t *task, parsec_device_modul
 {
     /* There is no actual computation in the task kernel... But it will take at least 1 flop / initialization in the memset */
     parsec_get_best_device_check_taskpool_t *tp = (parsec_get_best_device_check_taskpool_t *)task->taskpool;
-    int64_t flops = (int64_t)tp->_g_descA->mb * (int64_t)tp->_g_descA->nb;
-    return flops / dev->device_dweight;
+    int64_t flops = (int64_t)tp->_g_descA->mb * tp->_g_descA->nb;
+    return flops / dev->gflops_fp64;
 }
 
 /**

--- a/tests/dsl/ptg/cuda/get_best_device_check.jdf
+++ b/tests/dsl/ptg/cuda/get_best_device_check.jdf
@@ -6,6 +6,8 @@ extern "C" %{
  */
 #include "cuda_test_internal.h"
 
+static int64_t task_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev);
+
 %}
 
 %option no_taskpool_instance = true  /* can be aything */
@@ -47,7 +49,7 @@ END
 /**************************************************
  *                    task                        *
  **************************************************/
-task(m, n)
+task(m, n) [ time_estimate = task_time_estimate ]
 
 // Execution space
 m = 0 .. descA->nt-1
@@ -61,7 +63,7 @@ READ A <- A gpu_bind_A(m, n)
 WRITE B <- NEW
         -> B fake_task(m, n)
 
-BODY [type=CUDA weight=m+n+1]
+BODY [type=CUDA]
 {   
 #if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
     if( nb_cuda_devices > 0 ) { 
@@ -120,6 +122,14 @@ END
 
 
 extern "C" %{
+
+static int64_t task_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev)
+{
+    /* There is no actual computation in the task kernel... But it will take at least 1 flop / initialization in the memset */
+    parsec_get_best_device_check_taskpool_t *tp = (parsec_get_best_device_check_taskpool_t *)task->taskpool;
+    int64_t flops = (int64_t)tp->_g_descA->mb * (int64_t)tp->_g_descA->nb;
+    return flops / dev->device_dweight;
+}
 
 /**
  * @param [inout] dcA: the data, already distributed and allocated

--- a/tests/dsl/ptg/cuda/nvlink.jdf
+++ b/tests/dsl/ptg/cuda/nvlink.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2019-2021 The University of Tennessee and The University
+ * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -209,8 +209,8 @@ extern "C" %{
 static int64_t gemm_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev)
 {
   const parsec_nvlink_taskpool_t *tp = (parsec_nvlink_taskpool_t *)task->taskpool;
-  int64_t flops = (int64_t)2 * (int64_t)tp->_g_descA->super.mb * (int64_t)tp->_g_descA->super.nb * (int64_t)tp->_g_descA->super.mb;
-  return flops/(int64_t)dev->device_dweight;
+  int64_t flops = (int64_t)2 * tp->_g_descA->super.mb * tp->_g_descA->super.nb * tp->_g_descA->super.mb;
+  return flops / dev->gflops_fp64;
 }
 
 %}

--- a/tests/dsl/ptg/cuda/nvlink.jdf
+++ b/tests/dsl/ptg/cuda/nvlink.jdf
@@ -36,6 +36,9 @@ typedef cublasStatus_t (*cublas_dgemm_v2_t) ( cublasHandle_t handle,
                                               double       *C, int ldc);
 #endif  /* defined(PARSEC_HAVE_DEV_CUDA_SUPPORT) */
 
+/* Pre-declare function used as a property of some parameterized task */
+static int64_t gemm_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev);
+
 %}
 
 %option no_taskpool_instance = true  /* can be anything */
@@ -112,7 +115,7 @@ END
 /**************************************************
  *                       GEMMs                    *
  **************************************************/
-GEMM1(m, g, r)
+GEMM1(m, g, r) [ time_estimate = gemm_time_estimate ]
 
 // Execution space
 m = 0 .. descA->super.mt-1
@@ -130,8 +133,7 @@ RW   C <- (m == 0) ? C MAKE_C(g, r) : C GEMM1(m-1, g, r)
                                     : C DISCARD_C(g, r)
 
 BODY [type=CUDA
-      dyld=cublasDgemm_v2 dyldtype=cublas_dgemm_v2_t
-      weight=(1)]
+      dyld=cublasDgemm_v2 dyldtype=cublas_dgemm_v2_t]
 {
     cublasStatus_t status;
     cublasHandle_t handle;
@@ -158,7 +160,7 @@ BODY
 END
 
 
-GEMM2(m, g, r)
+GEMM2(m, g, r) [ time_estimate = gemm_time_estimate ]
 
 // Execution space
 m = 0 .. descA->super.mt-1
@@ -175,8 +177,7 @@ RW   C <- (m == 0) ? userM(g, r)    : C GEMM2(m-1, g, r)
        -> ((m + 1) < (descA->super.mt)) ? C GEMM2(m+1, g, r)
 
 BODY [type=CUDA
-      dyld=cublasDgemm_v2 dyldtype=cublas_dgemm_v2_t
-      weight=(1)]
+      dyld=cublasDgemm_v2 dyldtype=cublas_dgemm_v2_t]
 {
     cublasStatus_t status;
     cublasHandle_t handle;
@@ -203,3 +204,13 @@ BODY
 END
 
 
+extern "C" %{
+
+static int64_t gemm_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev)
+{
+  const parsec_nvlink_taskpool_t *tp = (parsec_nvlink_taskpool_t *)task->taskpool;
+  int64_t flops = (int64_t)2 * (int64_t)tp->_g_descA->super.mb * (int64_t)tp->_g_descA->super.nb * (int64_t)tp->_g_descA->super.mb;
+  return flops/(int64_t)dev->device_dweight;
+}
+
+%}

--- a/tests/dsl/ptg/cuda/stage_custom.jdf
+++ b/tests/dsl/ptg/cuda/stage_custom.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2019-2021 The University of Tennessee and The University
+ * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -245,8 +245,8 @@ static int64_t gemm_time_estimate(const parsec_task_t *task, parsec_device_modul
 {
   const parsec_stage_custom_taskpool_t *tp = (parsec_stage_custom_taskpool_t *)task->taskpool;
   int64_t mb = ((parsec_tiled_matrix_t*)tp->_g_descA)->mb;
-  int64_t flops = (int64_t)2 * mb * mb * mb;
-  return flops/(int64_t)dev->device_dweight;
+  int64_t flops = 2 * mb * mb * mb;
+  return flops / dev->gflops_fp64;
 }
 
 parsec_taskpool_t* testing_stage_custom_New( parsec_context_t *ctx, int M, int N, int MB, int NB, int P, int *ret)

--- a/tests/dsl/ptg/cuda/stage_custom.jdf
+++ b/tests/dsl/ptg/cuda/stage_custom.jdf
@@ -113,6 +113,9 @@ typedef void (*cublas_dgemm_t) ( char TRANSA, char TRANSB, int m, int n, int k,
                                  double *d_B, int ldb,
                                  double beta,  double *d_C, int ldc );
 
+/* Pre-declare function used as a property of some parameterized task */
+static int64_t gemm_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev);
+
 %}
 
 %option no_taskpool_instance = true  /* can be anything */
@@ -129,7 +132,7 @@ OUT    [type = "int*"]
 /**************************************************
  *                       TASK_GPU                 *
  **************************************************/
-TASK_GPU(m, k)
+TASK_GPU(m, k) [ time_estimate = gemm_time_estimate ]
 
 
 m = 0 .. descA->mt-1
@@ -165,7 +168,7 @@ END
 /**************************************************
  *                TASK_GPU_CUSTOM_STAGE                 *
  **************************************************/
-TASK_GPU_CUSTOM_STAGE(m, k)
+TASK_GPU_CUSTOM_STAGE(m, k) [ time_estimate = gemm_time_estimate ]
 
 
 m = 0 .. descB->mt-1
@@ -237,6 +240,14 @@ END
 
 
 extern "C" %{
+
+static int64_t gemm_time_estimate(const parsec_task_t *task, parsec_device_module_t *dev)
+{
+  const parsec_stage_custom_taskpool_t *tp = (parsec_stage_custom_taskpool_t *)task->taskpool;
+  int64_t mb = ((parsec_tiled_matrix_t*)tp->_g_descA)->mb;
+  int64_t flops = (int64_t)2 * mb * mb * mb;
+  return flops/(int64_t)dev->device_dweight;
+}
 
 parsec_taskpool_t* testing_stage_custom_New( parsec_context_t *ctx, int M, int N, int MB, int NB, int P, int *ret)
 {

--- a/tests/dsl/ptg/cuda/stress.jdf
+++ b/tests/dsl/ptg/cuda/stress.jdf
@@ -34,6 +34,9 @@ typedef void (*cublas_dgemm_t) ( char TRANSA, char TRANSB, int m, int n, int k,
                                  double alpha, double *d_A, int lda,
                                  double *d_B, int ldb,
                                  double beta,  double *d_C, int ldc );
+
+static int64_t time_estimate_gemm(const parsec_task_t *task, parsec_device_module_t *dev);
+
 %}
 
 %option no_taskpool_instance = true  /* can be anything */
@@ -108,7 +111,7 @@ END
 /**************************************************
  *                       GEMM                     *
  **************************************************/
-GEMM(m, g, r)
+GEMM(m, g, r) [ time_estimate = time_estimate_gemm ]
 
 // Execution space
 m = 0 .. descA->super.mt-1
@@ -127,8 +130,7 @@ RW   C <- (m == 0) ? C MAKE_C(g, r) : C GEMM(m-1, g, r)
                                     : C DISCARD_C(g, r)
 
 BODY [type=CUDA
-      dyld=cublasDgemm dyldtype=cublas_dgemm_t
-      weight=(1)]
+      dyld=cublasDgemm dyldtype=cublas_dgemm_t]
 {
     cublasStatus_t status;
     cublasSetKernelStream( parsec_body.stream );
@@ -151,3 +153,13 @@ BODY
 END
 
 
+extern "C" %{
+
+static int64_t time_estimate_gemm(const parsec_task_t *task, parsec_device_module_t *dev)
+{
+    const parsec_stress_taskpool_t *tp = (const parsec_stress_taskpool_t *)task->taskpool;
+    int64_t flops = (int64_t)2 * (int64_t)tp->_g_descA->super.nb * (int64_t)tp->_g_descA->super.mb * (int64_t)tp->_g_descA->super.mb;
+    return flops / (int64_t)dev->device_dweight;
+}
+
+%}

--- a/tests/dsl/ptg/cuda/stress.jdf
+++ b/tests/dsl/ptg/cuda/stress.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2019-2021 The University of Tennessee and The University
+ * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -158,8 +158,8 @@ extern "C" %{
 static int64_t time_estimate_gemm(const parsec_task_t *task, parsec_device_module_t *dev)
 {
     const parsec_stress_taskpool_t *tp = (const parsec_stress_taskpool_t *)task->taskpool;
-    int64_t flops = (int64_t)2 * (int64_t)tp->_g_descA->super.nb * (int64_t)tp->_g_descA->super.mb * (int64_t)tp->_g_descA->super.mb;
-    return flops / (int64_t)dev->device_dweight;
+    int64_t flops = (int64_t)2 * tp->_g_descA->super.nb * tp->_g_descA->super.mb * tp->_g_descA->super.mb;
+    return flops / dev->gflops_fp64;
 }
 
 %}


### PR DESCRIPTION
Current load balancing of devices is broken.

Main issue: when a task uses affinity or last writer as a heuristic to select the device, it does not count the task in the load, but it does remove it from the load when the task completes. This makes the parsec_device_load array become negative for some devices, and then the CPU is wrongly selected to schedule tasks...

Simplest fix: move the `+=` instruction outside of the `if( best_device <= 1)` block.

This PR does multiple other fixes, open for comment:

  - only way to guarantee that the load will remain >= 0 is to atomically update the load... This adds two atomics (in the best case) in the critical path... An alternative approach would be to have only the GPU manager update the load for itself, but then the load would only be accounted for when the task goes from the shared list to a private list, so wrong decisions could live longer... I think the additional atomic is a better trade-off
  - I found confusing that the load is accounted for in `get_best_device` for the `+` and in `cuda_kernel_scheduler` for the `-`. I think it's easier to read to do all the accounting in `cuda_kernel_scheduler`. A user / DSL that would bypass `get_best_device` to decide where to schedule would not break the accounting if we do both end in the kernel scheduler function.
  - Currently, we never use the weight arrays (or more correctly, we only use the `parsec_device_sweight` array for all purposes). The proposed patch would allow the DSL/user to decide which weight array to use. I added a property in jdf2c to define which array to use (defaulting to single precision).
