### PR TITLE
Fix CUDA protection macro use

### DIFF
--- a/parsec/mca/device/cuda/device_cuda.h
+++ b/parsec/mca/device/cuda/device_cuda.h
@@ -69,7 +69,7 @@ typedef parsec_data_copy_t parsec_gpu_data_copy_t;
     do {                                                                \
         cudaError_t __cuda_error = (cudaError_t) (ERROR);               \
         if( cudaSuccess != __cuda_error ) {                             \
-            parsec_warning( "%s:%d %s%s", __FILE__, __LINE__,           \
+            parsec_warning( "%s:%d %s %s", __FILE__, __LINE__,          \
                             (STR), cudaGetErrorString(__cuda_error) );  \
             CODE;                                                       \
         }                                                               \

--- a/parsec/mca/device/cuda/device_cuda_component.c
+++ b/parsec/mca/device/cuda/device_cuda_component.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -132,7 +133,7 @@ static int device_cuda_component_query(mca_base_module_t **module, int *priority
             continue; /* The user disabled NVLINK for that GPU */
 
         cudastatus = cudaSetDevice( source_gpu->cuda_index );
-        PARSEC_CUDA_CHECK_ERROR( "(parsec_device_cuda_component_query) cudaSetDevice ", cudastatus,
+        PARSEC_CUDA_CHECK_ERROR( "(parsec_device_cuda_component_query) cudaSetDevice", cudastatus,
                                  {continue;} );
 
         for( j = 0; NULL != (target_gpu = (parsec_device_cuda_module_t*)parsec_device_cuda_component.modules[j]); j++ ) {
@@ -140,11 +141,11 @@ static int device_cuda_component_query(mca_base_module_t **module, int *priority
 
             /* Communication mask */
             cudastatus = cudaDeviceCanAccessPeer( &canAccessPeer, source_gpu->cuda_index, target_gpu->cuda_index );
-            PARSEC_CUDA_CHECK_ERROR( "(parsec_device_cuda_component_query) cudaDeviceCanAccessPeer ", cudastatus,
+            PARSEC_CUDA_CHECK_ERROR( "(parsec_device_cuda_component_query) cudaDeviceCanAccessPeer", cudastatus,
                                      {continue;} );
             if( 1 == canAccessPeer ) {
                 cudastatus = cudaDeviceEnablePeerAccess( target_gpu->cuda_index, 0 );
-                PARSEC_CUDA_CHECK_ERROR( "(parsec_device_cuda_component_query) cuCtxEnablePeerAccess ", cudastatus,
+                PARSEC_CUDA_CHECK_ERROR( "(parsec_device_cuda_component_query) cuCtxEnablePeerAccess", cudastatus,
                                          {continue;} );
                 source_gpu->super.peer_access_mask = (int16_t)(source_gpu->super.peer_access_mask | (int16_t)(1 <<
                         target_gpu->super.super.device_index));
@@ -231,7 +232,7 @@ static int device_cuda_component_open(void)
          */
     }
     else {
-        PARSEC_CUDA_CHECK_ERROR( "cudaGetDeviceCount ", cudastatus,
+        PARSEC_CUDA_CHECK_ERROR( "cudaGetDeviceCount", cudastatus,
                              {
                                 parsec_mca_param_set_int(parsec_device_cuda_enabled_index, 0);
                                 return MCA_ERROR;

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -160,7 +161,7 @@ parsec_cuda_memory_register(parsec_device_module_t* device, parsec_data_collecti
      * all devices.
      */
     status = cudaHostRegister(ptr, length, cudaHostRegisterPortable );
-    PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_memory_register) cudaHostRegister ", status,
+    PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_memory_register) cudaHostRegister", status,
                             { goto restore_and_return; } );
 
     rc = PARSEC_SUCCESS;
@@ -187,7 +188,7 @@ static int parsec_cuda_memory_unregister(parsec_device_module_t* device, parsec_
      * as another thread might be submitting tasks at the same time (cuda_scheduling.h)
      */
     status = cudaHostUnregister(ptr);
-    PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_memory_unregister) cudaHostUnregister ", status,
+    PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_memory_unregister) cudaHostUnregister", status,
                             {continue;} );
 
     rc = PARSEC_SUCCESS;
@@ -271,7 +272,7 @@ static int parsec_cuda_set_device(parsec_device_gpu_module_t *gpu)
     parsec_device_cuda_module_t *cuda_device = (parsec_device_cuda_module_t *)gpu;
 
     cudaStatus = cudaSetDevice(cuda_device->cuda_index);
-    PARSEC_CUDA_CHECK_ERROR( "cudaSetDevice ", cudaStatus, {return PARSEC_ERROR;} );
+    PARSEC_CUDA_CHECK_ERROR( "cudaSetDevice", cudaStatus, {return PARSEC_ERROR;} );
     return PARSEC_SUCCESS;
 }
 
@@ -295,11 +296,11 @@ static int parsec_cuda_memcpy_async(struct parsec_device_gpu_module_s *gpu, stru
         kind = cudaMemcpyHostToDevice;
         break;
     default:
-        PARSEC_CUDA_CHECK_ERROR( "Translate parsec_device_transfer_direction_t to cudaMemcpyKind ", cudaErrorInvalidValue, {return PARSEC_ERROR;} );
+        PARSEC_CUDA_CHECK_ERROR( "Translate parsec_device_transfer_direction_t to cudaMemcpyKind", cudaErrorInvalidValue, {return PARSEC_ERROR;} );
     }
 
     cudaStatus =  cudaMemcpyAsync( dest, source, bytes, kind, cuda_stream->cuda_stream );
-    PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync ", cudaStatus, {return PARSEC_ERROR;} );
+    PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync", cudaStatus, {return PARSEC_ERROR;} );
     return PARSEC_SUCCESS;
 }
 
@@ -310,7 +311,7 @@ static int parsec_cuda_event_record(struct parsec_device_gpu_module_s *gpu, stru
     (void)gpu;
 
     cudaStatus = cudaEventRecord(cuda_stream->events[event_idx], cuda_stream->cuda_stream);
-    PARSEC_CUDA_CHECK_ERROR( "cudaEventRecord ", cudaStatus, {return PARSEC_ERROR;} );
+    PARSEC_CUDA_CHECK_ERROR( "cudaEventRecord", cudaStatus, {return PARSEC_ERROR;} );
     return PARSEC_SUCCESS;
 }
 
@@ -327,7 +328,7 @@ static int parsec_cuda_event_query(struct parsec_device_gpu_module_s *gpu, struc
     if(cudaErrorNotReady == cudaStatus) {
         return 0;
     }
-    PARSEC_CUDA_CHECK_ERROR( "cudaEventQuery ", cudaStatus, {return PARSEC_ERROR;} );
+    PARSEC_CUDA_CHECK_ERROR( "cudaEventQuery", cudaStatus, {return PARSEC_ERROR;} );
     return PARSEC_ERROR; /* should be unreachable */
 }
 
@@ -379,9 +380,9 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
 
     *module = NULL;
     cudastatus = cudaSetDevice( dev_id );
-    PARSEC_CUDA_CHECK_ERROR( "cudaSetDevice ", cudastatus, {return PARSEC_ERROR;} );
+    PARSEC_CUDA_CHECK_ERROR( "cudaSetDevice", cudastatus, {return PARSEC_ERROR;} );
     cudastatus = cudaGetDeviceProperties( &prop, dev_id );
-    PARSEC_CUDA_CHECK_ERROR( "cudaGetDeviceProperties ", cudastatus, {return PARSEC_ERROR;} );
+    PARSEC_CUDA_CHECK_ERROR( "cudaGetDeviceProperties", cudastatus, {return PARSEC_ERROR;} );
 
     szName    = prop.name;
     major     = prop.major;
@@ -425,7 +426,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
 
         /* Allocate the stream */
         cudastatus = cudaStreamCreate( &(cuda_stream->cuda_stream) );
-        PARSEC_CUDA_CHECK_ERROR( "cudaStreamCreate ", cudastatus,
+        PARSEC_CUDA_CHECK_ERROR( "cudaStreamCreate", cudastatus,
                                  {goto release_device;} );
         exec_stream->workspace    = NULL;
         PARSEC_OBJ_CONSTRUCT(&exec_stream->infos, parsec_info_object_array_t);
@@ -445,7 +446,7 @@ parsec_cuda_module_init( int dev_id, parsec_device_module_t** module )
             cuda_stream->events[k]   = NULL;
             exec_stream->tasks[k]    = NULL;
             cudastatus = cudaEventCreateWithFlags(&(cuda_stream->events[k]), cudaEventDisableTiming);
-            PARSEC_CUDA_CHECK_ERROR( "(INIT) cudaEventCreateWithFlags ", (cudaError_t)cudastatus,
+            PARSEC_CUDA_CHECK_ERROR( "(INIT) cudaEventCreateWithFlags", (cudaError_t)cudastatus,
                                      {goto release_device;} );
         }
         if(j == 0) {
@@ -611,7 +612,7 @@ parsec_cuda_module_fini(parsec_device_module_t* device)
     int j, k;
 
     status = cudaSetDevice( cuda_device->cuda_index );
-    PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_device_fini) cudaSetDevice ", status,
+    PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_device_fini) cudaSetDevice", status,
                             {continue;} );
 
     /* Release the registered memory */
@@ -632,7 +633,7 @@ parsec_cuda_module_fini(parsec_device_module_t* device)
         for( k = 0; k < exec_stream->max_events; k++ ) {
             assert( NULL == exec_stream->tasks[k] );
             status = cudaEventDestroy(cuda_stream->events[k]);
-            PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_device_fini) cudaEventDestroy ", status,
+            PARSEC_CUDA_CHECK_ERROR( "(parsec_cuda_device_fini) cudaEventDestroy", status,
                                     {continue;} );
         }
         exec_stream->max_events = 0;

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -700,7 +700,7 @@ parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device,
             mem_elem_per_gpu = total_size / eltsize;
         }
         rc = gpu_device->memory_allocate(gpu_device, total_size, &base_ptr);
-        if(PARSEC_SUCCESS != rc) { 
+        if(PARSEC_SUCCESS != rc) {
             parsec_warning("GPU[%s] Allocating %zu bytes of memory on the GPU device failed",
                            gpu_device->super.name, total_size);
             gpu_device->memory = NULL;

--- a/tests/dsl/dtd/dtd_test_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_test_simple_gemm.c
@@ -209,7 +209,7 @@ int gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
                 this_task->taskpool->context->my_rank,
                 gpu_stream->name, delta);
 
-    PARSEC_CUDA_CHECK_ERROR("cublasDgemm_v2 ", status,
+    PARSEC_CUDA_CHECK_ERROR("cublasDgemm_v2", status,
                             { return PARSEC_HOOK_RETURN_ERROR; });
 
     return PARSEC_HOOK_RETURN_DONE;
@@ -401,11 +401,11 @@ static void *allocate_one_on_device(void *obj, void *p)
      cudaError_t cr;
 
      cr = cudaMallocManaged(&one_device, sizeof(double), cudaMemAttachGlobal);
-     PARSEC_CUDA_CHECK_ERROR("cudaMalloc ", cr,
+     PARSEC_CUDA_CHECK_ERROR("cudaMalloc", cr,
                             { return NULL; });
 
      cr = cudaMemcpy(one_device, &one_host, sizeof(double), cudaMemcpyHostToDevice);
-     PARSEC_CUDA_CHECK_ERROR("cudaMemcpy ", cr,
+     PARSEC_CUDA_CHECK_ERROR("cudaMemcpy", cr,
                             { return NULL; });
 
      return one_device;

--- a/tests/runtime/cuda/nvlink.jdf
+++ b/tests/runtime/cuda/nvlink.jdf
@@ -3,6 +3,7 @@ extern "C" %{
  * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -147,7 +148,7 @@ BODY [type=CUDA
                                   &alpha, (double*)A, descA->super.mb,
                                   (double*)A, descA->super.mb,
                                   &beta, (double*)C, descA->super.mb );
-    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm_v2 ", status,
+    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm_v2", status,
                             {return -1;} );
 }
 END
@@ -191,7 +192,7 @@ BODY [type=CUDA
                                   &alpha, (double*)A, descA->super.mb,
                                   (double*)A, descA->super.mb,
                                   &beta, (double*)C, descA->super.mb );
-    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm_v2 ", status,
+    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm_v2", status,
                             {return -1;} );
 }
 END

--- a/tests/runtime/cuda/nvlink_wrapper.c
+++ b/tests/runtime/cuda/nvlink_wrapper.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec.h"
@@ -76,9 +77,9 @@ __parsec_nvlink_destructor( parsec_nvlink_taskpool_t* nvlink_taskpool)
             parsec_data_t *dta = ((parsec_dc_t*)userM)->data_of((parsec_dc_t*)userM, g, userM->super.super.myrank);
             parsec_data_copy_t *gpu_copy = parsec_data_get_copy(dta, cuda_device->super.super.device_index);
             cudaError_t status = cudaSetDevice( cuda_device->cuda_index );
-            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaSetDevice ", status, {} );
+            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaSetDevice", status, {} );
             status = (cudaError_t)cudaFree( gpu_copy->device_private );
-            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaFree ", status, {} );
+            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaFree", status, {} );
             gpu_copy->device_private = NULL;
             parsec_data_copy_detach(dta, gpu_copy, cuda_device->super.super.device_index);
             PARSEC_OBJ_RELEASE(gpu_copy);
@@ -86,7 +87,7 @@ __parsec_nvlink_destructor( parsec_nvlink_taskpool_t* nvlink_taskpool)
         }
     }
     parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)nvlink_taskpool->_g_userM );
-    
+
     free(dcA);
     free(userM);
 }
@@ -189,10 +190,10 @@ parsec_taskpool_t* testing_nvlink_New( parsec_context_t *ctx, int depth, int mb 
             parsec_data_copy_t *gpu_copy = PARSEC_OBJ_NEW(parsec_data_copy_t);
             /* We chose the GPU */
             cudaError_t status = cudaSetDevice( cuda_device->cuda_index );
-            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaSetDevice ", status, {return NULL;} );
+            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaSetDevice", status, {return NULL;} );
             /* Allocate memory on it, for one tile */
             status = (cudaError_t)cudaMalloc( &gpu_copy->device_private, mb*mb*parsec_datadist_getsizeoftype(PARSEC_MATRIX_DOUBLE) );
-            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaMalloc ", status, {return NULL;} );
+            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaMalloc", status, {return NULL;} );
             /* Attach this copy to the data, on the corresponding device */
             parsec_data_copy_attach(dta, gpu_copy, cuda_device->super.super.device_index);
             /* We also need to tell PaRSEC that the owner of this data is the GPU, or the
@@ -203,7 +204,7 @@ parsec_taskpool_t* testing_nvlink_New( parsec_context_t *ctx, int depth, int mb 
                                               cpu_copy->device_private,
                                               dta->nb_elts,
                                               cudaMemcpyHostToDevice );
-            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaMemcpy ", status, {return NULL;} );
+            PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaMemcpy", status, {return NULL;} );
             g++;
         }
     }

--- a/tests/runtime/cuda/stage_custom.jdf
+++ b/tests/runtime/cuda/stage_custom.jdf
@@ -3,6 +3,7 @@ extern "C" %{
  * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -57,14 +58,14 @@ stage_stride_in(parsec_gpu_task_t *gtask,
                                                        width, height,
                                                        cudaMemcpyHostToDevice,
                                                        cuda_stream->cuda_stream );
-                PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync ", ret, { return PARSEC_ERROR; } );
+                PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync", ret, { return PARSEC_ERROR; } );
             }else{
                 ret = (cudaError_t)cudaMemcpyAsync( copy_out->device_private,
                                                     copy_in->device_private,
                                                     copy_in->original->nb_elts,
                                                     cudaMemcpyDeviceToDevice,
                                                     cuda_stream->cuda_stream );
-                PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync ", ret, { return PARSEC_ERROR; } );
+                PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync", ret, { return PARSEC_ERROR; } );
             }
 
         }
@@ -102,7 +103,7 @@ stage_stride_out(parsec_gpu_task_t *gtask,
                                                    width, height,
                                                    cudaMemcpyDeviceToHost,
                                                    cuda_stream->cuda_stream );
-           PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync ", ret, { return PARSEC_ERROR; } );
+           PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync", ret, { return PARSEC_ERROR; } );
         }
     }
     return PARSEC_SUCCESS;
@@ -160,7 +161,7 @@ BODY [type=CUDA
                                  (double*)A, ldam,
                          lbeta,  (double*)A, ldam );
     status = cublasGetError();
-    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm ", status,
+    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm", status,
                             {return -1;} );
 }
 END
@@ -201,7 +202,7 @@ BODY [type=CUDA
                                  (double*)B, ldbm,
                          lbeta,  (double*)B, ldbm );
     status = cublasGetError();
-    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm ", status,
+    PARSEC_CUDA_CHECK_ERROR( "cublasDgemm", status,
                             {return -1;} );
 
 }

--- a/tests/runtime/cuda/stress.jdf
+++ b/tests/runtime/cuda/stress.jdf
@@ -3,6 +3,7 @@ extern "C" %{
  * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -140,7 +141,7 @@ BODY [type=CUDA
                          (double*)B, descA->super.mb,
                          1.0, (double*)C, descA->super.mb );
     status = cublasGetError();
-    PARSEC_CUDA_CHECK_ERROR( "cublasZgemm ", status,
+    PARSEC_CUDA_CHECK_ERROR( "cublasZgemm", status,
                             {return -1;} );
 }
 END


### PR DESCRIPTION
Be nice and print a space between strings allowing better readability of the error message.