### PR TITLE
Fix bug: some scenarios would call a nullptr function in profiling

### DIFF
--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -590,7 +590,7 @@ extern int device_delegate_begin, device_delegate_end;
                            key_hash((TASK)->task_class->make_key(           \
                               (TASK)->taskpool, (TASK)->locals ), NULL),    \
                            (TASK)->taskpool->taskpool_id,                   \
-                           (TASK)->task_class->profile_info,                \
+                           (TRACE_INFO) ? (TASK)->task_class->profile_info : NULL, \
                            (TRACE_INFO) ? (void*)(TASK) : NULL,             \
                            (FLAGS)); 
 #else

--- a/parsec/profiling.c
+++ b/parsec/profiling.c
@@ -1001,7 +1001,7 @@ parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key
 
     assert( key >= 2 );
 
-    this_event_length = EVENT_LENGTH( key, (NULL != info_data) );
+    this_event_length = EVENT_LENGTH( key, ((NULL != info_fn) && (NULL != info_data)) );
     assert( this_event_length < event_avail_space );
     if( context->next_event_position + this_event_length > event_avail_space ) {
         int rc = switch_event_buffer(context);
@@ -1021,7 +1021,7 @@ parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key
     this_event->event.taskpool_id = taskpool_id;
     this_event->event.flags = 0;
 
-    if( NULL != info_data ) {
+    if( (NULL != info_fn) && (NULL != info_data) ) {
         info_fn(this_event->info, info_data, parsec_prof_keys[ BASE_KEY(key) ].info_length);
         this_event->event.flags = PARSEC_PROFILING_EVENT_HAS_INFO;
     }

--- a/parsec/profiling_otf2.c
+++ b/parsec/profiling_otf2.c
@@ -748,7 +748,7 @@ parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key
 
     region = key < 0 ? -key : key;
 
-    if( NULL != info_data ) {
+    if( (NULL != info_fn) && (NULL != info_data) ) {
         size_t info_length = regions[region].info_length;
         char *info = alloca(info_length);
         info_fn(info, info_data, info_length);


### PR DESCRIPTION
One should never call `info_fn` if `info_fn` is `NULL` (obviously), and the PARSEC_PROF_TRACE_TASK macro always pass the task as `info_data` if the higher level wants to log. Change the test to test on `info_fn` instead of `info_data`.
