### PR TITLE
Correct the logic for passing over CPU/RECURSIVE devices

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2304,7 +2304,7 @@ static parsec_hook_return_t parsec_dtd_gpu_task_submit(parsec_execution_stream_t
 
     dev_index = parsec_get_best_device(this_task, &load);
     assert(dev_index >= 0 && dev_index < parsec_mca_device_enabled());
-    if (parsec_mca_device_get(dev_index)->type <= PARSEC_DEV_RECURSIVE) {
+    if (!parsec_mca_device_is_gpu(dev_index)) {
         return PARSEC_HOOK_RETURN_NEXT; /* Fall back */
     }
 
@@ -2352,7 +2352,7 @@ static parsec_hook_return_t parsec_dtd_cpu_task_submit(parsec_execution_stream_t
              PARSEC_OUTPUT == (flow->op_type & PARSEC_GET_OP_TYPE)) {
             int8_t data_owner_dev = this_task->data[i].data_in->original->owner_device;
             assert(data_owner_dev < parsec_mca_device_enabled());
-            if( data_owner_dev >= 0 && parsec_mca_device_get(data_owner_dev)->type > PARSEC_DEV_RECURSIVE) {
+            if( data_owner_dev >= 0 && parsec_mca_device_is_gpu(data_owner_dev) ) {
                 uint8_t access = 0;
                 if( PARSEC_INOUT == (flow->op_type & PARSEC_GET_OP_TYPE) )
                     access = PARSEC_FLOW_ACCESS_RW;

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -6755,7 +6755,7 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
         coutput("  dev_index = parsec_get_best_device((parsec_task_t*)this_task, &__load);\n");
     }
     coutput("  assert(dev_index >= 0);\n"
-            "  if( parsec_mca_device_get(dev_index)->type <= PARSEC_DEV_RECURSIVE ) {\n"
+            "  if( !parsec_mca_device_is_gpu(dev_index) ) {\n"
             "    return PARSEC_HOOK_RETURN_NEXT;  /* Fall back */\n"
             "  }\n"
             "\n"

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -215,7 +215,12 @@ PARSEC_DECLSPEC int parsec_mca_device_add(parsec_context_t*, parsec_device_modul
 /**
  * Retrieve a pointer to the registered device using the provided index.
  */
-PARSEC_DECLSPEC parsec_device_module_t* parsec_mca_device_get(uint32_t);
+PARSEC_DECLSPEC parsec_device_module_t* parsec_mca_device_get(uint32_t devindex);
+
+/**
+ * True if the device pointed by the index is a valid GPU device
+ */
+PARSEC_DECLSPEC int parsec_mca_device_is_gpu(uint32_t devindex);
 
 /**
  * Remove the device from the list of enabled devices. All data residing on the


### PR DESCRIPTION
Correct the logic for passing over CPU/RECURSIVE devices when the recursive device is not built-in

We use the dev->type instead of the dev_index to identify the devices. 