### PR TITLE
Alternative solution to the CI problem with GPUs

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -94,12 +94,6 @@ jobs:
       # run: ctest -C $BUILD_TYPE
       run: |
         source ${{github.workspace}}/.github/CI/spack_setup.sh
-        # enable devices only in tests that explicitely require them
-        PARSEC_MCA_device_cuda_enabled=0
-        PARSEC_MCA_device_hip_enabled=0
-        # restrict memory use for oversubscribed runners
-        PARSEC_MCA_device_cuda_memory_use=10
-        PARSEC_MCA_device_hip_memory_use=10
         ctest --output-on-failure
 
     - name: Save Artifact

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,10 @@ function(parsec_addtest_cmd target)
   endif()
   add_test(${ARGV})
   set_tests_properties(${target} PROPERTIES DEPENDS parsec_build_tests_test)
+  # Disable GPU accelerators by default for all tests
+  set_property(TEST ${target} PROPERTY ENVIRONMENT "PARSEC_MCA_device_cuda_enabled=0")
+  set_property(TEST ${target} PROPERTY ENVIRONMENT "PARSEC_MCA_device_hip_enabled=0")
+  set_property(TEST ${target} PROPERTY ENVIRONMENT "PARSEC_MCA_device_level_zero_enabled=0")
 endfunction(parsec_addtest_cmd)
 
 check_function_exists(erand48 PARSEC_HAVE_ERAND48)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,10 +66,10 @@ function(parsec_addtest_cmd target)
   endif()
   add_test(${ARGV})
   set_tests_properties(${target} PROPERTIES DEPENDS parsec_build_tests_test)
-  # Disable GPU accelerators by default for all tests
-  set_property(TEST ${target} PROPERTY ENVIRONMENT "PARSEC_MCA_device_cuda_enabled=0")
-  set_property(TEST ${target} PROPERTY ENVIRONMENT "PARSEC_MCA_device_hip_enabled=0")
-  set_property(TEST ${target} PROPERTY ENVIRONMENT "PARSEC_MCA_device_level_zero_enabled=0")
+  # enable devices only in tests that explicitely require them
+  # restrict memory use for oversubscribed runners
+  set_tests_properties(${target} PROPERTIES ENVIRONMENT
+    "PARSEC_MCA_device_cuda_enabled=0;PARSEC_MCA_device_hip_enabled=0;PARSEC_MCA_device_level_zero_enabled=0;PARSEC_MCA_device_cuda_memory_use=10;PARSEC_MCA_device_hip_memory_use=10;PARSEC_MCA_device_level_zero_memory_use=10")
 endfunction(parsec_addtest_cmd)
 
 check_function_exists(erand48 PARSEC_HAVE_ERAND48)

--- a/tests/api/init_fini.c
+++ b/tests/api/init_fini.c
@@ -3,7 +3,9 @@
 
 int main(int argc, char *argv[])
 {
-    MPI_Init(NULL, NULL);
+    int mpith = MPI_THREAD_SINGLE;
+    MPI_Init_thread(NULL, NULL, MPI_THREAD_SERIALIZED, &mpith);
+    assert(mpith >= MPI_THREAD_SERIALIZED); // parsec will do the complaining in NDEBUG
     parsec_context_t *parsec = parsec_init(-1, &argc, &argv);
     parsec_fini(&parsec);
     MPI_Finalize();

--- a/tests/api/touch_exf.F90
+++ b/tests/api/touch_exf.F90
@@ -2,6 +2,7 @@ PROGRAM TOUCH_EXF
 
   use, INTRINSIC :: ISO_C_BINDING, only : c_int
   use parsec_f08_interfaces
+  use mpi
 
 interface
   function touch_initialize_f08(block, n) BIND(C, name="touch_initialize")
@@ -19,13 +20,13 @@ interface
   end function touch_finalize_f08
 end interface
 
-  integer BLOCK, N, ret
+  integer BLOCK, N, mpith, ret
   parameter (BLOCK=10, N=100)
 
   type(parsec_context_t) :: context
   type(parsec_taskpool_t)  :: tp
 
-  call MPI_INIT(ret)
+  call MPI_Init_thread(MPI_THREAD_MULTIPLE, mpith, ret)
 
   call parsec_init(1, context)
 
@@ -43,7 +44,7 @@ end interface
 
   ret = touch_finalize_f08()
 
-  call MPI_FINALIZE(ret)
+  call MPI_Finalize(ret)
 
   call exit(ret)
 END


### PR DESCRIPTION
Testing shows that the CI has issues forwarding the environment variables to ctest.

Moreover, if one tests directly by calling 'ctest' on our own machine, the CI-level environment variables does not fix the problem.

In this PR, we set the `PARSEC_MCA_cuda_device_enabled` environment variable to 0 directly from CMake in `parsec_addtest_cmd`. 

   - This does the same thing as the change in the CI files was trying to do
   - specific tests can still overwrite this by either
         - setting the environment variable to 1 after adding the test with `parsec_addtest_cmd`
         - passing the MCA parameter to the command line
         - setting the number of GPUs on the command line (e.g. in dplasma)
  
This PR should replace PR#615 and close Issue #630 
