### PR TITLE
Fix the lack of direct GPU to GPU communications in multi-device runs.

### DIFF
--- a/parsec/mca/device/cuda/device_cuda_internal.h
+++ b/parsec/mca/device/cuda/device_cuda_internal.h
@@ -14,7 +14,7 @@
 BEGIN_C_DECLS
 
 /* From MCA parameters */
-extern int parsec_device_cuda_enabled_index, parsec_device_cuda_enabled;
+extern int parsec_device_cuda_enabled_index, parsec_device_cuda_enabled, parsec_cuda_nvlink_mask;
 extern int parsec_cuda_max_streams;
 extern int parsec_cuda_memory_block_size, parsec_cuda_memory_percentage, parsec_cuda_memory_number_of_blocks;
 extern char* parsec_cuda_lib_path;

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -660,6 +660,7 @@ int parsec_mca_device_registration_complete(parsec_context_t* context)
 
     if(parsec_mca_device_are_freezed)
         return PARSEC_ERR_NOT_SUPPORTED;
+    parsec_mca_device_are_freezed = 1;
 
     for( uint32_t i = 0; i < parsec_nb_devices; i++ ) {
         parsec_device_module_t* device = parsec_devices[i];
@@ -688,9 +689,11 @@ int parsec_mca_device_registration_complete(parsec_context_t* context)
         device->time_estimate_default = total_gflops_fp64/(double)device->gflops_fp64;
         parsec_debug_verbose(6, parsec_device_output, "  Dev[%d] default-time-estimate %-4"PRId64" <- double %-8"PRId64" single %-8"PRId64" tensor %-8"PRId64" half %-8"PRId64" %s",
                              i, device->time_estimate_default, device->gflops_fp64, device->gflops_fp32, device->gflops_tf32, device->gflops_fp16, device->gflops_guess? "GUESSED": "");
+        if(NULL != device->all_devices_attached) {
+            device->all_devices_attached(device);
+        }
     }
 
-    parsec_mca_device_are_freezed = 1;
     return PARSEC_SUCCESS;
 }
 

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -129,6 +129,16 @@ typedef int  (*parsec_device_sort_pending_list_function_f)(parsec_device_module_
  */
 typedef parsec_hook_return_t (*parsec_device_kernel_scheduler_function_t)( parsec_device_module_t *module, parsec_execution_stream_t *es, void *task);
 
+/**
+ * @brief Callback to complete initialization of a device after all
+ *   other devices have done their initialization/attachment
+ *   Typically used to compute the interconnect matrix between devices
+ *
+ * @param [INOUT]module: the module to complete the initialization
+ * @return PARSEC_SUCCESS or an error code
+ */
+typedef int (*parsec_device_all_devices_attached_f)(parsec_device_module_t *module);
+
 struct parsec_device_module_s {
     parsec_object_t                        super;
     const parsec_device_base_component_t  *component;
@@ -144,6 +154,7 @@ struct parsec_device_module_s {
     parsec_device_find_function_f          find_function;
     parsec_device_sort_pending_list_function_f sort_pending_list;
     parsec_device_kernel_scheduler_function_t  kernel_scheduler;
+    parsec_device_all_devices_attached_f   all_devices_attached;
 
     parsec_info_object_array_t             infos; /**< Per-device info objects are stored here */
     struct parsec_context_s* context;  /**< The PaRSEC context this device belongs too */


### PR DESCRIPTION
In https://github.com/ICLDisco/parsec/pull/570, we moved from using cuda_index to using device_index in the 'nvlink' mask that decides if we can directly communicate to another GPU. However, this bitmask was initialized at query time, before devices get assigned a device_index. As a consequence, the bitmask was wrong and no direct device to device communication was happening.

In this PR, we add a step, after all devices have been registered, to complete this initialization.

An alternative is to come back to using cuda_index-based bitmasks, but then the decision if two GPUs can directly communicate is device-type specific and needs to be moved from device_gpu.c to device_cuda_module.c, which means we add another function call to device_cuda_module.c inside the stage_in() function of device_gpu.c
