### PR TITLE
fixes memory leaks

### DIFF
--- a/parsec/class/parsec_hash_table.c
+++ b/parsec/class/parsec_hash_table.c
@@ -255,7 +255,7 @@ void parsec_hash_table_unlock_bucket_handle_impl(parsec_hash_table_t *ht,
              * Good enough hint that it's our role to do so */
             parsec_hash_table_resize(ht);
         }
-        /* Otherwise, let's asssume somebody resized already */
+        /* Otherwise, let's assume somebody resized already */
         parsec_atomic_rwlock_wrunlock(&ht->rw_lock);
     }
 }

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -1115,7 +1115,7 @@ parsec_dtd_find_task_class(parsec_dtd_taskpool_t *tp,
  * @param[in]       dc
  *                      Pointer to the dc the tile belongs to
  *
- * @ingroup         DTD_ITERFACE_INTERNAL
+ * @ingroup         DTD_INTERFACE_INTERNAL
  */
 void
 parsec_dtd_tile_insert(uint64_t key,
@@ -1141,7 +1141,7 @@ parsec_dtd_tile_insert(uint64_t key,
  * @param[in]       dc
  *                      Pointer to the dc the tile belongs to
  *
- * @ingroup         DTD_ITERFACE_INTERNAL
+ * @ingroup         DTD_INTERFACE_INTERNAL
  */
 void
 parsec_dtd_tile_remove(parsec_data_collection_t *dc, uint64_t key)
@@ -1163,7 +1163,7 @@ parsec_dtd_tile_remove(parsec_data_collection_t *dc, uint64_t key)
  * @param[in]       dc
  *                      Pointer to the dc the tile belongs to
  *
- * @ingroup         DTD_ITERFACE_INTERNAL
+ * @ingroup         DTD_INTERFACE_INTERNAL
  */
 parsec_dtd_tile_t *
 parsec_dtd_tile_find(parsec_data_collection_t *dc, uint64_t key)
@@ -1211,29 +1211,6 @@ void
 parsec_dtd_tile_retain(parsec_dtd_tile_t *tile)
 {
     PARSEC_OBJ_RETAIN(tile);
-}
-
-/* **************************************************************************** */
-/**
- * This function releases the master-structure and pushes them back in mempool
- *
- * @param[in,out]   tp
- *                      Pointer to DTD taskpool, the tile hash table
- *                      is attached to this taskpool
- * @param[in]       key
- *                      The function pointer to the body of the task class
- *
- * @ingroup         DTD_INTERFACE_INTERNAL
- */
-void
-parsec_dtd_release_task_class(parsec_dtd_taskpool_t *tp,
-                              uint64_t key)
-{
-    dtd_hash_table_pointer_item_t *item = parsec_dtd_find_task_class_internal(tp, key);
-    if (NULL == item)
-        return;
-    parsec_dtd_remove_task_class(tp, key);
-    parsec_mempool_free(tp->hash_table_bucket_mempool, item);
 }
 
 void
@@ -1300,8 +1277,7 @@ parsec_dtd_tile_of(parsec_data_collection_t *dc, parsec_data_key_t key)
         }
 
         SET_LAST_ACCESSOR(tile);
-        parsec_dtd_tile_insert(tile->key,
-                               tile, dc);
+        parsec_dtd_tile_insert(tile->key, tile, dc);
     }
     assert(tile->flushed == NOT_FLUSHED);
 #if defined(PARSEC_DEBUG_PARANOID)
@@ -1673,7 +1649,7 @@ dtd_release_dep_fct(parsec_execution_stream_t *es,
  *
  * @param   es,this_task,action_mask,ontask,ontask_arg
  *
- * @ingroup DTD_ITERFACE_INTERNAL
+ * @ingroup DTD_INTERFACE_INTERNAL
  */
 static void
 parsec_dtd_iterate_successors(parsec_execution_stream_t *es,
@@ -2434,7 +2410,11 @@ parsec_dtd_destroy_task_class(parsec_dtd_taskpool_t *dtd_tp, parsec_task_class_t
 
     /* We only register CPU hooks in the functions hash table */
     uint64_t fkey = (uint64_t)dtd_tc->cpu_func_ptr + tc->nb_flows;
-    parsec_dtd_release_task_class(dtd_tp, fkey);
+    dtd_hash_table_pointer_item_t *item = parsec_dtd_find_task_class_internal(dtd_tp, fkey);
+    if (NULL != item) {
+        parsec_dtd_remove_task_class(dtd_tp, fkey);
+        parsec_mempool_free(dtd_tp->hash_table_bucket_mempool, item);
+    }
     free((void*)tc->incarnations);
 
     /* As we fill the flows and then deps in sequential order, we can bail out at the first NULL */

--- a/parsec/interfaces/dtd/insert_function_internal.h
+++ b/parsec/interfaces/dtd/insert_function_internal.h
@@ -373,10 +373,6 @@ parsec_hook_return_t
 parsec_dtd_release_local_task( parsec_dtd_task_t *this_task );
 
 void
-parsec_dtd_release_task_class( parsec_dtd_taskpool_t  *tp,
-                               uint64_t key );
-
-void
 parsec_dtd_template_retain( const parsec_task_class_t *tc );
 
 void


### PR DESCRIPTION
I believe this fixes the following memory leaks 

```==196556== 320 bytes in 1 blocks are definitely lost in loss record 254 of 288
==196556==    at 0x4889FA4: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==196556==    by 0x49E3DEF: parsec_dtd_create_task_classv (insert_function.c:2185)
==196556==    by 0x49DF8AB: parsec_dtd_enqueue_taskpool (insert_function.c:256)
==196556==    by 0x49D062F: parsec_context_add_taskpool (scheduling.c:876)
```

and other stuff that was allocated in `parsec_dtd_create_task_classv` because i think the function originaly intended to be used to release task_classes is `parsec_dtd_task_class_release` and not `parsec_dtd_release_task_class` which given the similarity might have been confused (?)

as well as 

```==196556== 15 bytes in 1 blocks are definitely lost in loss record 69 of 288
==196556==    at 0x4885118: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==196556==    by 0x4B47D17: __vasprintf_internal (vasprintf.c:116)
==196556==    by 0x4B1D6B3: asprintf (asprintf.c:31)
==196556==    by 0x49E182F: parsec_dtd_taskpool_new (insert_function.c:1442)
==196556==    by 0x17035B: RUNTIME_sequence_create (runtime_async.c:30)
==196556==    by 0x131EEF: chameleon_sequence_create (async.c:51)
==196556==    by 0x145693: CHAMELEON_dplrnt_Tile (dplrnt.c:179)
==196556==    by 0x11A097: testing_dgemm_desc (testing_dgemm.c:92)
==196556==    by 0x112557: main (chameleon_dtesting.c:244)
```

because the return value of `asprintf` is wrongly checked and the pointer was lost immediatly