### PR TITLE
Skip profiling for task classes without profiling information

### DIFF
--- a/parsec/profiling.h
+++ b/parsec/profiling.h
@@ -533,7 +533,7 @@ void parsec_profiling_disable(void);
  * @brief Convenience macro to trace events with flags only if profiling is enabled
  */
 #define PARSEC_PROFILING_TRACE_FLAGS_INFO_FN(context, key, event_id, object_id, info_fn, info_data, flags ) \
-    if( parsec_profile_enabled ) {                                       \
+    if( parsec_profile_enabled && (-1 != (key))) {                                       \
         parsec_profiling_trace_flags_info_fn((context), (key), (event_id), (object_id), (info_fn), (info_data), (flags) ); \
     }
 


### PR DESCRIPTION
This PR fixes the issues related to profiling of tasks without profiling information. We decided to allow PINS modules to generate interesting information even for non-profilable tasks. Thus, we had to make sure that PINS module generating profile information would skip tasks marked without profiling (property `profile=off` in PTG as an example).

Added -2 as another value for the profiling array. `profiling_array[0] == -2` signifies that nothing has been initialized yet.

Replacing both #561 and #573.