### PR TITLE
ci: all tests must use parsec_addtest

### DIFF
--- a/tests/apps/merge_sort/Testings.cmake
+++ b/tests/apps/merge_sort/Testings.cmake
@@ -1,5 +1,5 @@
-add_test(apps/merge_sort ${SHM_TEST_CMD_LIST} apps/merge_sort/merge_sort)
+parsec_addtest_cmd(apps/merge_sort ${SHM_TEST_CMD_LIST} apps/merge_sort/merge_sort)
 if( MPI_C_FOUND )
-  add_test(apps/merge_sort:mp ${MPI_TEST_CMD_LIST} 4 apps/merge_sort/merge_sort)
+  parsec_addtest_cmd(apps/merge_sort:mp ${MPI_TEST_CMD_LIST} 4 apps/merge_sort/merge_sort)
 endif( MPI_C_FOUND)
 


### PR DESCRIPTION
otherwise they don't obey gpu memory restrictions.