### PR TITLE
Profiling hotfix: error in python3 when passing {char[64]} as conversion type

### DIFF
--- a/tools/profiling/python/pbt2ptt.pyx
+++ b/tools/profiling/python/pbt2ptt.pyx
@@ -869,7 +869,8 @@ cdef class ExtendedEvent:
                 if m is None:
                     logger.warning('Unknown format %s', ev_type)
                 else:
-                    self.fmt += <bytes>(b"%ss"%(m.group(1)))
+                    t = f"{m.group(1)}s"
+                    self.fmt += t.encode()
         logger.log(1,  'event[%s] = %s fmt \'%s\'', event_name, self.aev, self.fmt)
         self.ev_struct = struct.Struct(self.fmt)
         if self.ev_struct is None:


### PR DESCRIPTION
Since working with python3, we store `event.fmt` as a byte array instead of a string.

When parsing `{char[64]}` as a type qualifier, we want to store `64s` in the struct unpack code (a string of 64 characters), and we try to add "64s" as an array of bytes to fmt by doing `event.fmt += <bytes>("64s")`, but this fails with the message `TypeError: %b requires a bytes-like object, or an object that implements __bytes__, not 'str'`

According to
https://stackoverflow.com/questions/7585435/best-way-to-convert-string-to-bytes-in-python-3

string to bytes class in python3 cannot be done implicitly, but should be done using `x.encode()` which is portable between versions of python.

