### PR TITLE
Topic/add evaluate keyword

### DIFF
--- a/parsec/data.c
+++ b/parsec/data.c
@@ -74,7 +74,7 @@ static void parsec_data_construct(parsec_data_t* obj )
 
 static void parsec_data_destruct(parsec_data_t* obj )
 {
-    PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Release data %p", obj);
+    PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Destruct data %p", obj);
     for( uint32_t i = 0; i < parsec_nb_devices; i++ ) {
         parsec_data_copy_t *copy = NULL;
         parsec_device_module_t *device = parsec_mca_device_get(i);

--- a/parsec/data.c
+++ b/parsec/data.c
@@ -32,7 +32,6 @@ static void parsec_data_copy_construct(parsec_data_copy_t* obj)
     obj->device_private       = NULL;
     obj->arena_chunk          = NULL;
     obj->data_transfer_status = PARSEC_DATA_STATUS_NOT_TRANSFER;
-    obj->push_task            = NULL;
     obj->dtt                  = PARSEC_DATATYPE_NULL;
     PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Allocate data copy %p", obj);
 }

--- a/parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic.h
+++ b/parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic.h
@@ -82,4 +82,4 @@ void parsec_matrix_sym_block_cyclic_init( parsec_matrix_sym_block_cyclic_t * dc,
 
 END_C_DECLS
 
-#endif /* __TWO_DIM_RECTANGLE_CYCLIC_H__*/
+#endif /* __SYM_TWO_DIM_RECTANGLE_CYCLIC_H__ */

--- a/parsec/data_internal.h
+++ b/parsec/data_internal.h
@@ -69,7 +69,6 @@ struct parsec_data_copy_s {
                                                       *   Overlay data distributions assume that arithmetic
                                                       *   can be done on these pointers. */
     parsec_data_status_t      data_transfer_status;  /** three status */
-    struct parsec_task_s     *push_task;             /** the task who actually do the PUSH */
     parsec_datatype_t         dtt;                   /**< the appropriate type for the network engine to send an element */
 };
 

--- a/parsec/interfaces/ptg/ptg-compiler/jdf.h
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf.h
@@ -17,7 +17,7 @@
  * It should be independent from the internal representation of the JDF,
  * although it mechanically mimics some of its structures.
  *
- * Nothing of this strucutre holds atomic things, or memory efficient representations,
+ * Nothing of this structure holds atomic things, or memory efficient representations,
  * since we don't expect to do High Performance Parsing.
  */
 
@@ -182,10 +182,6 @@ typedef unsigned int jdf_flags_t;
 #define JDF_FUNCTION_FLAG_HAS_DATA_OUTPUT   ((jdf_flags_t)(1 << 5))
 #define JDF_FUNCTION_FLAG_NO_PREDECESSORS   ((jdf_flags_t)(1 << 6))
 
-#define JDF_PROP_TERMDET_NAME                  "termdet"
-#define JDF_PROP_TERMDET_LOCAL                 "local"
-#define JDF_PROP_TERMDET_DYNAMIC               "dynamic"
-
 #define JDF_HAS_UD_NB_LOCAL_TASKS              ((jdf_flags_t)(1 << 0))
 #define JDF_PROP_UD_NB_LOCAL_TASKS_FN_NAME     "nb_local_tasks_fn"
 
@@ -200,11 +196,6 @@ typedef unsigned int jdf_flags_t;
 
 #define JDF_FUNCTION_HAS_UD_DEPENDENCIES_FUNS  ((jdf_flags_t)(1 << 4))
 
-#define JDF_PROP_TERMDET_USER_TRIGGERED        "user-triggered"
-#define JDF_HAS_USER_TRIGGERED_TERMDET         ((jdf_flags_t)(1 << 5))
-
-#define JDF_HAS_DYNAMIC_TERMDET                ((jdf_flags_t)(1 << 6))
-
 #define JDF_PROP_UD_FIND_DEPS_FN_NAME          "find_deps_fn"
 #define JDF_PROP_UD_ALLOC_DEPS_FN_NAME         "alloc_deps_fn"
 #define JDF_PROP_UD_FREE_DEPS_FN_NAME          "free_deps_fn"
@@ -217,6 +208,9 @@ typedef unsigned int jdf_flags_t;
 #define JDF_PROP_TERMDET_LOCAL                 "local"
 #define JDF_PROP_TERMDET_DYNAMIC               "dynamic"
 #define JDF_PROP_TERMDET_USER_TRIGGERED        "user-triggered"
+
+#define JDF_BODY_PROP_EVALUATE                 "evaluate"
+#define JDF_BODY_PROP_HOOK                     "hook"
 
 typedef struct jdf_function_entry {
     struct jdf_object_t        super;
@@ -552,6 +546,7 @@ int jdf_dep_undefined_type(jdf_datatransfer_type_t datatype );
 #define PARSEC_RETURN_TYPE_FLOAT                2
 #define PARSEC_RETURN_TYPE_DOUBLE               3
 #define PARSEC_RETURN_TYPE_ARENA_DATATYPE_T     4
+#define PARSEC_INLINE_WITH_TASK                 5
 
 static inline char* enum_type_name(int type)
 {

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -890,9 +890,10 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
                                  flow->name, i, gpu_elem,
                                  gpu_elem->data_transfer_status == PARSEC_DATA_STATUS_UNDER_TRANSFER ? " [in transfer]" : "");
             if ( gpu_elem->data_transfer_status == PARSEC_DATA_STATUS_UNDER_TRANSFER ) {
-          	    /* We might want to do something special if the data is under transfer, but in the current
-                 * version we don't need to because an event is always generated for the push_in of each
-                 * task on the unique push_in stream.
+              /* The data is indeed under transfer, but as we always force an event at the end of this
+                 * step, we do not need to have a special case for this, because the forced event will
+                 * ensure the data will be available on the GPU by the time this task will move to the
+                 * next step.
                  */
             }
             parsec_atomic_unlock(&master->lock);
@@ -1358,7 +1359,7 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
         return 1;  /* positive returns have special meaning and are used for optimizations */
     }
 
-    /* Try to find an alternate source, to avoid always tranfering from the host to the device.
+    /* Try to find an alternate source, to avoid always transferring from the host to the device.
      * Current limitations: only for read-only data used read-only on the hosting GPU. */
     parsec_device_gpu_module_t *candidate_dev = (parsec_device_gpu_module_t*)parsec_mca_device_get( candidate->device_index );
     if( (PARSEC_FLOW_ACCESS_READ & type) && !(PARSEC_FLOW_ACCESS_WRITE & type) ) {
@@ -1620,7 +1621,6 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
     int32_t i;
 #if defined(PARSEC_DEBUG_NOISIER)
     char task_str[MAX_TASK_STRLEN];
-    char task_str2[MAX_TASK_STRLEN];
 #endif
     const parsec_flow_t        *flow;
     /**
@@ -1647,7 +1647,7 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
         assert( flow->flow_index == i );
         if(PARSEC_FLOW_ACCESS_NONE == (PARSEC_FLOW_ACCESS_MASK & flow->flow_flags)) continue;
         if(PARSEC_DATA_STATUS_UNDER_TRANSFER == task->data[i].data_out->data_transfer_status ) {
-            assert(task->data[i].data_out->push_task == task );  /* only the task who did this PUSH can modify the status */
+            /* only the task who did the PUSH can modify the status */
             parsec_atomic_lock(&task->data[i].data_out->original->lock);
             task->data[i].data_out->data_transfer_status = PARSEC_DATA_STATUS_COMPLETE_TRANSFER;
             parsec_data_end_transfer_ownership_to_copy(task->data[i].data_out->original,
@@ -1662,7 +1662,6 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
                                        NULL);
             }
 #endif
-            task->data[i].data_out->push_task = NULL;
             parsec_atomic_unlock(&task->data[i].data_out->original->lock);
             parsec_data_copy_t* source = gtask->sources[i];
             parsec_device_gpu_module_t *src_device =
@@ -1739,14 +1738,11 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
             continue;
         }
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:\tparsec_device_callback_complete_push, PUSH of %s: task->data[%d].data_out = %p [ref_count = %d], and push_task is %s, %s because transfer_status is %d",
+                             "GPU[%s]:\tparsec_device_callback_complete_push, PUSH of %s: task->data[%d].data_out = %p [ref_count = %d], and %s because transfer_status is %d",
                              gpu_device->super.name, parsec_task_snprintf(task_str, MAX_TASK_STRLEN, task),
                              i, task->data[i].data_out, task->data[i].data_out->super.super.obj_reference_count,
-                             (NULL != task->data[i].data_out->push_task) ? parsec_task_snprintf(task_str2, MAX_TASK_STRLEN, task->data[i].data_out->push_task) : "(null)",
-                             (task->data[i].data_out->data_transfer_status != PARSEC_DATA_STATUS_UNDER_TRANSFER) ?
-                             "all is good" : "Assertion",
+                             (task->data[i].data_out->data_transfer_status != PARSEC_DATA_STATUS_UNDER_TRANSFER) ? "all is good" : "Assertion",
                              task->data[i].data_out->data_transfer_status);
-        assert(task->data[i].data_out->data_transfer_status != PARSEC_DATA_STATUS_UNDER_TRANSFER);
         if( task->data[i].data_out->data_transfer_status == PARSEC_DATA_STATUS_UNDER_TRANSFER ) {  /* data is not ready */
             /**
              * As long as we have only one stream to push the data on the GPU we should never
@@ -1812,7 +1808,7 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
                                parsec_gpu_task_t* task,
                                parsec_gpu_task_t** out_task )
 {
-    int saved_rc = PARSEC_HOOK_RETURN_DONE, rc;
+    int rc;
 #if defined(PARSEC_DEBUG_NOISIER)
     char task_str[MAX_TASK_STRLEN];
 #endif
@@ -1871,7 +1867,7 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
         task = (parsec_gpu_task_t*)parsec_list_pop_front(stream->fifo_pending);  /* get the best task */
     }
     if( NULL == task ) {  /* No tasks, we're done */
-        return saved_rc;
+        return PARSEC_HOOK_RETURN_DONE;
     }
     PARSEC_LIST_ITEM_SINGLETON((parsec_list_item_t*)task);
 
@@ -1884,8 +1880,6 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
            *out_task = task;
             return rc;
         }
-
-        saved_rc = rc;
 
         *out_task = NULL;
         /**
@@ -2006,6 +2000,7 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
         ret = parsec_device_data_stage_in( gpu_device, flow,
                                            &(this_task->data[i]), gpu_task, gpu_stream );
         if( ret < 0 ) {
+            gpu_task->last_status = ret;
             return ret;
         }
     }
@@ -2018,7 +2013,7 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
 #if defined(PARSEC_PROF_TRACE)
     gpu_task->prof_key_end = -1; /* We do not log that event as the completion of this task */
 #endif
-    return ret;
+    return PARSEC_HOOK_RETURN_DONE;
 }
 
 /**
@@ -2221,7 +2216,7 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
                 }
 #endif
                 /* Move the data back into main memory */
-                if( PARSEC_SUCCESS != gpu_task->stage_out? gpu_task->stage_out(gpu_task, (1U << flow->flow_index), gpu_stream): PARSEC_SUCCESS){
+                if( PARSEC_SUCCESS != gpu_task->stage_out? gpu_task->stage_out(gpu_task, (1U << flow->flow_index), gpu_stream): PARSEC_SUCCESS) {
                     parsec_warning( "%s:%d %s", __FILE__, __LINE__,
                                     "gpu_task->stage_out from device ");
                     parsec_warning("data %s <<%p>> -> <<%p>>\n", this_task->task_class->out[i]->name,
@@ -2322,7 +2317,7 @@ parsec_device_kernel_epilog( parsec_device_gpu_module_t *gpu_device,
 
         /**
          * Let's lie to the engine by reporting that working version of this
-         * data (aka. the one that GEMM worked on) is now on the CPU.
+         * data is now on the CPU.
          */
         this_task->data[i].data_out = cpu_copy;
 

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -1354,7 +1354,6 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
                              "GPU[%s]:\t\tMove data copy %p [ref_count %d, key %x] of %zu bytes: data copy is already under transfer, ignoring double request",
                              gpu_device->super.name,
                              gpu_elem, gpu_elem->super.super.obj_reference_count, original->key, nb_elts);
-        assert(NULL != gpu_elem->push_task);
         parsec_atomic_unlock( &original->lock );
         return 1;  /* positive returns have special meaning and are used for optimizations */
     }
@@ -1519,7 +1518,6 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
                          __FILE__, __LINE__);
 
     gpu_elem->data_transfer_status = PARSEC_DATA_STATUS_UNDER_TRANSFER;
-    gpu_elem->push_task = gpu_task->ec;  /* only the task who does the transfer can modify the data status later. */
 
     parsec_atomic_unlock( &original->lock );
     return 1;  /* positive returns have special meaning and are used for optimizations */

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -287,9 +287,13 @@ typedef int64_t (parsec_time_estimate_fct_t)(const parsec_task_t *this_task, par
  */
 typedef char* (parsec_printtask_fn_t)(char *buffer, size_t buffer_size, const parsec_task_t *task);
 /**
- *
+ * Evaluate the opportunity for executing the task on the associated device.
+ * 
+ * @return PARSEC_HOOK_RETURN_DONE is this chore can be used, PARSEC_HOOK_RETURN_NEXT
+ *         for this chore to be skipped. Any other value will result in a warning
+ *         and the chore being skipped.
  */
-typedef float (parsec_evaluate_function_t)(const parsec_task_t* task);
+typedef parsec_hook_return_t (parsec_evaluate_function_t)(const parsec_task_t* task);
 
 /**
  * Retrieve the datatype for each flow (for input) or dependency (for output)

--- a/tests/dsl/ptg/user-defined-functions/main.c
+++ b/tests/dsl/ptg/user-defined-functions/main.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
         {0,                       0, 0,   0}
     };
     int option_index = 0, c;
-    int P = -1, MB = -1, NB = -1, M = -1, N = -1;
+    int P = -1, MB = -1, NB = 1, M = -1, N = 1;
 
 #if defined(PARSEC_HAVE_MPI)
     {
@@ -82,9 +82,9 @@ int main(int argc, char *argv[])
                         "Usage: %s [-M <M>] [-N <N>] [-m <MB>] [-n <NB>] [-P <P>]\n"
                         " Display how many times a probe function is called to build a basic PTG\n"
                         "  M:  number of rows in the matrix (default N)\n"
-                        "  N:  number of columns in the matrix (required)\n"
+                        "  N:  number of columns in the matrix\n"
                         "  MB: number of rows in a tile (default NB)\n"
-                        "  NB: number of columns in a tile (required)\n"
+                        "  NB: number of columns in a tile\n"
                         "  P:  number of rows of processes in the 2D grid (default np, must divide np)\n"
                         "  c:  number of computing threads to create per rank (default one per core)\n"
                         "\n", argv[0]);

--- a/tests/dsl/ptg/user-defined-functions/udf.jdf
+++ b/tests/dsl/ptg/user-defined-functions/udf.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2019-2021 The University of Tennessee and The University
+ * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -21,6 +21,20 @@ static parsec_key_fn_t ud_hash_struct = {
     .key_print = ud_key_print,
     .key_hash  = parsec_hash_table_generic_64bits_key_hash
 };
+
+static inline parsec_hook_return_t
+always_here(const parsec_task_t* task)
+{
+    (void)task;
+    return PARSEC_HOOK_RETURN_DONE;
+}
+
+static inline parsec_hook_return_t
+never_here(const parsec_task_t* task)
+{
+    (void)task;
+    return PARSEC_HOOK_RETURN_NEXT;
+}
 
 %}
 
@@ -65,7 +79,7 @@ UD_STARTUP1(m, n) [ startup_fn = ud_startup1 ]
 
 READ X <- A(m, n)
 
-BODY
+BODY [evaluate = %{ return PARSEC_HOOK_RETURN_DONE; %}]
 {
     /* Nothing */
 }
@@ -79,14 +93,32 @@ UD_HASH_STRUCT(m, n) [ hash_struct = ud_hash_struct ]
 
 READ X <- A(m, n)
 
-BODY
+BODY [ evaluate = never_here
+       type = CUDA]
 {
-    /* Nothing */
+    fprintf(stderr, "We should never execute the CUDA incarnation for task UD_HASH_STRUCT(%d, %d)\n",
+            m, n);
+}
+END
+
+BODY [ evaluate = never_here
+       type = RECURSIVE]
+{
+    fprintf(stderr, "We should never execute the RECURSIVE incarnation for task UD_HASH_STRUCT(%d, %d)\n",
+            m, n);
+}
+END
+
+BODY [ type = CPU
+       evaluate = always_here ]
+{
+    fprintf(stderr, "We should always execute the CPU incarnation for task UD_HASH_STRUCT(%d, %d)\n",
+            m, n);
 }
 END
 
 UD_STARTUP2(m, n) [ make_key_fn = ud_make_key
-                   startup_fn = ud_startup2 ]
+                    startup_fn = ud_startup2 ]
   m = 0 .. A->super.mt-1 .. %{ return logger(1, UDF_TT_NBLOCAL_MAKEKEY_STARTUP); %}
   n = 0 .. A->super.nt-1 .. %{ return logger(1, UDF_TT_NBLOCAL_MAKEKEY_STARTUP); %}
 


### PR DESCRIPTION
Allow the user to defined validators for specific BODY chores. The chores will then be disabled per task instance (aka for each task) until one of the chores accepts to run and the BODY itself completes successfully.