### PR TITLE
Fix the management of GPU copies.

### DIFF
--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -433,7 +433,7 @@ void parsec_mca_device_dump_and_reset_statistics(parsec_context_t* parsec_contex
     } else {
         snprintf(percent3, 64, "%5.2f", ((double)total_data_out / (double)total_required_out) * 100.0);
     }
-    printf("|All Devs |%10d | %5.2f | %8.2f%2s |   %8.2f%2s(%s)     |   %8.2f%2s(%s)     | %8.2f%2s | %8.2f%2s(%s)   |\n",
+    printf("|All Devs |%10d | %5.2f | %8.2f%2s |   %8.2f%2s(%s)   |   %8.2f%2s(%s)   | %8.2f%2s | %8.2f%2s(%s) |\n",
            total, (total/gtotal)*100.00,
            best_required_in,  required_in_unit,  best_data_in,  data_in_unit, percent1,
            best_d2d, d2d_unit, percent2,
@@ -504,7 +504,7 @@ int parsec_mca_device_fini(void)
     mca_base_component_t *component;
     for(int i = 0; i < num_modules_activated; i++ ) {
         module = modules_activated[i];
-        
+
         component = (mca_base_component_t*)module->component;
         component->mca_close_component();
         modules_activated[i] = NULL;

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -77,29 +77,31 @@ typedef int (parsec_stage_out_function_t)(parsec_gpu_task_t        *gtask,
                                           parsec_gpu_exec_stream_t *gpu_stream);
 
 struct parsec_gpu_task_s {
-    parsec_list_item_t               list_item;
-    uint16_t                         task_type;
-    uint16_t                         pushout;
-    int32_t                          last_status;
-    parsec_advance_task_function_t   submit;
-    parsec_complete_stage_function_t complete_stage;
-    parsec_stage_in_function_t      *stage_in;
-    parsec_stage_out_function_t     *stage_out;
+    parsec_list_item_t                list_item;
+    uint16_t                          task_type;
+    uint16_t                          pushout;
+    int32_t                           last_status;
+    parsec_advance_task_function_t    submit;
+    parsec_complete_stage_function_t  complete_stage;
+    parsec_stage_in_function_t       *stage_in;
+    parsec_stage_out_function_t      *stage_out;
 #if defined(PARSEC_PROF_TRACE)
-    int                              prof_key_end;
-    uint64_t                         prof_event_id;
-    uint32_t                         prof_tp_id;
+    int                               prof_key_end;
+    uint64_t                          prof_event_id;
+    uint32_t                          prof_tp_id;
 #endif
     union {
         struct {
-            parsec_task_t           *ec;
-            uint64_t                 last_data_check_epoch;
-            uint64_t                 load;  /* computational load imposed on the device */
-            const parsec_flow_t     *flow[MAX_PARAM_COUNT];
-            uint32_t                 flow_nb_elts[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
-                                                                     * on the GPU.
-                                                                     */
-            parsec_data_copy_t       *sources[MAX_PARAM_COUNT];
+            parsec_task_t            *ec;
+            uint64_t                  last_data_check_epoch;
+            uint64_t                  load;  /* computational load imposed on the device */
+            /* These should be set by the DSL */
+            const parsec_flow_t      *flow[MAX_PARAM_COUNT];  /* There is no consistent way to access the flows from the task_class,
+                                                               * so the DSL need to provide these flows here.
+                                                               */
+            uint32_t                  flow_nb_elts[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
+                                                                      * on the GPU.
+                                                                      */
             parsec_data_collection_t *flow_dc[MAX_PARAM_COUNT];     /* for each flow, data collection from which the data
                                                                      * to be transferred logically belongs to.
                                                                      * This gives the user the chance to indicate on the JDF
@@ -107,6 +109,10 @@ struct parsec_gpu_task_s {
                                                                      * User may want info from the DC (e.g. mtype),
                                                                      * & otherwise remote copies don't have any info.
                                                                      */
+            /* These are private and should not be used outside the device driver */
+            parsec_data_copy_t       *sources[MAX_PARAM_COUNT];  /* If the driver decides to acquire the data from a different
+                                                                  * source, it will temporary store the best candidate here.
+                                                                  */
         };
         struct {
             parsec_data_copy_t        *copy;

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -99,6 +99,7 @@ struct parsec_gpu_task_s {
             uint32_t                 flow_nb_elts[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
                                                                      * on the GPU.
                                                                      */
+            parsec_data_copy_t       *sources[MAX_PARAM_COUNT];
             parsec_data_collection_t *flow_dc[MAX_PARAM_COUNT];     /* for each flow, data collection from which the data
                                                                      * to be transferred logically belongs to.
                                                                      * This gives the user the chance to indicate on the JDF

--- a/tests/dsl/dtd/dtd_test_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_test_simple_gemm.c
@@ -552,35 +552,38 @@ int main(int argc, char **argv)
                 break;
             case 'h':
             case '?':
-                fprintf(stderr,
-                        "Usage %s [flags] [-- <parsec options>]\n"
-                        " Nota Bene: this test should not be used to evaluate performance of GEMM!\n"
-                        "    Use DPLASMA or other linear algebra libraries written on top of PaRSEC to evaluate this.\n"
-                        "\n"
-                        " Compute pdgemm on a process grid of PxQ, using all available GPUs on each\n"
-                        " node (modulo parsec options), using DTD. Compute C += AxB, where A is MxK\n"
-                        " tiled in mb x kb, B is KxN tiled in kb x nb, and C is MxN tiled in mb x nb\n"
-                        " Executes nruns iterations of the GEMM operation.\n"
-                        " flags:\n"
-                        "   --M|-M  / --K|-K  / --N|-N:   set M, K and N (resp.)\n"
-                        "   --mb|-m / --kb/-k / --nb|-n:  set mb, kb and nb (resp.)\n"
-                        "   --nruns|-t:                   set the number of runs to do\n"
-                        "   --device|-d:                  which device to use (CPU or GPU)\n"
-                        "   --verbose|-v:                 display which GEMM runs on which GPU\n"
-                        "                                 as execution is unfolding\n"
-                        "   --help|-h|-?:                 display this help\n"
-                        "   --debug|-D:                   blocks the process passed as parameter and\n"
-                        "                                 waits for gdb to connect to it\n"
-                        "   --Alarm|-A:                   sets the expected minimum performance for a\n"
-                        "                                 single GPU (kills the process if it takes longer\n"
-                        "                                 than the time corresponding to the expected\n"
-                        "                                 performance to complete the product)\n"
-                        "\n"
-                        " Nota Bene: this test should not be used to evaluate performance of GEMM!\n"
-                        "    Use DPLASMA or other linear algebra libraries written on top of PaRSEC to evaluate this.\n"
-                        "\n",
-                        argv[0]);
-                break;
+                if( 0 == rank ) {
+                    fprintf(stderr,
+                            "Usage %s [flags] [-- <parsec options>]\n"
+                            " Nota Bene: this test should not be used to evaluate performance of GEMM!\n"
+                            "    Use DPLASMA or other linear algebra libraries written on top of PaRSEC to evaluate this.\n"
+                            "\n"
+                            " Compute pdgemm on a process grid of PxQ, using all available GPUs on each\n"
+                            " node (modulo parsec options), using DTD. Compute C += AxB, where A is MxK\n"
+                            " tiled in mb x kb, B is KxN tiled in kb x nb, and C is MxN tiled in mb x nb\n"
+                            " Executes nruns iterations of the GEMM operation.\n"
+                            " flags:\n"
+                            "   --M|-M  / --K|-K  / --N|-N:   set M, K and N (resp.)\n"
+                            "   --mb|-m / --kb/-k / --nb|-n:  set mb, kb and nb (resp.)\n"
+                            "   --nruns|-t:                   set the number of runs to do\n"
+                            "   --device|-d:                  which device to use (CPU or GPU)\n"
+                            "   --verbose|-v:                 display which GEMM runs on which GPU\n"
+                            "                                 as execution is unfolding\n"
+                            "   --help|-h|-?:                 display this help\n"
+                            "   --debug|-D:                   blocks the process passed as parameter and\n"
+                            "                                 waits for gdb to connect to it\n"
+                            "   --Alarm|-A:                   sets the expected minimum performance for a\n"
+                            "                                 single GPU (kills the process if it takes longer\n"
+                            "                                 than the time corresponding to the expected\n"
+                            "                                 performance to complete the product)\n"
+                            "\n"
+                            " Nota Bene: this test should not be used to evaluate performance of GEMM!\n"
+                            "    Use DPLASMA or other linear algebra libraries written on top of PaRSEC to evaluate this.\n"
+                            "\n",
+                            argv[0]);
+                }
+                MPI_Finalize();
+                exit(0);
         }
     }
     int pargc = argc - optind;

--- a/tests/runtime/cuda/testing_get_best_device.c
+++ b/tests/runtime/cuda/testing_get_best_device.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
     int nb_gpus = 0;
     int info = 0;
 
-    while ((ch = getopt(argc, argv, "m:N:t:s:S:P:c:g:h:")) != -1) {
+    while ((ch = getopt(argc, argv, "m:N:t:s:S:P:c:g:h")) != -1) {
         switch (ch) {
             case 'm': m = atoi(optarg); break;
             case 'N': N = atoi(optarg); break;
@@ -75,6 +75,7 @@ int main(int argc, char *argv[])
                         "-P : rows (P) in the PxQ process grid (default: 1)\n"
                         "-c : number of cores used (default: -1)\n"
                         "-g : number of GPUs used (default: 0)\n"
+                        "-h : print this help message\n"
                         "\n");
                  exit(1);
         }


### PR DESCRIPTION
This patch fixes few issues:
- consistent return codes (based on HOOK_RETURN + positive values) for all the callbacks in the device code.
- avoid overwriting the task data_in. Instead keep them in a temporary copy in the gpu_task. Removes many bugs in the DSLs.
- Correctly handle the refcount and readers of the copies in the D2D case.