### PR TITLE
hotfix

### DIFF
--- a/parsec/mca/pins/papi/pins_papi_module.c
+++ b/parsec/mca/pins/papi/pins_papi_module.c
@@ -10,6 +10,7 @@
 #include "parsec/mca/pins/pins_papi_utils.h"
 #include "parsec/utils/output.h"
 #include "parsec/utils/mca_param.h"
+#include <string.h>
 #include <stdio.h>
 #include <papi.h>
 #include "parsec/execution_stream.h"

--- a/parsec/mca/pins/pins.c
+++ b/parsec/mca/pins/pins.c
@@ -6,6 +6,7 @@
 
 /* PaRSEC Performance Instrumentation Callback System */
 #include "parsec/parsec_config.h"
+#include <string.h>
 #include <stdlib.h>
 #include <assert.h>
 #include "parsec/mca/pins/pins.h"

--- a/parsec/mca/pins/pins_papi_utils.c
+++ b/parsec/mca/pins/pins_papi_utils.c
@@ -4,6 +4,8 @@
  *                         reserved.
  */
 
+#include <errno.h>
+#include <string.h>
 #include "parsec/parsec_config.h"
 #include "parsec/constants.h"
 #include <papi.h>


### PR DESCRIPTION
Missing #includes for PAPI-related files that make compilation fail with icx on Sunspot