### PR TITLE
HAVE_PEER_ACCESS is always present in all relevant versions of CUDA or

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,18 +696,10 @@ int main(int argc, char *argv[]) {
         message(STATUS "Using PGI internal CUDA SDK in ${CUDAToolkit_ROOT}")
       endif(_path_pgcuda)
     endif (_match_pgi)
-    find_package(CUDAToolkit)
+    find_package(CUDAToolkit 4)
     set(PARSEC_HAVE_CUDA ${CUDAToolkit_FOUND} CACHE BOOL "True if PaRSEC provide support for CUDA")
     if (CUDAToolkit_FOUND)
       message(STATUS "Found CUDA ${CUDAToolkit_VERSION} in ${CUDAToolkit_LIBRARY_DIR}")
-      cmake_push_check_state()
-      list(APPEND CMAKE_REQUIRED_LIBRARIES CUDA::cudart)
-      if(CUDAToolkit_VERSION VERSION_LESS "4.0")
-          set(PARSEC_HAVE_PEER_DEVICE_MEMORY_ACCESS 0)
-      else()
-          check_function_exists(cudaDeviceCanAccessPeer PARSEC_HAVE_PEER_DEVICE_MEMORY_ACCESS)
-      endif()
-      cmake_pop_check_state()
       get_target_property(extra_cuda_libs CUDA::cudart INTERFACE_LINK_LIBRARIES)
       if(extra_cuda_libs)
           list(APPEND EXTRA_LIBS ${extra_cuda_libs})
@@ -725,7 +717,7 @@ int main(int argc, char *argv[]) {
     # This is kinda ugly but the PATH and HINTS don't get transmitted to sub-dependents
     set(CMAKE_SYSTEM_PREFIX_PATH_save ${CMAKE_SYSTEM_PREFIX_PATH})
     list(APPEND CMAKE_SYSTEM_PREFIX_PATH /opt/rocm)
-    find_package(HIP QUIET) #quiet because hip-config.cmake is not part of core-cmake and will spam a loud warning when hip/rocm is not installed
+    find_package(HIP 1.9 QUIET) #quiet because hip-config.cmake is not part of core-cmake and will spam a loud warning when hip/rocm is not installed
     set(CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH_save})
     if(HIP_FOUND AND PARSEC_HAVE_CUDA)
       # the underlying reason is that the generated ptg code cannot include at the same time

--- a/parsec/include/parsec/parsec_options.h.in
+++ b/parsec/include/parsec/parsec_options.h.in
@@ -83,7 +83,6 @@
 #cmakedefine PARSEC_GPU_WITH_HIP
 #cmakedefine PARSEC_GPU_HIP_ALLOC_PER_TILE
 #cmakedefine PARSEC_GPU_WITH_OPENCL
-#cmakedefine PARSEC_HAVE_PEER_DEVICE_MEMORY_ACCESS
 
 /* debug */
 #cmakedefine PARSEC_DEBUG

--- a/parsec/mca/device/cuda/device_cuda_component.c
+++ b/parsec/mca/device/cuda/device_cuda_component.c
@@ -56,9 +56,7 @@ parsec_device_base_component_t parsec_device_cuda_component = {
         /* Component name and version */
         "cuda",
         /* Component options */
-#if defined(PARSEC_HAVE_PEER_DEVICE_MEMORY_ACCESS)
         "+peer_access"
-#endif
         "",
         PARSEC_VERSION_MAJOR,
         PARSEC_VERSION_MINOR,
@@ -78,12 +76,12 @@ parsec_device_base_component_t parsec_device_cuda_component = {
     },
     NULL
 };
- 
+
 mca_base_component_t * device_cuda_static_component(void)
 {
     return (mca_base_component_t *)&parsec_device_cuda_component;
 }
- 
+
 static int device_cuda_component_query(mca_base_module_t **module, int *priority)
 {
     int i, j, rc;
@@ -117,7 +115,6 @@ static int device_cuda_component_query(mca_base_module_t **module, int *priority
         parsec_device_cuda_component.modules[j] = NULL;
     }
 
-#if defined(PARSEC_HAVE_PEER_DEVICE_MEMORY_ACCESS)
     parsec_device_cuda_module_t *source_gpu, *target_gpu;
     cudaError_t cudastatus;
 
@@ -127,7 +124,7 @@ static int device_cuda_component_query(mca_base_module_t **module, int *priority
 
         if( ! ( (1<<i) & cuda_nvlink_mask ) )
             continue; /* The user disabled NVLINK for that GPU */
-        
+
         cudastatus = cudaSetDevice( source_gpu->cuda_index );
         PARSEC_CUDA_CHECK_ERROR( "(parsec_device_cuda_component_query) cudaSetDevice ", cudastatus,
                                  {continue;} );
@@ -148,7 +145,6 @@ static int device_cuda_component_query(mca_base_module_t **module, int *priority
             }
         }
     }
-#endif
 
     parsec_gpu_enable_debug();
 
@@ -156,7 +152,7 @@ static int device_cuda_component_query(mca_base_module_t **module, int *priority
     void *ptr = parsec_device_cuda_component.modules;
     *priority = 10;
     *module = (mca_base_module_t *)ptr;
-    
+
     return MCA_SUCCESS;
 }
 
@@ -285,7 +281,7 @@ static int device_cuda_component_close(void)
         rc = parsec_cuda_module_fini((parsec_device_module_t*)cdev);
         if( PARSEC_SUCCESS != rc ) {
             PARSEC_DEBUG_VERBOSE(0, parsec_gpu_output_stream,
-                                 "GPU[%d] Failed to release resources on CUDA device\n", 
+                                 "GPU[%d] Failed to release resources on CUDA device\n",
                                  cdev->cuda_index);
         }
 
@@ -293,7 +289,7 @@ static int device_cuda_component_close(void)
         rc = parsec_mca_device_remove((parsec_device_module_t*)cdev);
         if( PARSEC_SUCCESS != rc ) {
             PARSEC_DEBUG_VERBOSE(0, parsec_gpu_output_stream,
-                                 "GPU[%d] Failed to unregister CUDA device %d\n", 
+                                 "GPU[%d] Failed to unregister CUDA device %d\n",
                                  cdev->cuda_index, cdev->cuda_index);
         }
 
@@ -308,7 +304,7 @@ static int device_cuda_component_close(void)
 
         PARSEC_DEBUG_VERBOSE(0, parsec_gpu_output_stream,
                              "GPU[%d] CUDA device still registered with PaRSEC at the end of CUDA finalize.\n"
-                             " Please contact the developers or fill an issue.\n", 
+                             " Please contact the developers or fill an issue.\n",
                              cdev->cuda_index);
     }
 #endif  /* defined(PARSEC_DEBUG_NOISIER) */


### PR DESCRIPTION
Issue: ROCM would not use peer-access operators because we don't have a cmake test for the rocm-specific version of the have_peer_access function.

However, HAVE_PEER_ACCESS is always present in all relevant versions of CUDA or ROCM, so no need to cmake detect it, just require minimum cuda and rocm versions.