### PR TITLE
Profiling off fix

### DIFF
--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -894,15 +894,6 @@ static char *dump_profiling_init(void **elem, void *arg)
                             jdf_basename, fname, 256-R, 256-G, 256-B,
                             jdf_basename, fname, jdf_basename, fname,
                             jdf_basename, fname, jdf_basename, fname);
-    // string_arena_add_string(info->sa,
-                            // "%s_profiling_array_counter = 0; /* initialize profiling array to -1 */\n"
-                            // "for(; %s_profiling_array_counter < %s_profiling_array_counter_limit; %s_profiling_array_counter++)\n"
-                            // "{\n"
-                            // "    %s_profiling_array[%s_profiling_array_counter] = -1;\n"
-                            // "}\n",
-                            // jdf_basename,
-                            // jdf_basename, jdf_basename, jdf_basename, 
-                            // jdf_basename, jdf_basename);
     string_arena_add_string(info->sa,
                             "parsec_profiling_add_dictionary_keyword(\"%s::%s\", \"fill:%02X%02X%02X\",\n"
                             "                                       sizeof(parsec_task_prof_info_t)+%d*sizeof(parsec_assignment_t),\n"

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -861,6 +861,15 @@ static char *dump_profiling_init(void **elem, void *arg)
     string_arena_t *profiling_convertor_params;
 
     if( !profile_enabled(f->properties) ) {
+        /**
+         * We have to set the `profiling_array` elements to -1
+         * then we will return NULL
+         */
+        string_arena_add_string(info->sa,
+                                "%s_profiling_array[START_KEY(%s_%s.task_class_id + PARSEC_%s_NB_TASK_CLASSES) /* %s (internal init) start key */] = -1;\n"
+                                "%s_profiling_array[END_KEY(%s_%s.task_class_id + PARSEC_%s_NB_TASK_CLASSES)   /* %s (internal init) end   key */] = -1;\n",
+                                jdf_basename, jdf_basename, fname, jdf_basename, fname,
+                                jdf_basename, jdf_basename, fname, jdf_basename, fname);
         return NULL;
     }
 
@@ -885,6 +894,15 @@ static char *dump_profiling_init(void **elem, void *arg)
                             jdf_basename, fname, 256-R, 256-G, 256-B,
                             jdf_basename, fname, jdf_basename, fname,
                             jdf_basename, fname, jdf_basename, fname);
+    // string_arena_add_string(info->sa,
+                            // "%s_profiling_array_counter = 0; /* initialize profiling array to -1 */\n"
+                            // "for(; %s_profiling_array_counter < %s_profiling_array_counter_limit; %s_profiling_array_counter++)\n"
+                            // "{\n"
+                            // "    %s_profiling_array[%s_profiling_array_counter] = -1;\n"
+                            // "}\n",
+                            // jdf_basename,
+                            // jdf_basename, jdf_basename, jdf_basename, 
+                            // jdf_basename, jdf_basename);
     string_arena_add_string(info->sa,
                             "parsec_profiling_add_dictionary_keyword(\"%s::%s\", \"fill:%02X%02X%02X\",\n"
                             "                                       sizeof(parsec_task_prof_info_t)+%d*sizeof(parsec_assignment_t),\n"
@@ -1579,6 +1597,10 @@ static void jdf_generate_structure(jdf_t *jdf)
         /* If the profile property is ON then enable the profiling array */
         need_profile = profile_enabled(f->properties);
     }
+    /**
+     * not all elements are set to {-1} in this initialization,
+     * but later they will be initialized
+     */
     if( need_profile )
         coutput("#if defined(PARSEC_PROF_TRACE)\n"
                 "#  if defined(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT)\n"

--- a/parsec/mca/pins/pins.c
+++ b/parsec/mca/pins/pins.c
@@ -33,18 +33,18 @@ void parsec_pins_instrument(struct parsec_execution_stream_s* es,
                             parsec_task_t* task)
 {
     assert( method_flag < PARSEC_PINS_FLAG_COUNT );
+    #if defined(PARSEC_PROF_TRACE)
     /**
      * profiling array only generated if at least one task requires profiling,
      * so must check it.
      */
     if((NULL != task) 
-       #if defined(PARSEC_PROF_TRACE)
        && (NULL != task->taskpool->profiling_array)
        && (-1 == task->taskpool->profiling_array[START_KEY(task->task_class->task_class_id)])
-       #endif  /* defined(PARSEC_PROF_TRACE) */
        ) {
         return;
     }
+    #endif  /* defined(PARSEC_PROF_TRACE) */
 
 
     parsec_pins_next_callback_t* cb_event = &es->pins_events_cb[method_flag];

--- a/parsec/mca/pins/pins.c
+++ b/parsec/mca/pins/pins.c
@@ -12,6 +12,8 @@
 #include "parsec/constants.h"
 #include "parsec/utils/debug.h"
 #include "parsec/execution_stream.h"
+#include "parsec/parsec_internal.h"
+#include "parsec/parsec_binary_profile.h"
 
 /**
  * Mask for PINS events that are enabled by default.
@@ -31,6 +33,19 @@ void parsec_pins_instrument(struct parsec_execution_stream_s* es,
                             parsec_task_t* task)
 {
     assert( method_flag < PARSEC_PINS_FLAG_COUNT );
+    /**
+     * profiling array only generated if at least one task requires profiling,
+     * so must check it.
+     */
+    if((NULL != task) 
+       #if defined(PARSEC_PROF_TRACE)
+       && (NULL != task->taskpool->profiling_array)
+       && (-1 == task->taskpool->profiling_array[START_KEY(task->task_class->task_class_id)])
+       #endif  /* defined(PARSEC_PROF_TRACE) */
+       ) {
+        return;
+    }
+
 
     parsec_pins_next_callback_t* cb_event = &es->pins_events_cb[method_flag];
     while( NULL != cb_event->cb_func ) {

--- a/tests/profiling/async.jdf
+++ b/tests/profiling/async.jdf
@@ -41,7 +41,7 @@ verbose          [ type = "int" ]
 taskqueue        [ type = "parsec_task_t **" ]
 NB               [ type = "int" ]
 
-STARTUP(s)
+STARTUP(s)  [profile=off]
 
 s = 0 .. 0
 

--- a/tests/profiling/check-async.py
+++ b/tests/profiling/check-async.py
@@ -12,12 +12,11 @@ try:
     FULL_RESCHED = t.event_types['FULL_RESCHED']
     ASYNC = t.event_types['async::ASYNC']
     RESCHED = t.event_types['async::RESCHED']
-    STARTUP = t.event_types['async::STARTUP']
 except AttributeError:
         print("HDF5 file {} does not contains the event_types attribute. The file might be empty, corrupted or it was incorrectly generated".format(filename), file=sys.stderr)
         sys.exit(2)
 except KeyError:
-    print("One of keys FULL_ASYNC, FULL_RESCHED, ASYNC, RESCHED, or STARTUP is not defined in the trace",
+    print("One of keys FULL_ASYNC, FULL_RESCHED, ASYNC, or RESCHED is not defined in the trace",
           file=sys.stderr)
     sys.exit(1)
 
@@ -29,16 +28,17 @@ except KeyError:
     sys.exit(1)
 
 error = 0
+try:
+    STARTUP = t.event_types['async::STARTUP']
+    print("Error: there should be no STARTUP tasks." +
+          "because they were marked with property \"[profiling=off]\"",
+          file=sys.stderr)
+    error += 1
+except KeyError:
+    print("There are no STARTUP tasks (they were marked off).")
+
 
 try:
-    if len(t.events[t.events.type == STARTUP]) != 1:
-        print("Error: there should be exactly one STARTUP task.",
-              file=sys.stderr)
-        error += 1
-    else:
-        startup = t.events[t.events.type == STARTUP].iloc[0]
-        print("There is one STARTUP task.")
-
     if len(t.events[t.events.type == FULL_RESCHED]) != 1:
         print("Error: there should be exactly one FULL_RESCHED event.",
               file=sys.stderr)
@@ -73,7 +73,7 @@ except AttributeError:
         print("HDF5 file {} does not contains the events attribute. The file might be empty, corrupted or it was incorrectly generated".format(filename), file=sys.stderr)
         sys.exit(2)
 except KeyError:
-    print("One of keys FULL_ASYNC, FULL_RESCHED, ASYNC, RESCHED, or STARTUP is not defined in the trace",
+    print("One of keys FULL_ASYNC, FULL_RESCHED, ASYNC, or RESCHED is not defined in the trace",
           file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
A response to https://github.com/ICLDisco/parsec/issues/529.


Applied the patch suggested by @bosilca, but there were two more things that needed done.

1. Sometimes the `profiling_array` is not initialized. This was fixed to now have `pins.c` check first in `parsec_pins_instrument`.
2. The `profiling_array` wasn't truly being initialized to `-1`. Saying `static int myarr[200] = {-1}` only sets the first element to `-1` with the current PaRSEC compiler settings. I added code to truly initialize all tasks.

I will continue a few tests of my own and I encourage you to double-check as well. I'll let you know if I find anything else!