### PR TITLE
bugfix: dtd taskpool destructor should work symetric to contructor

### DIFF
--- a/tests/dsl/dtd/CMakeLists.txt
+++ b/tests/dsl/dtd/CMakeLists.txt
@@ -1,5 +1,6 @@
 link_libraries(tests_common)
 
+parsec_addtest_executable(C dtd_test_empty SOURCES dtd_test_empty.c)
 parsec_addtest_executable(C dtd_test_pingpong SOURCES dtd_test_pingpong.c)
 parsec_addtest_executable(C dtd_test_task_generation SOURCES dtd_test_task_generation.c)
 parsec_addtest_executable(C dtd_test_war SOURCES dtd_test_war.c)

--- a/tests/dsl/dtd/Testings.cmake
+++ b/tests/dsl/dtd/Testings.cmake
@@ -2,6 +2,7 @@
 #
 # Shared Memory Testings
 #
+parsec_addtest_cmd(dsl/dtd/empty ${SHM_TEST_CMD_LIST} dsl/dtd/dtd_test_empty)
 parsec_addtest_cmd(dsl/dtd/task_generation ${SHM_TEST_CMD_LIST} dsl/dtd/dtd_test_task_generation)
 parsec_addtest_cmd(dsl/dtd/task_inserting_task ${SHM_TEST_CMD_LIST} dsl/dtd/dtd_test_task_inserting_task)
 parsec_addtest_cmd(dsl/dtd/task_insertion ${SHM_TEST_CMD_LIST} dsl/dtd/dtd_test_task_insertion)
@@ -15,6 +16,7 @@ endif(PARSEC_HAVE_CUDA AND CMAKE_CUDA_COMPILER)
 # Distributed Memory Testings
 #
 if( MPI_C_FOUND )
+  parsec_addtest_cmd(dsl/dtd/empty:mp ${MPI_TEST_CMD_LIST} 2 dsl/dtd/dtd_test_empty)
   parsec_addtest_cmd(dsl/dtd/pingpong:mp ${MPI_TEST_CMD_LIST} 2 dsl/dtd/dtd_test_pingpong)
   parsec_addtest_cmd(dsl/dtd/task_inserting_task:mp ${MPI_TEST_CMD_LIST} 4 dsl/dtd/dtd_test_task_inserting_task)
   parsec_addtest_cmd(dsl/dtd/task_insertion:mp ${MPI_TEST_CMD_LIST} 4 dsl/dtd/dtd_test_task_insertion)

--- a/tests/dsl/dtd/dtd_test_empty.c
+++ b/tests/dsl/dtd/dtd_test_empty.c
@@ -1,0 +1,26 @@
+#include "parsec.h"
+#include <mpi.h>
+
+int main(int argc, char **argv)
+{
+    parsec_context_t* parsec;
+    int rank = 0, world = 1;
+
+#if defined(PARSEC_HAVE_MPI)
+    int provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
+    MPI_Comm_size(MPI_COMM_WORLD, &world);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#endif
+
+    parsec = parsec_init( -1, &argc, &argv );
+    parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
+    parsec_taskpool_free( dtd_tp );
+    parsec_fini(&parsec);
+
+#ifdef PARSEC_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
bugfix: dtd taskpool destructor should work symetric to contructor and invocation of the startup_hook

fixes #568 