### PR TITLE
pip install --prefix has version-dependent behaviors

### DIFF
--- a/tests/profiling/Testings.cmake
+++ b/tests/profiling/Testings.cmake
@@ -4,7 +4,7 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
   parsec_addtest_cmd(profiling/bw_generate_prof:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
   set_property(TEST profiling/bw_generate_prof:mp PROPERTY FIXTURES_SETUP bw_prof_files)
 
-  set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/")
   parsec_addtest_cmd(profiling/bw_generate_hdf5 ${SHM_TEST_CMD_LIST}
     ${Python_EXECUTABLE}
     ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=bw.h5 bw-0.prof bw-1.prof)

--- a/tools/profiling/python/CMakeLists.txt
+++ b/tools/profiling/python/CMakeLists.txt
@@ -45,7 +45,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SETUP_PY}.in
 # location and import the pbt2ptt module.
 add_custom_command(OUTPUT ${OUTPUT}
                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SRC_PYTHON_SUPPORT} ${CMAKE_CURRENT_BINARY_DIR}
-                   COMMAND ${Python_EXECUTABLE} -m pip install --quiet --prefix=${CMAKE_CURRENT_BINARY_DIR}/python.test .
+                   COMMAND ${Python_EXECUTABLE} -m pip install --quiet --upgrade --target=${CMAKE_CURRENT_BINARY_DIR}/python.test .
                    COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                    DEPENDS parsec-base ${SRC_PYTHON_SUPPORT})
 add_custom_target(pbt2ptt ALL DEPENDS ${OUTPUT})


### PR DESCRIPTION
Use pip install --target to test in the compile directory, but pip install --prefix to install final files

pip install --prefix uses different directories depending on the version of Python3 on Linux. python3.8 was installing things in <prefix>/lib/python-3.8/sites-package (or something close to that) python3.10 is installing things in <prefix>/local/lib/python-3.10/dist-packages (or something close to that)

pip install --target installs everything in <target>, but does not follow the appropriate hierarchy for an actual install.

With this patch, we use pip install --target python.test to install everything flat *in a known directory* in order to test locally without install. And we use pip install --prefix to install files with the right hierarchy in an actual install.