### PR TITLE
Add device async/again support.

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -625,7 +625,7 @@ parsec_execute_and_come_back(parsec_taskpool_t *tp,
  * @param[in]   this_task
  *                  The task we are trying to unpack the parameters for
  * @param[out]  ...
- *                  The variables where the paramters will be unpacked
+ *                  The variables where the parameters will be unpacked
  *
  * @ingroup DTD_INTERFACE
  */
@@ -741,7 +741,7 @@ void *parsec_dtd_task_profile_info(void *dst, const void *task_, size_t size)
     parsec_dtd_task_param_t *param = GET_HEAD_OF_PARAM_LIST(task);
 
     assert( task->super.task_class->task_class_type == PARSEC_TASK_CLASS_TYPE_DTD );
-    
+
     memcpy(dst, &task->super.prof_info, sizeof(parsec_task_prof_info_t));
     ptr = dst + sizeof(parsec_task_prof_info_t);
 
@@ -750,7 +750,7 @@ void *parsec_dtd_task_profile_info(void *dst, const void *task_, size_t size)
             assert( ptr-dst < (intptr_t)size ); (void)size;
             memcpy(ptr, param->pointer_to_tile, param->arg_size);
             ptr += param->arg_size;
-        } 
+        }
         param = param->next;
     }
 
@@ -767,7 +767,7 @@ static char* parsec_dtd_task_snprintf(char *buffer, size_t buffer_size, const pa
 
     char *b = buffer;
     int ret, remaining = buffer_size;
-    
+
     ret = snprintf(b, remaining, "%s(", tc->name);
     if(ret < 0) {
         *b = '\0';
@@ -939,7 +939,7 @@ parsec_dtd_insert_task_class(parsec_dtd_taskpool_t *tp,
     char *info_str = NULL;
     int info_size = 0;
 #endif
-    
+
     if(tc->super.task_class_id != UINT8_MAX) {
         parsec_warning("Task class %s (%p) has invalid or already defined task_class_id",
                         (void*)tc, tc->super.name);
@@ -995,7 +995,7 @@ parsec_dtd_insert_task_class(parsec_dtd_taskpool_t *tp,
             }
         }
     }
- 
+
     if(NULL == info_str) {
         tc->super.profile_info = parsec_task_profile_info;
         parsec_dtd_add_profiling_info(&tp->super, tc->super.task_class_id, tc->super.name);
@@ -3260,12 +3260,12 @@ __parsec_dtd_taskpool_create_task(parsec_taskpool_t *tp,
     /* Safeguard: check that the rank has been set by affinity if it is needed */
     if( tp->context->nb_nodes > 1 ) {
         if((-1 == rank) && (write_flow_count > 1)) {
-            parsec_fatal("You inserted a task without indicating where the task should be executed(using\n"
+            parsec_fatal("You inserted a task without indicating where the task should be executed (using\n"
                          "PARSEC_AFFINITY flag). This will result in executing this task on all nodes and the outcome\n"
                          "might be not be what you want. So we are exiting for now. Please see the usage of\n"
                          "PARSEC_AFFINITY flag.\n");
         } else if( rank == -1 && write_flow_count == 1 ) {
-            /* we have tasks with no real data as parameter so we are safe to execute it in each mpi process */
+            /* we have tasks with no real data as parameter so we are safe to execute it in each process */
             rank = tp->context->my_rank;
         }
     } else {

--- a/parsec/interfaces/dtd/insert_function.h
+++ b/parsec/interfaces/dtd/insert_function.h
@@ -178,7 +178,7 @@ typedef parsec_hook_return_t (parsec_dtd_funcptr_t)(parsec_execution_stream_t *,
  *                                     - UNPACK_VALUE
  *                                     - UNPACK_SCRATCH
  *                                     - UNPACK_DATA
- *                                     Following each FLAG the pointer to the memory location where the paramater
+ *                                     Following each FLAG the pointer to the memory location where the parameter
  *                                     will be copied needs to be given.
  *
  * There is no way to unpack individual parameters. e.g. If user wants to unpack the 3rd parameter only, they have to

--- a/parsec/interfaces/dtd/insert_function.h
+++ b/parsec/interfaces/dtd/insert_function.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2019 The University of Tennessee and The University
+ * Copyright (c) 2015-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  **/
@@ -21,13 +21,6 @@ BEGIN_C_DECLS
  * @addtogroup DTD_INTERFACE
  *  @{
  */
-
-/**
- * To see examples please look at testing_zpotrf_dtd.c, testing_zgeqrf_dtd.c,
- * testing_zgetrf_incpiv_dtd.c files in the directory "root_of_DPLASMA/tests/testing/".
- * Very simple example of inserting just one task can be found in
- * "root_of_PaRSEC/example/interfaces/dtd/"
- **/
 
 /**
  * The following is a definition of the flags, for usage please check usage of parsec_dtd_insert_task() below.
@@ -157,7 +150,7 @@ typedef struct parsec_dtd_taskpool_s     parsec_dtd_taskpool_t;
 #define PARSEC_DTD_MAX_PARAMS 64
 
 /**
- * Function pointer typeof  kernel pointer pased as parameter to insert_function().
+ * Function pointer typeof  kernel pointer passed as parameter to insert_function().
  * This is the prototype of the function in which the actual operations of each task
  * is implemented by the User. The actual computation will be performed in functions
  * having this prototype.
@@ -185,7 +178,7 @@ typedef parsec_hook_return_t (parsec_dtd_funcptr_t)(parsec_execution_stream_t *,
  *                                     - UNPACK_VALUE
  *                                     - UNPACK_SCRATCH
  *                                     - UNPACK_DATA
- *                                     Following each FLAG the pointer to the memory location where the paramter
+ *                                     Following each FLAG the pointer to the memory location where the paramater
  *                                     will be copied needs to be given.
  *
  * There is no way to unpack individual parameters. e.g. If user wants to unpack the 3rd parameter only, they have to
@@ -234,10 +227,10 @@ parsec_dtd_tile_t * parsec_dtd_tile_new(parsec_taskpool_t *dtd_tp, int rank);
  *    This function should include the actual computation the user wants to perform on the data.
  * 3. The priority of the task, if not sure user should provide 0.
  * 4. The name of the task.
- * 5. Variadic type parameter. User can pass any number of paramters. The runtime will pack the
- *    parameters and attach them to the task they belong to. User can later use unpakcing
- *    fuction provided to get access to the parametrs.
- *    Each paramter to pass to a task should be expressed in the form of a triplet. e.g
+ * 5. Variadic type parameter. User can pass any number of parameters. The runtime will pack the
+ *    parameters and attach them to the task they belong to. User can later use unpacking
+ *    fuction provided to get access to the parameters.
+ *    Each paramater to pass to a task should be expressed in the form of a triplet. e.g
  *
  *    1.      sizeof(int),             &uplo,                           VALUE,
  *
@@ -255,7 +248,7 @@ parsec_dtd_tile_t * parsec_dtd_tile_new(parsec_taskpool_t *dtd_tp, int rank);
  *         sizeof(double *),           &pointer_to_double,             SCRATCH,
  *
  *          (size in bytes),    (the pointer of the pointer       (runtime will copy the address of
- *                               vairable we want to pass to the   the pointer which the task can later
+ *                               variable we want to pass to the   the pointer which the task can later
  *                               task. This pointer will be        retrieve)
  *                               copied),
  *
@@ -281,7 +274,7 @@ parsec_dtd_tile_t * parsec_dtd_tile_new(parsec_taskpool_t *dtd_tp, int rank);
  *                                                                  in order is situated)
  *
  *      *******  THIS PARAMETER MUST BE PROVIDED *******
- *      4. "0" indicates the end of paramter list. This should always be the last parameter.
+ *      4. "0" indicates the end of parameter list. This should always be the last parameter.
  *
  */
 void
@@ -318,7 +311,7 @@ parsec_insert_dtd_task(parsec_task_t *this_task);
 /**
  * This function should be called anytime users
  * are using data in their parsec-dtd runs.
- * This functions intializes/cleans necessary
+ * This functions initializes/cleans necessary
  * structures in a data-descriptor(dc). The
  * init should be called after a valid dc
  * has been acquired, and the fini before
@@ -348,7 +341,7 @@ parsec_dtd_taskpool_new(void);
  * data from the rank that last edited it
  * to the rank that owns it. So we end up with the
  * same data distribution as we started with.
- * The tile of a data can be acqiured using the
+ * The tile of a data can be acquired using the
  * PARSEC_DTD_TILE_OF or PARSEC_DTD_TILE_OF_KEY macro.
  * To ensure consistent and correct behavior, user
  * must wait on the taskpool before inserting
@@ -368,7 +361,7 @@ parsec_dtd_data_flush_all( parsec_taskpool_t *tp,
                            parsec_data_collection_t  *dc );
 
 /**
- * This function returns the taskpool a task bekongs to.
+ * This function returns the taskpool a task belongs to.
  */
 parsec_taskpool_t *
 parsec_dtd_get_taskpool(parsec_task_t *this_task);

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -433,7 +433,7 @@ void parsec_mca_device_dump_and_reset_statistics(parsec_context_t* parsec_contex
     } else {
         snprintf(percent3, 64, "%5.2f", ((double)total_data_out / (double)total_required_out) * 100.0);
     }
-    printf("|All Devs |%10d | %5.2f | %8.2f%2s |   %8.2f%2s(%s)   |   %8.2f%2s(%s)   | %8.2f%2s | %8.2f%2s(%s) |\n",
+    printf("|All Devs |%10d | %5.2f | %8.2f%2s |   %8.2f%2s(%s)     |   %8.2f%2s(%s)     | %8.2f%2s | %8.2f%2s(%s)   |\n",
            total, (total/gtotal)*100.00,
            best_required_in,  required_in_unit,  best_data_in,  data_in_unit, percent1,
            best_d2d, d2d_unit, percent2,

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -78,8 +78,9 @@ typedef int (parsec_stage_out_function_t)(parsec_gpu_task_t        *gtask,
 
 struct parsec_gpu_task_s {
     parsec_list_item_t               list_item;
-    int                              task_type;
-    int32_t                          pushout;
+    uint16_t                         task_type;
+    uint16_t                         pushout;
+    int32_t                          last_status;
     parsec_advance_task_function_t   submit;
     parsec_complete_stage_function_t complete_stage;
     parsec_stage_in_function_t      *stage_in;

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -42,8 +42,9 @@ typedef struct remote_dep_wire_activate_s {
     remote_dep_datakey_t deps;         /**< a pointer to the dep structure on the source */
     remote_dep_datakey_t output_mask;  /**< the mask of the output dependencies satisfied by this activation message */
     uint32_t             taskpool_id;
-    uint32_t             task_class_id;
-    uint32_t             length;
+    uint16_t             task_class_id;
+    uint16_t             length;
+    uint32_t             root;
     parsec_assignment_t  locals[MAX_LOCAL_COUNT];
 } remote_dep_wire_activate_t;
 
@@ -66,7 +67,7 @@ struct parsec_dep_type_description_s {
 };
 
 /**
- * This structure holds the key information for any data mouvement. It contains the arena
+ * This structure holds the key information for any data movement. It contains the arena
  * where the data is allocated from, or will be allocated from. It also contains the
  * pointer to the buffer involved in the communication (or NULL if the data will be
  * allocated before the reception). Finally, it contains the triplet allowing a correct send
@@ -125,7 +126,7 @@ struct remote_dep_output_param_s {
     struct parsec_dep_data_description_s  data;        /**< The data propagated by this message. */
     uint32_t                             deps_mask;   /**< A bitmask of all the output dependencies
                                                        propagated by this message. The bitmask uses
-                                                       depedencies indexes not flow indexes. */
+                                                       dependencies indexes not flow indexes. */
     int32_t                              priority;    /**< the priority of the message */
     uint32_t                             count_bits;  /**< The number of participants */
     uint32_t*                            rank_bits;   /**< The array of bits representing the propagation path */
@@ -133,7 +134,7 @@ struct remote_dep_output_param_s {
 
 struct parsec_remote_deps_s {
     parsec_list_item_t               super;
-    parsec_lifo_t                   *origin;        /**< The memory arena where the data pointer is comming from */
+    parsec_lifo_t                   *origin;        /**< The memory arena where the data pointer is coming from */
     struct parsec_taskpool_s        *taskpool;      /**< parsec taskpool generating this data transfer */
     int32_t                          pending_ack;   /**< Number of releases before completion */
     int32_t                          from;          /**< From whom we received the control */

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -874,10 +874,7 @@ remote_dep_get_datatypes(parsec_execution_stream_t* es,
     } else {
         parsec_task_t task;
         task.taskpool   = origin->taskpool;
-        /* Do not set the task.task_class here, because it might trigger a race condition in DTD */
-
-        task.priority = 0;  /* unknown yet */
-
+        task.priority   = 0;  /* unknown yet */
         task.task_class = task.taskpool->task_classes_array[origin->msg.task_class_id];
         for(i = 0; i < task.task_class->nb_flows;
             task.data[i].data_in = task.data[i].data_out = NULL,
@@ -1407,7 +1404,6 @@ static int remote_dep_nothread_send(parsec_execution_stream_t* es,
     int peer, position = 0;
 
     peer = item->cmd.activate.peer;  /* this doesn't change */
-    deps = (parsec_remote_deps_t*)item->cmd.activate.task.source_deps;
 
   pack_more:
     assert(peer == item->cmd.activate.peer);

--- a/tests/dsl/dtd/CMakeLists.txt
+++ b/tests/dsl/dtd/CMakeLists.txt
@@ -28,6 +28,7 @@ if( PARSEC_HAVE_CUDA )
   target_sources(dtd_test_new_tile PRIVATE dtd_test_new_tile_cuda_kernels.cu)
 
   parsec_addtest_executable(C dtd_test_cuda_task_insert SOURCES dtd_test_cuda_task_insert.c)
+  parsec_addtest_executable(C dtd_test_cuda_again_async SOURCES dtd_test_cuda_again_async.c)
   if( TARGET CUDA::cublas )
     parsec_addtest_executable(C dtd_test_simple_gemm SOURCES dtd_test_simple_gemm.c)
     target_link_libraries(dtd_test_simple_gemm PRIVATE CUDA::cublas m)

--- a/tests/dsl/dtd/dtd_test_cuda_again_async.c
+++ b/tests/dsl/dtd/dtd_test_cuda_again_async.c
@@ -1,0 +1,194 @@
+#include "parsec.h"
+#include "parsec/arena.h"
+#include "parsec/data_dist/matrix/matrix.h"
+#include "parsec/data_dist/matrix/two_dim_rectangle_cyclic.h"
+#include "parsec/interfaces/dtd/insert_function_internal.h"
+#include "tests/tests_data.h"
+
+#if defined(PARSEC_HAVE_MPI)
+#include <mpi.h>
+#endif  /* defined(PARSEC_HAVE_MPI) */
+
+void parsec_dtd_pack_args( parsec_task_t *this_task, ... )
+{
+    parsec_dtd_task_t *current_task = (parsec_dtd_task_t *)this_task;
+    parsec_dtd_task_param_t *current_param = GET_HEAD_OF_PARAM_LIST(current_task);
+    int i = 0;
+    void *tmp_val;
+    void **tmp_ref;
+    va_list arguments;
+
+    va_start(arguments, this_task);
+    while( current_param != NULL) {
+        if((current_param->op_type & PARSEC_GET_OP_TYPE) == PARSEC_VALUE ) {
+            tmp_val = va_arg(arguments, void*);
+            memcpy(current_param->pointer_to_tile, tmp_val, current_param->arg_size);
+        } else if((current_param->op_type & PARSEC_GET_OP_TYPE) == PARSEC_SCRATCH ||
+                  (current_param->op_type & PARSEC_GET_OP_TYPE) == PARSEC_REF ) {
+            tmp_ref = va_arg(arguments, void**);
+            current_param->pointer_to_tile = *tmp_ref;
+        } else if((current_param->op_type & PARSEC_GET_OP_TYPE) == PARSEC_INPUT ||
+                  (current_param->op_type & PARSEC_GET_OP_TYPE) == PARSEC_INOUT ||
+                  (current_param->op_type & PARSEC_GET_OP_TYPE) == PARSEC_OUTPUT ) {
+            tmp_ref = va_arg(arguments, void**);
+            this_task->data[i].data_in = *tmp_ref;
+            assert(0);
+            i++;
+        } else {
+            parsec_warning("/!\\ Flag is not recognized in parsec_dtd_unpack_args /!\\.\n");
+            assert(0);
+        }
+        current_param = current_param->next;
+    }
+    va_end(arguments);
+}
+
+static int max_repeat = 50;
+static parsec_task_t* array_of_async_tasks[100];
+
+/**
+ * This test check the correct handling of the PARSEC_HOOK_RETURN_ASYNC and
+ * PARSEC_HOOK_RETURN_AGAIN. The cuda_task_async will atomically save the task 
+ * onto a predefined array, and the cuda_task_again will repeat itself until
+ * the async task appears on the array. At that point it reenable the async task
+ * and continue it's execution until a predefined number of iteration have been
+ * reached. If more iterations have been already done it will return asap.
+ */
+
+int cuda_task_async(parsec_device_gpu_module_t *gpu_device,
+                    parsec_gpu_task_t *gpu_task,
+                    parsec_gpu_exec_stream_t *gpu_stream)
+{
+    parsec_task_t *this_task = gpu_task->ec;
+    int i, first;
+
+    (void)gpu_device; (void)gpu_stream;
+    parsec_dtd_unpack_args(this_task, &i, &first);
+    if( 0 == first ) {
+        first += 1;  /* mark the second call to this task */
+        parsec_dtd_pack_args(this_task, &i, &first);
+        PARSEC_LIST_ITEM_SINGLETON(this_task);
+        fprintf(stdout, "Task %p preparing for async behavior\n", this_task);
+        parsec_atomic_cas_ptr(&array_of_async_tasks[i], NULL, this_task);
+        return PARSEC_HOOK_RETURN_ASYNC;
+    }
+    fprintf(stdout, "Task %p is back alive after an async. Complete and leave\n", this_task);
+    return PARSEC_HOOK_RETURN_DONE;
+}
+
+int cuda_task_again(parsec_device_gpu_module_t *gpu_device,
+                    parsec_gpu_task_t *gpu_task,
+                    parsec_gpu_exec_stream_t *gpu_stream)
+{
+    parsec_task_t *this_task = gpu_task->ec;
+    int i, repeat, done;
+
+    (void)gpu_device; (void)gpu_stream;
+    parsec_dtd_unpack_args(this_task, &i, &repeat, &done);
+    if( !done  ) {
+        repeat += 1;
+        if( NULL == array_of_async_tasks[i] ) {
+            fprintf(stdout, "Task [%d] %p waiting for the async task (repeat %d)\n", i, this_task, repeat - 1);
+        } else {
+            /* There is a small opportunity for race conditions between the insertion of the async task and
+               it's reschedule by the again task.
+             */
+            sleep(1);
+            parsec_task_t* async_task = array_of_async_tasks[i];
+            fprintf(stdout, "Async Task %p is reinserted into the runtime\n", async_task);
+            array_of_async_tasks[i] = NULL;
+            parsec_execution_stream_t* local_es = parsec_my_execution_stream();
+            __parsec_reschedule(local_es, async_task);
+            done = 1;
+        }
+        parsec_dtd_pack_args(this_task, &i, &repeat, &done);
+        return PARSEC_HOOK_RETURN_AGAIN;
+    }
+    if(repeat < max_repeat) {
+        fprintf(stdout, "Task [%d] %p is cycling while waiting for repeat (%d)\n", i, this_task, repeat);
+        repeat += 1;
+        parsec_dtd_pack_args(this_task, &i, &repeat, &done);
+        return PARSEC_HOOK_RETURN_AGAIN;
+    }
+    fprintf(stdout, "Task [%d] %p is now officially complete\n", i, this_task);
+    return PARSEC_HOOK_RETURN_DONE;
+}
+
+int main(int argc, char* argv[])
+{
+    int ret;
+    parsec_context_t *parsec_context = NULL;
+    int rank, world;
+
+#if defined(PARSEC_HAVE_MPI)
+    {
+        int provided;
+        MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
+    }
+    MPI_Comm_size(MPI_COMM_WORLD, &world);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#else
+    world = 1;
+    rank = 0;
+#endif
+
+    parsec_context = parsec_init(-1, NULL, NULL);
+    // Create new DTD taskpool
+    parsec_taskpool_t *tp = parsec_dtd_taskpool_new();
+
+    parsec_task_class_t *again_tc, *async_tc;
+
+    ret = parsec_context_start(parsec_context);
+    PARSEC_CHECK_ERROR(ret, "parsec_context_start");
+
+    // Registering the dtd_handle with PARSEC context
+    ret = parsec_context_add_taskpool(parsec_context, tp);
+    PARSEC_CHECK_ERROR(ret, "parsec_context_add_taskpool");
+
+    again_tc = parsec_dtd_create_task_class(tp, "AGAIN",
+                                            sizeof(int), PARSEC_VALUE,  /* i */
+                                            sizeof(int), PARSEC_VALUE,  /* repeat */
+                                            sizeof(int), PARSEC_VALUE,  /* done */
+                                            PARSEC_DTD_ARG_END);
+    parsec_dtd_task_class_add_chore(tp, again_tc, PARSEC_DEV_CUDA, cuda_task_again);
+
+    async_tc = parsec_dtd_create_task_class(tp, "ASYNC",
+                                            sizeof(int), PARSEC_VALUE,  /* i */
+                                            sizeof(int), PARSEC_VALUE,  /* repeat */
+                                            PARSEC_DTD_ARG_END);
+    parsec_dtd_task_class_add_chore(tp, async_tc, PARSEC_DEV_CUDA, cuda_task_async);
+
+    int zero = 0, done = 0;
+    for( int i = 0; i < world; ++i ) {
+        parsec_dtd_insert_task_with_task_class(tp, async_tc, 0, PARSEC_DEV_ALL,
+                                               PARSEC_AFFINITY, &i,
+                                               PARSEC_VALUE, &zero,
+                                               PARSEC_DTD_ARG_END);
+    }
+
+    for( int i = 0; i < world; ++i ) {
+        parsec_dtd_insert_task_with_task_class(tp, again_tc, 0, PARSEC_DEV_ALL,
+                                               PARSEC_AFFINITY, &i,
+                                               PARSEC_VALUE, &zero,
+                                               PARSEC_VALUE, &done,
+                                               PARSEC_DTD_ARG_END);
+    }
+
+    // Wait for task completion
+    ret = parsec_taskpool_wait(tp);
+    PARSEC_CHECK_ERROR(ret, "parsec_taskpool_wait");
+
+    ret = parsec_context_wait(parsec_context);
+    PARSEC_CHECK_ERROR(ret, "parsec_context_wait");
+
+    parsec_dtd_task_class_release(tp, again_tc);
+    parsec_dtd_task_class_release(tp, async_tc);
+
+    parsec_taskpool_free(tp);
+
+    parsec_fini(&parsec_context);
+
+#if defined(PARSEC_HAVE_MPI)
+    MPI_Finalize();
+#endif
+}

--- a/tests/dsl/ptg/branching/branching_wrapper.c
+++ b/tests/dsl/ptg/branching/branching_wrapper.c
@@ -43,7 +43,7 @@ parsec_taskpool_t *branching_new(parsec_data_collection_t *A, int size, int nb)
     }
 
     tp = parsec_branching_new(A, nb);
-    
+
     ptrdiff_t lb, extent;
     parsec_type_create_contiguous(size, parsec_datatype_int_t, &block);
     parsec_type_extent(block, &lb, &extent);

--- a/tests/dsl/ptg/strange.jdf
+++ b/tests/dsl/ptg/strange.jdf
@@ -17,7 +17,7 @@ struct prev_next_s {
 /**
  * This test build a chain using different different local variables
  * and inlined functions. The local variable m is not necessary for the
- * functionning of the test,it is there for validation purposes.
+ * functioning of the test, it is there for validation purposes.
  */
 %}
 
@@ -36,7 +36,7 @@ neworder  [type = "struct prev_next_s*" hidden = on default = "NULL"]
 START(k)
  k = %{return *VAL;%} .. %{return *VAL;%}
 
- // Parallel partitionning
+ // Parallel partitioning
 : descA(%{return neworder[0].next;%}, 0)
 
 RW A <- descA(%{return neworder[0].next;%}, 0)


### PR DESCRIPTION
In both cases an event is added into the stream and once this event completes the task is processes according to it's last return: async tasks being dropped from the runtime and again tasks being rescheduled right away on the same stream.

One of the issues with the fact that AGAIN tasks remain on the same stream is that a certain number of AGAIN tasks (equal to the number of pending tasks in the stream) on the same stream will block the stream for new tasks. Thus, in order to provide progress the device tasks returning AGAIN must be careful with the time spent in the body.