### PR TITLE
Prevent race condition in accelerator copies management

### DIFF
--- a/parsec/data.c
+++ b/parsec/data.c
@@ -329,11 +329,11 @@ int parsec_data_start_transfer_ownership_to_copy(parsec_data_t* data,
 
     copy = data->device_copies[device];
     assert( NULL != copy );
-    
+
     PARSEC_DEBUG_VERBOSE(10, parsec_debug_output,
                          "DEV[%d]: start transfer ownership of data %p to copy %p in mode %d",
                          device, data, copy, access_mode);
-    
+
     switch( copy->coherency_state ) {
     case PARSEC_DATA_COHERENCY_INVALID:
         transfer_required = 1;
@@ -414,8 +414,6 @@ int parsec_data_start_transfer_ownership_to_copy(parsec_data_t* data,
             data->device_copies[i]->coherency_state = PARSEC_DATA_COHERENCY_SHARED;
         }
     }
-
-    assert( (!transfer_required) || (data->device_copies[valid_copy]->version >= copy->version) );
 
     if( PARSEC_FLOW_ACCESS_READ & access_mode ) {
         copy->readers++;

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -385,7 +385,7 @@ void parsec_mca_device_dump_and_reset_statistics(parsec_context_t* parsec_contex
         required_out[device->device_index]    += device->required_data_out;
         d2dtmp = 0;
         for(unsigned int j = 1; j < device->data_in_array_size; j++) {
-            d2dtmp                            += device->data_in_from_device[i];
+            d2dtmp                            += device->data_in_from_device[j];
         }
         d2d[device->device_index]             += d2dtmp;
         /* Update the context-level statistics */


### PR DESCRIPTION
Prevent the owner device from repurposing a GPU copy while another GPU is planning to use it as a candidate for a d2d transfer.