### PR TITLE
Allow locals and parameters to be defined via CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,12 @@ endif(NOT CMAKE_BUILD_TYPE)
 option(PARSEC_WANT_HOME_CONFIG_FILES
        "Should the runtime check for the parameter configuration file in the user home (\$HOME/.parsec/mca-params.conf)" ON)
 
+### PaRSEC runtime configuration parameters
+set(PARSEC_MAX_LOCAL_COUNT 20 CACHE STRING "Number of local variables for tasks (default 20)")
+set(PARSEC_MAX_PARAM_COUNT 20 CACHE STRING "Number of parameters for tasks (default 20)")
+set(PARSEC_MAX_DEP_IN_COUNT 10 CACHE STRING "Number of input flows for each task (default 10)")
+set(PARSEC_MAX_DEP_OUT_COUNT 10 CACHE STRING "Number of output flows for each task (default 10)")
+
 ### PaRSEC PP options
 set(PARSEC_PTGPP_FLAGS "--noline" CACHE STRING "Additional parsec-ptgpp precompiling flags (separate flags with ';')" )
 mark_as_advanced(PARSEC_PTGPP_FLAGS)
@@ -139,10 +145,9 @@ mark_as_advanced(PARSEC_PTGPP_FLAGS)
 option(PARSEC_WITH_DEVEL_HEADERS "Install additional headers in include/parsec allowing external compilation." ON)
 
 ## Multicore scheduler parameters
-
-mark_as_advanced(PARSEC_SCHED_DEPS_MASK)
 option(PARSEC_SCHED_DEPS_MASK
   "Use a complete bitmask to track the dependencies, instead of a counter -- increase the debugging features, but limits to a maximum of 30 input dependencies" ON)
+mark_as_advanced(PARSEC_SCHED_DEPS_MASK)
 
 ### Distributed engine parameters
 mark_as_advanced(PARSEC_DIST_THREAD PARSEC_DIST_PRIORITIES)

--- a/parsec/include/parsec/parsec_config_bottom.h
+++ b/parsec/include/parsec/parsec_config_bottom.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -164,12 +164,6 @@ typedef int32_t parsec_dependency_t;
  * A set of constants defining the capabilities of the underlying
  * runtime.
  */
-#define MAX_LOCAL_COUNT  20
-#define MAX_PARAM_COUNT  20
-
-#define MAX_DEP_IN_COUNT  10
-#define MAX_DEP_OUT_COUNT 10
-
 #define MAX_TASK_STRLEN 128
 
 #define PARSEC_MAX_DEVICE_NAME_LEN 64

--- a/parsec/include/parsec/parsec_options.h.in
+++ b/parsec/include/parsec/parsec_options.h.in
@@ -2,7 +2,7 @@
 #define PARSEC_CONFIG_H_HAS_BEEN_INCLUDED
 
 /* This file contains the OS dependent capabilities, and should be generic for
- * all compilers o a particular architecture. It is used during the PaRSEC build to
+ * all compilers on a particular architecture. It is used during the PaRSEC build to
  * import all OS dependent features, but once PaRSEC installed this file will
  * become the parsec_config.h and will hide all compiler dependent features used
  * during PaRSEC compilation.
@@ -119,11 +119,6 @@
 #define CMAKE_PARSEC_C_FLAGS      "@CMAKE_C_FLAGS@"
 #define CMAKE_PARSEC_C_INCLUDES   "@PARSEC_C_INCLUDES@"
 
-/**
- * The following 3 defines are deprecated. Instead users should
- * rely on the corresponding PARSEC_HAVE_DEV_XXX_SUPPORT
- */
-
 #cmakedefine PARSEC_HAVE_HWLOC
 #cmakedefine PARSEC_HAVE_PAPI
 #cmakedefine PARSEC_HAVE_MPI
@@ -145,6 +140,15 @@
 #define PARSEC_LIB_LEVEL_ZERO_PREFIX "."
 
 #define PARSEC_SIZEOF_VOID_P @CMAKE_SIZEOF_VOID_P@
+
+/* The max number of local variables for each task */
+#define MAX_LOCAL_COUNT   @PARSEC_MAX_LOCAL_COUNT@
+/* The max number of parameter variables for each task */
+#define MAX_PARAM_COUNT   @PARSEC_MAX_PARAM_COUNT@
+/* The max number of input dependencies (not flows) for each task */
+#define MAX_DEP_IN_COUNT  @PARSEC_MAX_DEP_IN_COUNT@
+/* The max number of output dependencies (not flows) for each task */
+#define MAX_DEP_OUT_COUNT @PARSEC_MAX_DEP_OUT_COUNT@
 
 #include "parsec/parsec_config_bottom.h"
 


### PR DESCRIPTION
Allow the user to configure the number of locals, parameters and data dependencies for the runtime.

Fixes #579.