### PR TITLE
Fix/rocm detect and unknown device warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.18)
+cmake_minimum_required (VERSION 3.19)
 project (PARSEC C)
 
 include(CMakeDependentOption)
@@ -78,7 +78,7 @@ include(CTest)
 ## Check for the support of additional languages and capabilities
 option(SUPPORT_FORTRAN
        "Enable support for Fortran bindings (default ON)" ON)
-# In CMake 3.12, enable_language OPTIONAL has no effect and will still 
+# In CMake 3.12, enable_language OPTIONAL has no effect and will still
 # enable the language for a compiler that does not work/is not present
 # causing all sort of problems downstream. For now use CheckLanguage before.
 include(CheckLanguage)
@@ -717,7 +717,7 @@ int main(int argc, char *argv[]) {
     # This is kinda ugly but the PATH and HINTS don't get transmitted to sub-dependents
     set(CMAKE_SYSTEM_PREFIX_PATH_save ${CMAKE_SYSTEM_PREFIX_PATH})
     list(APPEND CMAKE_SYSTEM_PREFIX_PATH /opt/rocm)
-    find_package(HIP 1.9 QUIET) #quiet because hip-config.cmake is not part of core-cmake and will spam a loud warning when hip/rocm is not installed
+    find_package(HIP 5 QUIET) #quiet because hip-config.cmake is not part of core-cmake and will spam a loud warning when hip/rocm is not installed
     set(CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH_save})
     if(HIP_FOUND AND PARSEC_HAVE_CUDA)
       # the underlying reason is that the generated ptg code cannot include at the same time

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -35,7 +35,7 @@ static int parsec_cuda_data_advise(parsec_device_module_t *dev, parsec_data_t *d
  * https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list
  * we should limit the list of supported architectures to more recent setups.
  */
-static int cuda_legal_compute_capabilities[] = {35, 37, 50, 52, 53, 60, 61, 62, 70, 72, 75, 80};
+static int cuda_legal_compute_capabilities[] = {35, 37, 50, 52, 53, 60, 61, 62, 70, 72, 75, 80, 90};
 
 static int
 parsec_cuda_memory_reserve( parsec_device_cuda_module_t* gpu_device,
@@ -71,7 +71,7 @@ static int parsec_cuda_device_lookup_cudamp_floprate(int major, int minor, int *
         *drate = 4;
     } else if (major == 5 && minor == 3) {
         *hrate = 256;
-        *trate = *srate = 128;
+        *srate = 128;
         *drate = 4;
     } else if (major == 6 && minor == 0) {
         *hrate = 128;
@@ -100,16 +100,23 @@ static int parsec_cuda_device_lookup_cudamp_floprate(int major, int minor, int *
         *trate = 512;
         *srate = 64;
         *drate = 32;
-    } else {  /* Unknown device */
-        if( major >= 8 ) {  /* If more recent than 8.0 let's assume the performance will not decrease */
-            *hrate = 256;
-            *trate = 512;
-            *srate = 64;
-            *drate = 32;
-            parsec_warning("Unknown GPU capabilities %d, %d, assuming 8, 0 capability.", major, minor);
-        } else {
-            parsec_warning("Unknown GPU capabilities %d, %d, assuming basic capability.", major, minor);
-        }
+    } else if (major == 8 && minor == 6) {
+        *hrate = 256;
+        *trate = 512;
+        *srate = 128;
+        *drate = 2;
+    } else if (major == 8 && minor == 9) {
+        *hrate = 256;
+        *trate = 512;
+        *srate = 128;
+        *drate = 2;
+    } else if (major == 9 && minor == 0) {
+        *hrate = 3712;
+        *trate = 1856;
+        *srate = 128;
+        *drate = 64;
+    } else { /* Unknown device */
+        return PARSEC_ERR_NOT_IMPLEMENTED;
     }
     return PARSEC_SUCCESS;
 }
@@ -458,16 +465,16 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
     device->data_advise         = parsec_cuda_data_advise;
     device->memory_release      = parsec_cuda_flush_lru;
 
-    if (parsec_cuda_device_lookup_cudamp_floprate(major, minor, &drate, &srate, &trate, &hrate) == PARSEC_ERROR ) {
+    if (parsec_cuda_device_lookup_cudamp_floprate(major, minor, &drate, &srate, &trate, &hrate) == PARSEC_ERR_NOT_IMPLEMENTED ) {
         parsec_warning( "Device %s with capabilities %d.%d is unknown. Gflops rate is a random guess."
                         "Load balancing and performance might be negatively impacted. Please contact"
                         "the PaRSEC runtime developers", gpu_device->super.name, major, minor );
     }
     /* We compute gflops based on FMA rate */
-    device->gflops_fp16 = fp16 = 2.f * hrate * streaming_multiprocessor * freqHz * 1e-9f;
-    device->gflops_tf32 = tf32 = 2.f * trate * streaming_multiprocessor * freqHz * 1e-9f;
-    device->gflops_fp32 = fp32 = 2.f * srate * streaming_multiprocessor * freqHz * 1e-9f;
-    device->gflops_fp64 = fp64 = 2.f * drate * streaming_multiprocessor * freqHz * 1e-9f;
+    device->gflops_fp16 = fp16 = 2.f * hrate * streaming_multiprocessor * freqHz * 1e-12f;
+    device->gflops_tf32 = tf32 = 2.f * trate * streaming_multiprocessor * freqHz * 1e-12f;
+    device->gflops_fp32 = fp32 = 2.f * srate * streaming_multiprocessor * freqHz * 1e-12f;
+    device->gflops_fp64 = fp64 = 2.f * drate * streaming_multiprocessor * freqHz * 1e-12f;
     /* don't assert fp16, tf32, maybe they actually do not exist on the architecture */
     assert(device->gflops_fp32 > 0);
     assert(device->gflops_fp64 > 0);
@@ -493,7 +500,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
                       "\tLocation (PCI Bus/Device/Domain): %x:%x.%x\n"
                       "\tSM                 : %d\n"
                       "\tFrequency (GHz)    : %f\n"
-                      "\tpeak Gflops        : double %2.1f, single %2.1f, tensor, %2.1f, half %2.1f\n"
+                      "\tpeak Tflop/s       : %4.2f fp64,\t%4.2f fp32,\t%4.2f tf32,\t%4.2f fp16\n"
                       "\tPeak Mem Bw (GB/s) : %.2f [Clock Rate (Ghz) %.2f | Bus Width (bits) %d]\n"
                       "\tconcurrency        : %s\n"
                       "\tcomputeMode        : %d\n",

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -49,7 +49,6 @@ static int parsec_cuda_flush_lru( parsec_device_module_t *device );
  * precision.
  * The following table provides updated values for future archs
  * http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#arithmetic-instructions
- *
  */
 static int parsec_cuda_device_lookup_cudamp_floprate(const char* name, int major, int minor, int *drate, int *srate, int *trate, int *hrate)
 {
@@ -58,7 +57,11 @@ static int parsec_cuda_device_lookup_cudamp_floprate(const char* name, int major
     *drate = 1;
     *hrate = *trate = 0;  /* not supported */
 
-#if !defined(PARSEC_HAVE_DEV_HIP_SUPPORT) /* AMD devices all report the same major/minor so we need something else */
+#if !defined(PARSEC_HAVE_DEV_HIP_SUPPORT)
+    /* AMD devices all report the same major/minor so we need something else
+     * AMD does not provide a handy list of FMA/cycle like NVIDIA does, so we
+     * have to use wikipedia... https://en.wikipedia.org/wiki/AMD_Instinct
+     */
     (void)name;
     if ((major == 3 && minor == 0) ||
         (major == 3 && minor == 2)) {

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -790,10 +790,10 @@ static int cpu_weights(parsec_device_module_t* device, int nstreams)
           parsec_inform("CPU Device: %s\n"
                         "\tParsec Streams     : %d\n"
                         "\tFrequency (GHz)    : %2.2f\n"
-                        "\tpeak Gflops        : double %2.4f, single %2.4f",
+                        "\tPeak Tflop/s       : %2.4f fp64,\t%2.4f fp32",
                         cpu_model,
                         nstreams,
-                        freq, nstreams*freq*dp_ipc, nstreams*freq*fp_ipc);
+                        freq, nstreams*freq*dp_ipc*1e-3, nstreams*freq*fp_ipc*1e-3);
        }
     }
  notfound:

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -667,8 +667,8 @@ int parsec_mca_device_registration_complete(parsec_context_t* context)
         if( NULL == device ) continue;
         if( PARSEC_DEV_RECURSIVE == device->type ) continue;
         device->time_estimate_default = total_gflops_fp64/(double)device->gflops_fp64;
-        parsec_debug_verbose(6, parsec_device_output, "  Dev[%d] default-time-estimate %-4"PRId64" <- double %-8"PRId64" single %-8"PRId64" tensor %-8"PRId64" half %-8"PRId64,
-                             i, device->time_estimate_default, device->gflops_fp64, device->gflops_fp32, device->gflops_tf32, device->gflops_fp16);
+        parsec_debug_verbose(6, parsec_device_output, "  Dev[%d] default-time-estimate %-4"PRId64" <- double %-8"PRId64" single %-8"PRId64" tensor %-8"PRId64" half %-8"PRId64" %s",
+                             i, device->time_estimate_default, device->gflops_fp64, device->gflops_fp32, device->gflops_tf32, device->gflops_fp16, device->gflops_guess? "GUESSED": "");
     }
 
     parsec_mca_device_are_freezed = 1;

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -143,6 +143,7 @@ struct parsec_device_module_s {
     int64_t   gflops_fp32;  /**< Number of single precision operations per nanosecond (or gflops/s) */
     int64_t   gflops_fp64;  /**< Number of double precision operations per nanosecond (or gflops/s) */
     int64_t   gflops_tf32;  /**< Number of tensor operations per nanosecond (or gflops/s) */
+    uint8_t   gflops_guess; /**< True if the device is not 'known' which entails that the 'gflops' rates have been populated with fallback (arbitrary) values. */
     int64_t   time_estimate_default; /**< An estimate of the time to execute on that device a task that would take 1ns using the aggregate power of all devices. This is the default time_estimate if none is user-set. */
     int64_t   device_load;     /**< Number of nanoseconds of work submitted to the device, and not completed now. This variable is adjusted by the runtime using the time_estimate loads from the tasks. */
 #if defined(PARSEC_PROF_TRACE)

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -143,15 +143,15 @@ struct parsec_device_module_s {
     int64_t   gflops_fp32;  /**< Number of single precision operations per nanosecond (or gflops/s) */
     int64_t   gflops_fp64;  /**< Number of double precision operations per nanosecond (or gflops/s) */
     int64_t   gflops_tf32;  /**< Number of tensor operations per nanosecond (or gflops/s) */
-    uint8_t   gflops_guess; /**< True if the device is not 'known' which entails that the 'gflops' rates have been populated with fallback (arbitrary) values. */
     int64_t   time_estimate_default; /**< An estimate of the time to execute on that device a task that would take 1ns using the aggregate power of all devices. This is the default time_estimate if none is user-set. */
     int64_t   device_load;     /**< Number of nanoseconds of work submitted to the device, and not completed now. This variable is adjusted by the runtime using the time_estimate loads from the tasks. */
-#if defined(PARSEC_PROF_TRACE)
-    parsec_profiling_stream_t *profiling;
-#endif  /* defined(PROFILING) */
+    uint8_t gflops_guess; /**< True if the device is not 'known' which entails that the 'gflops' rates have been populated with fallback (arbitrary) values. */
     uint8_t data_in_array_size; /**< Current size of the data_in_from_device array. Used for safety checking */
     uint8_t device_index;
     uint8_t type;
+#if defined(PARSEC_PROF_TRACE)
+    parsec_profiling_stream_t *profiling;
+#endif  /* defined(PROFILING) */
 };
 
 PARSEC_OBJ_CLASS_DECLARATION(parsec_device_module_t);


### PR DESCRIPTION
1. fixes detection of Rocm not working
2. add AMD device detection
3. add cuda 8.5--9 device detection
4. removes non-conditional warnings about unknown device
5. roll-in unknown device warnings to the relevant places (debug when computing default-time-estimate, and the SHOW_CAPS option)