### PR TITLE
More flexible paranoid checks in data_dist/matrix implementations

### DIFF
--- a/parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic.c
+++ b/parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic.c
@@ -144,7 +144,7 @@ static parsec_data_t* sym_twoDBC_data_of(parsec_data_collection_t *desc, ...)
     assert( n < dc->super.nt );
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == sym_twoDBC_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
     assert( dc->super.storage == PARSEC_MATRIX_TILE );
     assert( (dc->uplo == PARSEC_MATRIX_LOWER && m>=n) ||
@@ -200,7 +200,7 @@ static int32_t sym_twoDBC_vpid_of(parsec_data_collection_t *desc, ...)
     assert( n < dc->super.nt );
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == sym_twoDBC_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
     assert( (dc->uplo == PARSEC_MATRIX_LOWER && m>=n) ||
             (dc->uplo == PARSEC_MATRIX_UPPER && n>=m) );

--- a/parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic_band.c
+++ b/parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic_band.c
@@ -68,7 +68,7 @@ static parsec_data_t* sym_twoDBC_band_data_of(parsec_data_collection_t *desc, ..
     va_end(ap);
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == sym_twoDBC_band_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
 
     /* Check tile location within band_size */

--- a/parsec/data_dist/matrix/two_dim_rectangle_cyclic.c
+++ b/parsec/data_dist/matrix/two_dim_rectangle_cyclic.c
@@ -321,7 +321,7 @@ static int32_t twoDBC_vpid_of(parsec_data_collection_t *desc, ...)
     assert( n < dc->super.nt );
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == twoDBC_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
 
     /* Offset by (i,j) to translate (m,n) in the global matrix */
@@ -384,7 +384,7 @@ static parsec_data_t* twoDBC_data_of(parsec_data_collection_t *desc, ...)
     assert( n < dc->super.nt );
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == twoDBC_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
 
     /* Offset by (i,j) to translate (m,n) in the global matrix */
@@ -599,7 +599,7 @@ static int32_t twoDBC_kcyclic_vpid_of(parsec_data_collection_t *desc, ...)
 
     /* Assert using local info */
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == twoDBC_kcyclic_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
 
     /* Offset by (i,j) to translate (m,n) in the global matrix */
@@ -646,7 +646,7 @@ static parsec_data_t* twoDBC_kcyclic_data_of(parsec_data_collection_t *desc, ...
 
     /* Assert using local info */
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == twoDBC_kcyclic_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
 
     /* Offset by (i,j) to translate (m,n) in the global matrix */

--- a/parsec/data_dist/matrix/two_dim_rectangle_cyclic_band.c
+++ b/parsec/data_dist/matrix/two_dim_rectangle_cyclic_band.c
@@ -70,7 +70,7 @@ static parsec_data_t* twoDBC_band_data_of(parsec_data_collection_t *desc, ...)
     va_end(ap);
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == twoDBC_band_rank_of(desc, m, n));
+    assert(desc->myrank == desc->rank_of(desc, m, n));
 #endif
 
     /* Check tile location within band_size */

--- a/parsec/data_dist/matrix/vector_two_dim_cyclic.c
+++ b/parsec/data_dist/matrix/vector_two_dim_cyclic.c
@@ -213,7 +213,7 @@ static int32_t vector_twoDBC_vpid_of(parsec_data_collection_t *desc, ...)
     m += dc->super.i / dc->super.mb;
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == vector_twoDBC_rank_of(desc, m));
+    assert(desc->myrank == desc->rank_of(desc, m));
 #endif
 
     /* Compute the local tile row */
@@ -247,7 +247,7 @@ static parsec_data_t* vector_twoDBC_data_of(parsec_data_collection_t *desc, ...)
     m += dc->super.i / dc->super.mb;
 
 #if defined(DISTRIBUTED)
-    assert(desc->myrank == vector_twoDBC_rank_of(desc, m));
+    assert(desc->myrank == desc->rank_of(desc, m));
 #endif
 
     /* Compute the local tile row */


### PR DESCRIPTION
Current asserts in data_dist/matrix implementations do not allow to redefine the rank_of of these distributions in PARANOID mode. Use the rank_of function instead of the hard-coded distribution's rank_of function in the asserts to allow more flexible use of the distributions.
