### PR TITLE
Pick a stable spack branch

### DIFF
--- a/.github/CI/github_runner.yaml
+++ b/.github/CI/github_runner.yaml
@@ -25,3 +25,10 @@ spack:
   specs:
     - matrix:
       - [$pkgs]
+  packages:
+     binutils:
+       buildable: false
+       externals:
+       - spec: binutils@2.38
+         prefix: /usr
+

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -7,7 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
-#env:
+env:
+  RUNNER_ENV : github_runner
+  RUNNER_SPACK_BRANCH : e4s-23.08
 
 # Allows to run this workflow manually from the Actions tab
 #workflow_dispatch:
@@ -26,7 +28,6 @@ jobs:
     env:
       BUILD_DIRECTORY : "${{github.workspace}}/build/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
       INSTALL_DIRECTORY : "${{github.workspace}}/install/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
-      RUNNER_ENV : github_runner
       BUILD_CONFIG : >
         -G Ninja
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -112,7 +113,6 @@ jobs:
     env:
       BUILD_DIRECTORY : "${{github.workspace}}/build/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
       INSTALL_DIRECTORY : "${{github.workspace}}/install/${{ matrix.build_type }}/shared_${{matrix.shared_type}}/profile_${{matrix.profiling}}"
-      RUNNER_ENV : github_runner
       BUILD_CONFIG : >
         -G Ninja
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}


### PR DESCRIPTION
Add RUNNER_SPACK_BRANCH to allow an updated spack branch to be used instead of the curretn default (e4s-23.08).