### PR TITLE
bugfix: in dtd sometimes the cpu incarnation and gpu incarnations are

### DIFF
--- a/parsec/class/info.c
+++ b/parsec/class/info.c
@@ -302,6 +302,7 @@ void *parsec_info_get(parsec_info_object_array_t *oa, parsec_info_id_t iid)
     void *ret, *nio;
     parsec_info_entry_t *ie;
 
+    if(iid < 0) return NULL;
     parsec_ioa_resize_and_rdlock(oa, iid);
     ret = oa->info_objects[iid];
     parsec_atomic_rwlock_rdunlock(&oa->rw_lock);

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -168,16 +168,15 @@ int __parsec_execute( parsec_execution_stream_t* es,
             }
         }
 
-        parsec_hook_t *hook = tc->incarnations[chore_id].hook;
-        if( NULL == hook ) goto next_chore;
 #if defined(PARSEC_DEBUG)
         parsec_debug_verbose(5, parsec_debug_output, "Thread %d of VP %d Execute %s[%d] chore %d",
                              es->th_id, es->virtual_process->vp_id,
                              tmp, tc->incarnations[chore_id].type,
                              chore_id);
 #endif
+        parsec_hook_t *hook = tc->incarnations[chore_id].hook;
+        assert( NULL != hook );
         rc = hook( es, task );
-
 #if defined(PARSEC_PROF_TRACE)
         task->prof_info.task_return_code = rc;
 #endif

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -168,15 +168,16 @@ int __parsec_execute( parsec_execution_stream_t* es,
             }
         }
 
+        parsec_hook_t *hook = tc->incarnations[chore_id].hook;
+        if( NULL == hook ) goto next_chore;
 #if defined(PARSEC_DEBUG)
         parsec_debug_verbose(5, parsec_debug_output, "Thread %d of VP %d Execute %s[%d] chore %d",
                              es->th_id, es->virtual_process->vp_id,
                              tmp, tc->incarnations[chore_id].type,
                              chore_id);
 #endif
-        parsec_hook_t *hook = tc->incarnations[chore_id].hook;
-
         rc = hook( es, task );
+
 #if defined(PARSEC_PROF_TRACE)
         task->prof_info.task_return_code = rc;
 #endif
@@ -185,8 +186,9 @@ int __parsec_execute( parsec_execution_stream_t* es,
                 /* Let's assume everything goes just fine */
                 task->status = PARSEC_TASK_STATUS_COMPLETE;
                 if(PARSEC_DEV_RECURSIVE >= tc->incarnations[chore_id].type) {
-                    /* accelerators count their own executed tasks */
-                    parsec_device_module_t *dev = parsec_mca_device_get(chore_id);
+                    /* accelerators count their own executed tasks so this is a
+                     * type DEV_RECURSIVE or DEV_CPU, they must be dev 0 and 1 */
+                    parsec_device_module_t *dev = parsec_mca_device_get(tc->incarnations[chore_id].type - PARSEC_DEV_CPU);
                     parsec_atomic_fetch_inc_int64((int64_t*)&dev->executed_tasks);
                 }
             }
@@ -526,7 +528,10 @@ int __parsec_task_progress( parsec_execution_stream_t* es,
         case PARSEC_HOOK_RETURN_NEXT:    /* Try next variant [if any] */
         case PARSEC_HOOK_RETURN_DISABLE: /* Disable the device, something went wrong */
         case PARSEC_HOOK_RETURN_ERROR:   /* Some other major error happened */
-            assert( 0 ); /* Internal error: invalid return value */
+            parsec_fatal("Executing task of class %s failed with parsec_hook_return_t error %d", task->task_class->name, rc);
+            /* we should not call fatal here, but the caller code
+             * is not ready to handle error cases yet */
+            return rc;
         }
         break;
     }


### PR DESCRIPTION
not in order and that caused all sort of havoc. Also we should not try to obtain an invalid iid when querying per-stream-infos (again from dtd when gpus are disabled by hand)