### PR TITLE
Fix some errors with ctest for profiling

### DIFF
--- a/.github/CI/github_runner.yaml
+++ b/.github/CI/github_runner.yaml
@@ -8,7 +8,13 @@ spack:
     - bison
     - hwloc
     - python@3
+    - py-pip
+    - py-pandas
+    - py-matplotlib
+    - py-tables
+    - py-networkx
     - py-cython
+    - py-wheel
     - cmake
     - ninja
     - otf2@2.3

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -22,7 +22,7 @@ jobs:
         shared_type : [ OFF, ON ]
         profiling : [ ON ]
 
-    name: "Type = ${{ matrix.build_type }} shared=${{ matrix.shared_type }} profiling=${{matrix.profiling}}"
+    name: "Type=${{ matrix.build_type }} shared=${{ matrix.shared_type }} profiling=${{matrix.profiling}}"
     env:
       BUILD_DIRECTORY : "${{github.workspace}}/build/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
       INSTALL_DIRECTORY : "${{github.workspace}}/install/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
@@ -108,7 +108,7 @@ jobs:
         shared_type : [ ON ]
         profiling : [ OFF, ON ]
 
-    name: "Type = ${{ matrix.build_type }} shared=${{ matrix.shared_type }} profiling=${{matrix.profiling}}"
+    name: "Type=${{ matrix.build_type }} shared=${{ matrix.shared_type }} profiling=${{matrix.profiling}}"
     env:
       BUILD_DIRECTORY : "${{github.workspace}}/build/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
       INSTALL_DIRECTORY : "${{github.workspace}}/install/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
@@ -119,6 +119,7 @@ jobs:
         -DPARSEC_DEBUG_NOISIER=OFF
         -DBUILD_SHARED_LIBS=${{ matrix.shared_type }}
         -DPARSEC_PROF_TRACE=${{ matrix.profiling }}
+        -DPARSEC_PROF_TRACE_SYSTEM='PaRSEC Binary Tracing Format'
         -DMPIEXEC_PREFLAGS='--bind-to;none;--oversubscribe'
         -DCMAKE_INSTALL_PREFIX=$INSTALL_DIRECTORY
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -119,7 +119,6 @@ jobs:
         -DPARSEC_DEBUG_NOISIER=OFF
         -DBUILD_SHARED_LIBS=${{ matrix.shared_type }}
         -DPARSEC_PROF_TRACE=${{ matrix.profiling }}
-        -DPARSEC_PROF_TRACE_SYSTEM='PaRSEC Binary Tracing Format'
         -DMPIEXEC_PREFLAGS='--bind-to;none;--oversubscribe'
         -DCMAKE_INSTALL_PREFIX=$INSTALL_DIRECTORY
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -90,7 +90,7 @@ jobs:
       # run: ctest -C $BUILD_TYPE
       run: |
         source ${{github.workspace}}/.github/CI/spack_setup.sh
-        cmake --build . --target test
+        ctest --output-on-failure
 
     - name: Save Artifact
       if: failure()
@@ -192,7 +192,7 @@ jobs:
       # run: ctest -C $BUILD_TYPE
       run: |
         source ${{github.workspace}}/.github/CI/spack_setup.sh
-        cmake --build . --target test
+        ctest --output-on-failure
 
     - name: Save Testing Artifact
       if: failure()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,10 +210,9 @@ endif()
 option(PARSEC_PROF_TRACE
   "Enable the generation of the profiling information during
   execution" OFF)
-set(PARSEC_PROF_TRACE_SYSTEM "Auto" CACHE STRING "Select the profiling system,
- if PARSEC_PROF_TRACE is ON")
-#This enforces that only the 3 values are available in ccmake or cmake-gui
-set_property(CACHE PARSEC_PROF_TRACE_SYSTEM PROPERTY STRINGS "Auto" "OTF2" "PaRSEC Binary Tracing Format")
+  set(PARSEC_PROF_TRACE_SYSTEM "PaRSEC Binary Tracing Format" CACHE STRING "Select the profiling system, if PARSEC_PROF_TRACE is ON")
+#This enforces that only valid values are available in ccmake or cmake-gui
+set_property(CACHE PARSEC_PROF_TRACE_SYSTEM PROPERTY STRINGS "OTF2" "PaRSEC Binary Tracing Format")
 option(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT
   "Generate Profiling traces for the internal_init tasks in the PTG interface (expert mode only)" OFF)
 mark_as_advanced(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT) #This is available in export mode only

--- a/configure
+++ b/configure
@@ -326,7 +326,8 @@ function set_python_venv {
     if ${PYTHON_EXECUTABLE:-python3} -m venv -h >/dev/null; then
         ${PYTHON_EXECUTABLE:-python3} -m venv venv
         source venv/bin/activate
-        pip install Cython pandas matplotlib tables
+        python -m pip install --upgrade pip
+        pip install Cython pandas matplotlib tables networkx wheel
     else
         echo >&2 "Could not prepare a Python venv because \`-m venv\` is not supported by the selected python..." && exit 3
     fi

--- a/parsec/profiling_otf2.c
+++ b/parsec/profiling_otf2.c
@@ -96,7 +96,7 @@ static int nbregions                      = 0;
 static int next_region                    = 0;
 static int next_attr_id                   = 0;
 
-static int  thread_profiling_id = 0;
+static int32_t  thread_profiling_id = 0;
 
 typedef struct {
     char *type_name;
@@ -884,7 +884,7 @@ int parsec_profiling_dbp_dump( void )
             parsec_warning("PaRSEC Profiling System: OTF2 Error -- %s (%s)", OTF2_Error_GetName(rc), OTF2_Error_GetDescription(rc));
         }
     }
-    assert(thread_profiling_id == nb_local_threads);
+    assert((uint64_t)thread_profiling_id == nb_local_threads);
     parsec_list_unlock( &threads );
 
 

--- a/tests/profiling/Testings.cmake
+++ b/tests/profiling/Testings.cmake
@@ -1,67 +1,59 @@
 find_package (Python COMPONENTS Interpreter)
 if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
-  parsec_addtest_cmd(profiling/generate_profile_bw:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
-
-  set_property(TEST profiling/generate_profile_bw:mp PROPERTY RESOURCE_LOCK bw_file)
-  set_property(TEST profiling/generate_profile_bw:mp PROPERTY FIXTURES_SETUP bw_file_base)
+  # BW test
+  parsec_addtest_cmd(profiling/bw_generate_prof:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
+  set_property(TEST profiling/bw_generate_prof:mp PROPERTY FIXTURES_SETUP bw_prof_files)
 
   set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
-  parsec_addtest_cmd(profiling/generate_hdf5 ${SHM_TEST_CMD_LIST}
+  parsec_addtest_cmd(profiling/bw_generate_hdf5 ${SHM_TEST_CMD_LIST}
     ${Python_EXECUTABLE}
     ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=bw.h5 bw-0.prof bw-1.prof)
-  set_property(TEST profiling/generate_hdf5 APPEND PROPERTY DEPENDS profiling/generate_profile_bw:mp)
-  set_property(TEST profiling/generate_hdf5 APPEND PROPERTY ENVIRONMENT
+  set_property(TEST profiling/bw_generate_hdf5 APPEND PROPERTY ENVIRONMENT
     PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
-  set_property(TEST profiling/generate_hdf5 PROPERTY RESOURCE_LOCK bw_file)
-  set_property(TEST profiling/generate_hdf5 PROPERTY FIXTURES_REQUIRED bw_file_base)
-  set_property(TEST profiling/generate_hdf5 PROPERTY FIXTURES_SETUP bw_file_base)
+  set_property(TEST profiling/bw_generate_hdf5 PROPERTY FIXTURES_REQUIRED bw_prof_files)
+  set_property(TEST profiling/bw_generate_hdf5 PROPERTY FIXTURES_SETUP bw_h5_files)
 
-  parsec_addtest_cmd(profiling/check_hdf5 ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-comms.py)
-  set_property(TEST profiling/check_hdf5 APPEND PROPERTY DEPENDS profiling/generate_hdf5)
-  set_property(TEST profiling/generate_hdf5 PROPERTY RESOURCE_LOCK bw_file)
-  set_property(TEST profiling/generate_hdf5 PROPERTY FIXTURES_REQUIRED bw_file)
+  parsec_addtest_cmd(profiling/bw_check_hdf5 ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-comms.py)
+  set_property(TEST profiling/bw_check_hdf5 PROPERTY FIXTURES_REQUIRED bw_h5_files)
 
-  parsec_addtest_cmd(profiling/generate_profile_async ${SHM_TEST_CMD_LIST} profiling/async 100 -- --mca profile_filename async  --mca mca_pins task_profiler)
-  set_property(TEST profiling/generate_profile_async PROPERTY RESOURCE_LOCK async_file)
-  set_property(TEST profiling/generate_profile_async PROPERTY FIXTURES_SETUP async_file_base)
+  parsec_addtest_cmd(profiling/bw_cleanup_files ${SHM_TEST_CMD_LIST} rm -f bw-0.prof bw-1.prof bw.h5)
+  set_property(TEST profiling/bw_cleanup_files PROPERTY FIXTURES_CLEANUP bw_prof_files;bw_h5_files)
 
-  parsec_addtest_cmd(profiling/generate_hdf5_async ${SHM_TEST_CMD_LIST}
+  # ASYNC test
+  parsec_addtest_cmd(profiling/async_generate_prof ${SHM_TEST_CMD_LIST} profiling/async 100 -- --mca profile_filename async  --mca mca_pins task_profiler)
+  set_property(TEST profiling/async_generate_prof PROPERTY FIXTURES_SETUP async_prof_files)
+
+  parsec_addtest_cmd(profiling/async_generate_hdf5 ${SHM_TEST_CMD_LIST}
                      ${Python_EXECUTABLE}
                      ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=async.h5 async-0.prof)
-  set_property(TEST profiling/generate_hdf5_async APPEND PROPERTY DEPENDS profiling/generate_profile_async)
-  set_property(TEST profiling/generate_hdf5_async APPEND PROPERTY ENVIRONMENT
+  set_property(TEST profiling/async_generate_hdf5 APPEND PROPERTY ENVIRONMENT
     PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
-  set_property(TEST profiling/generate_hdf5_async PROPERTY RESOURCE_LOCK async_file)
-  set_property(TEST profiling/generate_hdf5_async PROPERTY FIXTURES_REQUIRED async_file_base)
-  set_property(TEST profiling/generate_hdf5_async PROPERTY FIXTURES_SETUP async_file)
+  set_property(TEST profiling/async_generate_hdf5 PROPERTY FIXTURES_REQUIRED async_prof_files)
+  set_property(TEST profiling/async_generate_hdf5 PROPERTY FIXTURES_SETUP async_h5_files)
 
-  parsec_addtest_cmd(profiling/check_hdf5_async ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-async.py async.h5)
-    set_property(TEST profiling/check_hdf5_async APPEND PROPERTY DEPENDS profiling/generate_hdf5_async)
-  set_property(TEST profiling/check_hdf5_async PROPERTY RESOURCE_LOCK async_file)
-  set_property(TEST profiling/check_hdf5_async PROPERTY FIXTURES_REQUIRED async_file)
+  parsec_addtest_cmd(profiling/async_check_hdf5 ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling/check-async.py async.h5)
+  set_property(TEST profiling/async_check_hdf5 PROPERTY FIXTURES_REQUIRED async_h5_files)
 
-  #  parsec_addtest_cmd(profiling/cleanup_profile_files ${SHM_TEST_CMD_LIST} rm -f bw-0.prof bw-1.prof bw.h5 async-0.prof async.h5)
+  parsec_addtest_cmd(profiling/async_cleanup_files ${SHM_TEST_CMD_LIST} rm -f async-0.prof async.h5)
+  set_property(TEST profiling/async_cleanup_files PROPERTY FIXTURES_CLEANUP async_prof_files;async_h5_files)
 
   if(PARSEC_PROF_GRAPHER)
-    parsec_addtest_cmd(profiling/generate_profile_and_dot_bw:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 3 -f 2 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler --mca profile_dot bw)
-    set_property(TEST profiling/generate_profile_and_dot_bw:mp PROPERTY RESOURCE_LOCK bw_file_and_dot)
-    set_property(TEST profiling/generate_profile_and_dot_bw:mp PROPERTY FIXTURES_SETUP bw_file_base_and_dot)
+    # BW with DOT test; do not use the same file names as BW tests to avoid requiring serialization of tests (RESOURCE_LOCK)
+    parsec_addtest_cmd(profiling/bwd_generate_prof_and_dot:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 3 -f 2 -l 2097152 -- --mca profile_filename bwd  --mca mca_pins task_profiler --mca profile_dot bwd)
+    set_property(TEST profiling/bwd_generate_prof_and_dot:mp PROPERTY FIXTURES_SETUP bwd_prof_and_dot_files)
 
-    parsec_addtest_cmd(profiling/generate_hdf5_for_dag_and_dot ${SHM_TEST_CMD_LIST}
-            ${Python_EXECUTABLE}
-            ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=bw.h5 bw-0.prof bw-1.prof)
-    set_property(TEST profiling/generate_hdf5_for_dag_and_dot APPEND PROPERTY DEPENDS profiling/generate_profile_and_dot_bw:mp)
-    set_property(TEST profiling/generate_hdf5_for_dag_and_dot APPEND PROPERTY ENVIRONMENT
+    parsec_addtest_cmd(profiling/bwd_generate_hdf5 ${SHM_TEST_CMD_LIST}
+                       ${Python_EXECUTABLE}
+                       ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=bwd.h5 bwd-0.prof bwd-1.prof)
+    set_property(TEST profiling/bwd_generate_hdf5 APPEND PROPERTY ENVIRONMENT
                  PYTHONPATH=${TMPPYTHONPATH}/:$ENV{PYTHONPATH})
-    set_property(TEST profiling/generate_hdf5_for_dag_and_dot PROPERTY RESOURCE_LOCK bw_file_and_dot)
-    set_property(TEST profiling/generate_hdf5_for_dag_and_dot PROPERTY FIXTURES_REQUIRED bw_file_base_and_dot)
-    set_property(TEST profiling/generate_hdf5_for_dag_and_dot PROPERTY FIXTURES_SETUP bw_file)
+    set_property(TEST profiling/bwd_generate_hdf5 PROPERTY FIXTURES_REQUIRED bwd_prof_and_dot_files)
+    set_property(TEST profiling/bwd_generate_hdf5 PROPERTY FIXTURES_SETUP bwd_prof_and_dot_h5_files)
 
-    parsec_addtest_cmd(profiling/check_DAG_and_Trace ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/profiling/python/examples/example-DAG-and-Trace.py --dot bw-0.dot --dot bw-1.dot --h5 bw.h5)
-    set_property(TEST profiling/check_DAG_and_Trace APPEND PROPERTY DEPENDS profiling/generate_hdf5_for_dag_and_dot)
-    set_property(TEST profiling/check_DAG_and_Trace PROPERTY RESOURCE_LOCK bw_file_and_dot)
-    set_property(TEST profiling/check_DAG_and_Trace PROPERTY FIXTURES_REQUIRED bw_file)
+    parsec_addtest_cmd(profiling/bwd_check_hdf5_and_dot ${SHM_TEST_CMD_LIST} ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/profiling/python/examples/example-DAG-and-Trace.py --dot bwd-0.dot --dot bwd-1.dot --h5 bwd.h5)
+    set_property(TEST profiling/bwd_check_hdf5_and_dot PROPERTY FIXTURES_REQUIRED bwd_prof_and_dot_h5_files)
 
-    parsec_addtest_cmd(profiling/cleanup_dot_files ${SHM_TEST_CMD_LIST} rm -f bw-0.prof bw-1.prof bw.h5 bw-0.dot bw-1.dot)
+    parsec_addtest_cmd(profiling/bwd_cleanup_files ${SHM_TEST_CMD_LIST} rm -f bwd-0.prof bwd-1.prof bwd.h5 bwd-0.dot bwd-1.dot)
+    set_property(TEST profiling/bwd_cleanup_files PROPERTY FIXTURES_CLEANUP bwd_prof_and_dot_files;bwd_prof_and_dot_h5_files)
   endif(PARSEC_PROF_GRAPHER)
 endif(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)

--- a/tools/profiling/python/CMakeLists.txt
+++ b/tools/profiling/python/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SRC_PYTHON_SUPPORT ${CMAKE_CURRENT_SOURCE_DIR}/common_utils.py ${CMAKE_CURRE
 set(SETUP_PY setup.py)
 
 set(PYTHON_TOOLS_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR})
-set(OUTPUT ${PYTHON_TOOLS_BIN_DIR}/build/timestamp)
+set(OUTPUT ${PYTHON_TOOLS_BIN_DIR}/build/pbt2ptt.timestamp)
 
 if(Python_VERSION_MAJOR EQUAL 2)
   # We do not support python 2 anymore. If you really need it you can go back

--- a/tools/profiling/python/examples/example-DAG-and-Trace.py
+++ b/tools/profiling/python/examples/example-DAG-and-Trace.py
@@ -42,7 +42,7 @@ not_predefined_types = list(trace.event_types)
 for t in predefined_tasks:
     try:
         not_predefined_types.remove( trace.event_types[t] )
-    except IndexError:
+    except KeyError:
         pass
 
 # To increase efficiency, we gather only the user-task events in a
@@ -74,7 +74,7 @@ slist = dag.successors_from_id(network_event.tpid, network_event.tcid, network_e
 print("Task {}( {} ) ran on node {} from {} (s) to {} (s)"
       .format(task_node['label'], task_node['param'], task_event.node_id, task_event.begin/1e9, task_event.end/1e9))
 print("It generated a payload receive event on node {} from {} (s) to {} (s)"
-      .format(network_event.node_id, network_event.begin/1e9, network_event.end/1e9)
+      .format(network_event.node_id, network_event.begin/1e9, network_event.end/1e9))
 
 # Let's iterate over the successors
 for n in list(slist.keys()):

--- a/tools/profiling/python/pbt2ptt.pyx
+++ b/tools/profiling/python/pbt2ptt.pyx
@@ -6,7 +6,7 @@ The preferred nomenclature for the Python Binary Trace is "PBT",
 REQUIREMENTS:
 # Cython 0.19+ required.
 # pandas 0.13+ (and numpy, etc.) required.
-# Python 2.7.3 recommended.
+# Python 3.5+  recommended.
 
 BUILD NOTES:
 # Be SURE to build this against the same version of Python as you have built Cython itself.
@@ -519,6 +519,7 @@ cpdef construct_dataframe_v1(builder):
             event.setdefault(k, None)
     # Build a DataFrame with dtype object
     builder.events = pd.DataFrame(builder.events, dtype=object)
+    builder.infos = dict()
 
 
 cpdef construct_dataframe_v2(builder):


### PR DESCRIPTION
DEPEND and RESOURCE_LOCK clauses would not always prevent out-of-order execution of tests (in particular cleanup actions)
1. use FIXTURES_SETUP, FIXTURES_REQUIRE, FIXTURES_CLEANUP instead of
   DEPENDS and RESOURCE_LOCK to enforce ordering
2. never use the same file names for independent tests (removes the need for
   RESOURCE_LOCKs, individual sets bw;async;bwd can execute concurrently)
3. systematic names for the tests `$test_$action_$files`



profiling: the bwd_h5_and_dot fail