### PR TITLE
Fix the parsec_future_t.

### DIFF
--- a/parsec/class/parsec_future.h
+++ b/parsec/class/parsec_future.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
  */
 
 
@@ -48,7 +49,7 @@ typedef int   (*parsec_future_is_ready_t)       (parsec_base_future_t*);
 typedef void* (*parsec_future_get_or_trigger_t) (parsec_base_future_t*, ...);
 typedef void  (*parsec_future_set_t)            (parsec_base_future_t*, void*);
 typedef void* (*parsec_future_get_t)            (parsec_base_future_t*);
-typedef void  (*parsec_future_init_t)           (parsec_base_future_t*, ...);
+typedef void  (*parsec_future_init_t)           (parsec_base_future_t*, parsec_future_cb_fulfill, ...);
 
 #define PARSEC_DATA_FUTURE_STATUS_INIT      ((uint8_t)0x01) /* Future has been initialized. */
 #define PARSEC_DATA_FUTURE_STATUS_TRIGGERED ((uint8_t)0x02) /* Future has been triggered. */

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
  */
 #ifndef __USE_PARSEC_REMOTE_DEP_H__
 #define __USE_PARSEC_REMOTE_DEP_H__
@@ -109,12 +110,8 @@ struct parsec_reshape_promise_description_s {
 };
 
 /* Callback to do a local reshaping of a datacopy */
-void parsec_local_reshape(parsec_base_future_t *future,
-                          void **in_data,
-                          parsec_execution_stream_t *es,
-                          parsec_task_t *task);
-
-
+void parsec_local_reshape_cb(parsec_base_future_t *future, ... );
+/* assumed: void **in_data, parsec_execution_stream_t *es, parsec_task_t *task */
 
 struct remote_dep_output_param_s {
     /** Never change this structure without understanding the

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -606,10 +607,18 @@ reshape_copy_allocate(parsec_dep_type_description_t* data)
  * @param[in] tp parsec_taskpool_t.
  * @param[in] task parsec_task_t.
  */
-void parsec_local_reshape(parsec_base_future_t *future,
-                          void **in_data,
-                          parsec_execution_stream_t *es,
-                          parsec_task_t *task){
+void parsec_local_reshape_cb(parsec_base_future_t *future, ... )
+{
+    void **in_data;
+    parsec_execution_stream_t *es;
+    parsec_task_t *task;
+
+    va_list ap;
+    va_start(ap, future);
+    in_data = va_arg(ap, void**);
+    es = va_arg(ap, parsec_execution_stream_t*);
+    task = va_arg(ap, parsec_task_t*);
+    va_end(ap);
 
     parsec_reshape_promise_description_t *dt = (parsec_reshape_promise_description_t*)*in_data;
     parsec_taskpool_t* tp = (task != NULL) ? task->taskpool: NULL;

--- a/tests/class/future.c
+++ b/tests/class/future.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
  */
 
 #include <pthread.h>
@@ -26,7 +27,8 @@ parsec_countable_future_t *c_fut;
 int cores = 4;
 int ncopy = 100;
 
-void test_cb(parsec_base_future_t* future){
+void test_cb(parsec_base_future_t* future, ...)
+{
     int* temp = (int*)parsec_future_get(future);
     printf("callback returning %d\n", *temp);
 }
@@ -37,7 +39,7 @@ static void *do_test(void* _param){
     int id = param[0]; //thread id
     int *res;
     int validate = 0;
-    /* Even number's thread will set the future to be ready, 
+    /* Even number's thread will set the future to be ready,
      * Odd number thread will read the value set by previous thread
      */
     if(id % 2 == 0) {
@@ -47,7 +49,7 @@ static void *do_test(void* _param){
         for(int i = 0; i < ncopy; i++) {
             res = parsec_future_get(fut_array[id+i*cores-1]);
             if(*res != data[id+i*cores-1]) {
-                printf("thread %d index %d with value %d, expected %d \n", 
+                printf("thread %d index %d with value %d, expected %d \n",
                         id, id+i*cores-1, *((int*)res), data[id+i*cores-1]);validate++;
             }
         }
@@ -59,7 +61,7 @@ static void *do_test(void* _param){
 static void *do_test2(void* _param){
     int * param = (int*)_param;
     int id = param[0]; /* thread id */
- 
+
     data[id] += 1;
     parsec_future_set(fut_array[id], &data[id]);
     /* Decrement count from a thread */
@@ -93,7 +95,7 @@ int main(int argc, char* argv[])
     char *m;
     pthread_t * threads;
 
-    /* Read in the parameters */ 
+    /* Read in the parameters */
     while( (ch = getopt(argc, argv, "c:n:h")) != -1 ) {
         switch(ch) {
             case 'c':
@@ -114,7 +116,7 @@ int main(int argc, char* argv[])
                 break;
         }
     }
-    
+
     c_fut = PARSEC_OBJ_NEW(parsec_countable_future_t);
     parsec_future_init(c_fut, NULL, cores);
     printf("running with %d cores and %d copies\n", cores, ncopy);
@@ -123,7 +125,7 @@ int main(int argc, char* argv[])
     fut_array = malloc(cores*ncopy*sizeof(parsec_base_future_t*));
     data = malloc(cores*ncopy*sizeof(int));
     int *ids = malloc(cores*sizeof(int));
-    
+
     /* Test base future get  functionality */
     for(i=0; i< cores*ncopy; i++){
         data[i] = i;
@@ -134,7 +136,7 @@ int main(int argc, char* argv[])
         ids[i] = i;
         pthread_create(&threads[i], NULL, do_test, &ids[i]);
     }
- 
+
     for(i=0; i< cores; i++){
         flag += pthread_join(threads[i], &retval);
     }
@@ -144,7 +146,7 @@ int main(int argc, char* argv[])
     for(i=0; i < cores*ncopy; i++){
         PARSEC_OBJ_RELEASE(fut_array[i]);
     }
-    
+
     /* Test base future callback functionality */
     for(i=0; i< cores; i++){
         data[i] = i;
@@ -152,7 +154,7 @@ int main(int argc, char* argv[])
         /* Initialize the callback function */
         parsec_future_init(fut_array[i], test_cb);
     }
-    
+
     for(i=0; i< cores; i++){
         ids[i] = i;
         pthread_create(&threads[i], NULL, do_test2, &ids[i]);
@@ -166,7 +168,7 @@ int main(int argc, char* argv[])
     for(i=0; i < cores; i++){
         PARSEC_OBJ_RELEASE(fut_array[i]);
     }
-    
+
     free(threads);
     if(parsec_future_is_ready(c_fut)){
         printf("countable future successfully triggered\n");


### PR DESCRIPTION
Our initial impementation used an old trick (functions prototypes without parameters), with the parameters correctly instantiated by the caller. Unfortunately, this is not supported by newer versions of the Cstandard, and compilers are becoming more and more picky. We have to move away from it.

Thus, we now use variadic functions for parsec futures. A quite invasive PR, but without any logical impact.