### PR TITLE
Discover atomic support for __int128_t.

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -10,6 +10,9 @@ on:
 env:
   RUNNER_ENV : github_runner
   RUNNER_SPACK_BRANCH : e4s-23.08
+  CC : gcc
+  FC : gfortran
+  CXX : g++
 
 # Allows to run this workflow manually from the Actions tab
 #workflow_dispatch:

--- a/parsec/class/list_item.h
+++ b/parsec/class/list_item.h
@@ -281,20 +281,6 @@ parsec_list_item_ring_push_sorted( parsec_list_item_t* ring,
  * @cond FALSE
  */
 #if defined(PARSEC_DEBUG_PARANOID)
-#define PARSEC_ITEMS_VALIDATE(ITEMS)                                    \
-    do {                                                                \
-        parsec_list_item_t *__end = (ITEMS);                            \
-        int _number; parsec_list_item_t *__item;                        \
-        for(_number=0, __item = (parsec_list_item_t*)__end->list_next;  \
-            __item != __end;                                            \
-            __item = (parsec_list_item_t*)__item->list_next ) {         \
-            assert( (__item->refcount == 0) || (__item->refcount == 1) ); \
-            assert( __end->refcount == __item->refcount );              \
-            if( __item->refcount == 1 )                                 \
-                assert(__item->belong_to == __end->belong_to);          \
-            if( ++_number > 1000 ) assert(0);                           \
-        }                                                               \
-    } while(0)
 
 #define PARSEC_ITEM_ATTACH(LIST, ITEM)                                  \
     do {                                                                \
@@ -328,10 +314,6 @@ parsec_list_item_ring_push_sorted( parsec_list_item_t* ring,
     } while (0)
 #else
 /** @endcond */
-/**
- * @brief Check that an item is well formed (it does belong to the structure it is supposed to)
- */
-#define PARSEC_ITEMS_VALIDATE_ELEMS(ITEMS) do { (void)(ITEMS); } while(0)
 /**
  * @brief Attach an item to a higher level structure
  */

--- a/parsec/include/parsec/sys/atomic-c11.h
+++ b/parsec/include/parsec/sys/atomic-c11.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 The University of Tennessee and The University
+ * Copyright (c) 2016-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -13,7 +13,7 @@
  * with the exception of parsec_atomic_lock operations, which use proper
  * acquire/release semantics, and the memory barriers.
  *
- * Change this define to memory_order_seq_cst to restore senquential
+ * Change this define to memory_order_seq_cst to restore sequential
  * consistency of atomic operations.
  *
  * NOTE: semantically, we should use memory_order_consume to ensure that

--- a/tests/class/lifo.c
+++ b/tests/class/lifo.c
@@ -88,7 +88,7 @@ static void check_translate_outoforder(parsec_lifo_t *l1,
     for(e = 0; e < NBELT; e++) {
         elt = (elt_t *)parsec_lifo_pop( l1 );
         if( NULL == elt )
-            fatal(" ! Error: there are only %u elements in %s -- expecting %u\n", e+1, lifo1name, NBELT);
+            fatal(" ! Error: there are only %u elements in %s -- expecting %u\n", e, lifo1name, NBELT);
         check_elt( elt );
         parsec_lifo_push( l2, (parsec_list_item_t *)elt );
         if( elt->base >= NBELT )


### PR DESCRIPTION
Our detection of atomic operations on 128 bits was incorrect, resulting in a conflict with compilers with proper support for _Atomic. The conflict arise from the fact that our detection thought that 128 bits atomic lock-less operations were available, but the compiler decided not to use them in the lifo (even with the correct compilation flags). 

Fixes #586.