### PR TITLE
HOTFIX: make the default number of devices be all the devices seen by…

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_component.c
+++ b/parsec/mca/device/cuda/device_cuda_component.c
@@ -239,11 +239,11 @@ static int device_cuda_component_open(void)
     }
 
     if( ndevices > parsec_device_cuda_enabled ) {
-        if( 0 < parsec_device_cuda_enabled_index ) {
+        if( 0 < parsec_device_cuda_enabled ) {
             ndevices = parsec_device_cuda_enabled;
         }
     } else if (ndevices < parsec_device_cuda_enabled ) {
-        if( 0 < parsec_device_cuda_enabled_index ) {
+        if( 0 < parsec_device_cuda_enabled ) {
             if( 0 == ndevices ) {
                 parsec_warning("User requested %d CUDA devices, but none are available on %s."
                                " CUDA support will be therefore disabled.",

--- a/parsec/mca/device/level_zero/device_level_zero_component.c
+++ b/parsec/mca/device/level_zero/device_level_zero_component.c
@@ -343,11 +343,11 @@ static int device_level_zero_component_open(void)
 
 
     if( ndevices > parsec_device_level_zero_enabled ) {
-        if( 0 < parsec_device_level_zero_index ) {
+        if( 0 < parsec_device_level_zero_enabled ) {
             ndevices = parsec_device_level_zero_enabled;
         }
     } else if (ndevices < parsec_device_level_zero_enabled ) {
-        if( 0 < parsec_device_level_zero_index ) {
+        if( 0 < parsec_device_level_zero_enabled ) {
             parsec_warning("User requested %d LEVEL_ZERO devices, but only %d are available on %s\n."
                            " PaRSEC will enable all %d of them.",
                            parsec_device_level_zero_enabled, ndevices, parsec_hostname, ndevices);


### PR DESCRIPTION
… cudaGetDeviceCount/hipGetDeviceCount/zeDeviceGet

Current code is testing if parsec_device_cuda_enabled_index < 0 (or similar counter for LZ), but parsec_device_cuda_enabled_index is the value returned by parsec_mca_param_reg_int_name() which is always positive, as it returns where that parameter is located in the parameter array.

The code wanted to check if testing if parsec_device_cuda_enabled < 0, so that if the user passes -1 or if the user omits to define the MCA parameter (default value is -1), then parsec takes the number of devices discovered by CUDA/HIP/LZ, as is claimed in the documentation of the MCA parameter.