### PR TITLE
CUDA: disable timer support on cuda events

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -408,8 +408,8 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
         for( k = 0; k < exec_stream->max_events; k++ ) {
             cuda_stream->events[k]   = NULL;
             exec_stream->tasks[k]    = NULL;
-            cudastatus = cudaEventCreate(&(cuda_stream->events[k]));
-            PARSEC_CUDA_CHECK_ERROR( "(INIT) cudaEventCreate ", (cudaError_t)cudastatus,
+            cudastatus = cudaEventCreateWithFlags(&(cuda_stream->events[k]), cudaEventDisableTiming);
+            PARSEC_CUDA_CHECK_ERROR( "(INIT) cudaEventCreateWithFlags ", (cudaError_t)cudastatus,
                                      {goto release_device;} );
         }
         if(j == 0) {


### PR DESCRIPTION
According to the [docs](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html#group__CUDART__EVENT_1g7b317e07ff385d85aa656204b971a042), disabling timers on events can improve performance.

I wrote a small benchmark to test the difference on xsdk:
```
    auto now = system_now();
    for (int i = 0; i < NUM_ITER; ++i) {
        ret = cudaEventRecord(event);
        assert(cudaSuccess == ret);
	    do {
           ret = cudaEventQuery(event);
	    } while (cudaErrorNotReady == ret);
        assert(cudaSuccess == ret);
    }

    auto then = system_now();
    std::cout << "Time " << duration_in_mus(now, then) << " us, avg " << duration_in_mus(now, then) / (double)NUM_ITER << " us " << std::endl;
```

The difference is about an order of magnitude:

Timers enabled: 5.18817
Timers disabled: 0.46593
