### PR TITLE
GPU: lazy memory allocation

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -530,12 +530,10 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
     gpu_device->memory_free      = parsec_cuda_memory_free;
     gpu_device->find_incarnation = parsec_cuda_find_incarnation;
 
-    if( PARSEC_SUCCESS != parsec_device_memory_reserve(gpu_device,
-                                                           parsec_cuda_memory_percentage,
-                                                           parsec_cuda_memory_number_of_blocks,
-                                                           parsec_cuda_memory_block_size) ) {
-        goto release_device;
-    }
+    /* Device memory initialization is delayed until first device use */
+    gpu_device->memory_percentage = parsec_cuda_memory_percentage;
+    gpu_device->number_blocks     = parsec_cuda_memory_number_of_blocks;
+    gpu_device->eltsize           = parsec_cuda_memory_block_size;
 
     if( show_caps ) {
         parsec_inform("GPU Device %-8s: %s [capability %d.%d] %s\n"

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -231,6 +231,11 @@ struct parsec_device_gpu_module_s {
                                                    *   is increased every time a new data is made available, so
                                                    *   that we know which tasks can be evaluated for submission.
                                                    */
+
+    int                         memory_percentage; /**< What % of the memory available on the device we want to use*/
+    int                         number_blocks;     /**< In case memory_percentage is not set, how many blocks we want to allocate on the device */
+    size_t                      eltsize;           /**< And what size in byte are these blocks */ 
+
     parsec_list_t              gpu_mem_lru;   /* Read-only blocks, and fresh blocks */
     parsec_list_t              gpu_mem_owned_lru;  /* Dirty blocks */
     parsec_fifo_t              pending;
@@ -334,10 +339,7 @@ typedef struct {
 
 #endif  /* defined(PROFILING) */
 
-int parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device,
-                                      int           memory_percentage,
-                                      int           number_blocks,
-                                      size_t        eltsize );
+int parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device );
 int parsec_device_attach( parsec_device_module_t* device, parsec_context_t* context );
 int parsec_device_detach( parsec_device_module_t* device, parsec_context_t* context );
 int parsec_device_taskpool_register(parsec_device_module_t* device, parsec_taskpool_t* tp);

--- a/parsec/mca/device/level_zero/device_level_zero_module.c
+++ b/parsec/mca/device/level_zero/device_level_zero_module.c
@@ -425,12 +425,10 @@ int parsec_level_zero_module_init( int dev_id, parsec_device_level_zero_driver_t
     gpu_device->memory_free      = parsec_level_zero_memory_free;
     gpu_device->find_incarnation = parsec_level_zero_find_incarnation;
 
-    if( PARSEC_SUCCESS != parsec_device_memory_reserve(gpu_device,
-                                                           parsec_level_zero_memory_percentage,
-                                                           parsec_level_zero_memory_number_of_blocks,
-                                                           parsec_level_zero_memory_block_size) ) {
-        goto release_device;
-    }
+    /* Device memory initialization is delayed until first device use */
+    gpu_device->memory_percentage = parsec_level_zero_memory_percentage;
+    gpu_device->number_blocks     = parsec_level_zero_memory_number_of_blocks;
+    gpu_device->eltsize           = parsec_level_zero_memory_block_size;
 
     if( show_caps ) {
         parsec_inform("LEVEL ZERO GPU Device %d: %s\n"

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -186,8 +186,11 @@ int __parsec_execute( parsec_execution_stream_t* es,
                 task->status = PARSEC_TASK_STATUS_COMPLETE;
                 if(PARSEC_DEV_RECURSIVE >= tc->incarnations[chore_id].type) {
                     /* accelerators count their own executed tasks */
+#if 0
+                    /* This is wrong: chore_id is the index in incarnations, but it's not the device id */
                     parsec_device_module_t *dev = parsec_mca_device_get(chore_id);
                     parsec_atomic_fetch_inc_int64((int64_t*)&dev->executed_tasks);
+#endif
                 }
             }
             /* Record EXEC_END event only for incarnation that succeeds */


### PR DESCRIPTION
PR #613 made all CI tests initialize the GPU if there is a GPU available. When running in oversubscribe mode, this can lead to falsely failing tests, that fail not because of a software issue, but because of a deployment issue (multiple processes trying to allocate 90% of the GPU memory at the same time).

In general, since we don't know if the GPU will be used or not, we should not preemptively allocate all the memory on it. This PR makes memory allocation lazy: it is delayed until we do try to use some GPU memory.

The drawback is that the first GPU task will also pay the cost of a large cuda_malloc / zmalloc etc...