### PR TITLE
Compute CPU and GPU versions without lying during kernel epilog (enable TTG/PTG versioning to coexist)

### DIFF
--- a/parsec/data_dist/matrix/map_operator.c
+++ b/parsec/data_dist/matrix/map_operator.c
@@ -188,7 +188,6 @@ add_task_to_list(parsec_execution_stream_t *es,
     parsec_task_t* new_context = (parsec_task_t*)parsec_thread_mempool_allocate( es->context_mempool );
 
     PARSEC_COPY_EXECUTION_CONTEXT(new_context, newcontext);
-    new_context->status = PARSEC_TASK_STATUS_NONE;
     pready_list[vpid_dst] = (parsec_task_t*)parsec_list_item_ring_push_sorted( (parsec_list_item_t*)(pready_list[vpid_dst]),
                                                                                (parsec_list_item_t*)new_context,
                                                                                parsec_execution_context_priority_comparator );
@@ -430,6 +429,7 @@ static void parsec_map_operator_startup_fn(parsec_context_t *context,
     parsec_execution_stream_t* es;
 
     *startup_list = NULL;
+    PARSEC_OBJ_CONSTRUCT(&fake_context, parsec_task_t);
     fake_context.task_class = &parsec_map_operator;
     fake_context.taskpool = tp;
     fake_context.priority = 0;

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2631,6 +2631,7 @@ parsec_dtd_create_and_initialize_task(parsec_dtd_taskpool_t *dtd_tp,
 
     assert(this_task->super.super.super.obj_reference_count == 1);
 
+    PARSEC_OBJ_CONSTRUCT(&this_task->super, parsec_task_t);
     this_task->orig_task = NULL;
     this_task->super.taskpool = (parsec_taskpool_t *)dtd_tp;
     this_task->ht_item.key = (parsec_key_t)(uintptr_t)(dtd_tp->task_id++);
@@ -2648,8 +2649,6 @@ parsec_dtd_create_and_initialize_task(parsec_dtd_taskpool_t *dtd_tp,
     this_task->rank = rank;
     this_task->super.priority = 0;
     this_task->super.chore_mask = PARSEC_DEV_ANY_TYPE;
-    this_task->super.selected_device = NULL; this_task->super.selected_chore = -1; this_task->super.load = 0;
-    this_task->super.status = PARSEC_TASK_STATUS_NONE;
 
     int j;
     parsec_dtd_flow_info_t *flow;

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -1828,12 +1828,6 @@ complete_hook_of_dtd(parsec_execution_stream_t *es,
 
         if( PARSEC_INOUT == (op_type_on_current_flow & PARSEC_GET_OP_TYPE) ||
             PARSEC_OUTPUT == (op_type_on_current_flow & PARSEC_GET_OP_TYPE)) {
-            parsec_data_copy_t *data_out = this_task->data[current_dep].data_out;
-            /* assert(NULL != data_out); // DEBUG */
-            if( NULL != data_out ) {
-                data_out->version++;
-            }
-
             parsec_data_copy_t *data_in = this_task->data[current_dep].data_in;
             if( PARSEC_PULLIN & op_type_on_current_flow ) {
                 assert(NULL != data_in);
@@ -2323,6 +2317,7 @@ static parsec_hook_return_t parsec_dtd_cpu_task_submit(parsec_execution_stream_t
         parsec_dtd_flow_info_t *flow = FLOW_OF(dtd_task, i);
         if(  PARSEC_INOUT == (flow->op_type & PARSEC_GET_OP_TYPE) ||
              PARSEC_OUTPUT == (flow->op_type & PARSEC_GET_OP_TYPE)) {
+            this_task->data[i].data_in->version++;
             int8_t data_owner_dev = this_task->data[i].data_in->original->owner_device;
             assert(data_owner_dev < parsec_mca_device_enabled());
             if( data_owner_dev >= 0 && parsec_mca_device_is_gpu(data_owner_dev) ) {
@@ -2331,7 +2326,6 @@ static parsec_hook_return_t parsec_dtd_cpu_task_submit(parsec_execution_stream_t
                     access = PARSEC_FLOW_ACCESS_RW;
                 else
                     access = PARSEC_FLOW_ACCESS_WRITE;
-                this_task->data[i].data_in->version++;
                 parsec_data_transfer_ownership_to_copy(this_task->data[i].data_in->original, 0, access);
                 // We need to remove ourselves as reader on this data, as transfer_ownership always counts an additional reader
                 this_task->data[i].data_in->readers--;

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -177,8 +177,8 @@ static void houtput(const char *format, ...)
 
 /**
  * @brief Generate the C code from a variable name or from an inlined function.
- * 
- * @param expr 
+ *
+ * @param expr
  */
 static void var_to_c_code(jdf_expr_t* expr)
 {
@@ -1356,7 +1356,7 @@ static inline char* jdf_generate_task_typedef(void **elt, void* arg)
                   f->fname, nb_locals, f->nb_max_local_def, MAX_LOCAL_COUNT);
         exit(1);
     }
-    
+
     JDF_COUNT_LIST_ENTRIES(f->dataflow, jdf_dataflow_t, next, nb_flows);
     UTIL_DUMP_LIST_FIELD(sa_data, f->dataflow, next, varname, dump_string, NULL,
                          "", "  parsec_data_pair_t _f_", ";\n", ";\n");
@@ -1796,7 +1796,7 @@ static void jdf_generate_range_min_without_fn(const jdf_t *jdf, const jdf_expr_t
         coutput("  %s = %s;\n", ret_name, dump_expr((void**)expr->jdf_ta1, &info));
     else
         coutput("  %s = %s;\n", ret_name, dump_expr((void**)expr, &info));
-    
+
     for(ld = jdf_expr_lv_first(expr->local_variables); NULL != ld; ld = jdf_expr_lv_next(expr->local_variables, ld)) {
         coutput("  }\n");
     }
@@ -1864,7 +1864,7 @@ static void jdf_generate_range_max(const jdf_t *jdf, const jdf_function_entry_t 
     coutput("%s\n",
             UTIL_DUMP_LIST(sa2, f->locals, next, dump_local_assignments, &ai,
                            "", "  ", "\n", "\n"));
-    
+
     for(ld = jdf_expr_lv_first(expr->local_variables); NULL != ld; ld = jdf_expr_lv_next(expr->local_variables, ld)) {
         assert(ld->ldef_index != -1);
         if( JDF_RANGE == ld->op )
@@ -1930,18 +1930,18 @@ static void jdf_generate_range_increment(const jdf_t *jdf, const jdf_function_en
     coutput("%s\n",
             UTIL_DUMP_LIST(sa2, f->locals, next, dump_local_assignments, &ai,
                            "", "  ", "\n", "\n"));
-    
+
     for(ld = jdf_expr_lv_first(expr->local_variables); NULL != ld; ld = jdf_expr_lv_next(expr->local_variables, ld)) {
         assert(-1 != ld->ldef_index);
         coutput("  { /* New scope for local index '%s' */ \n"
                 "    int %s = locals->ldef[%d].value;\n",
                 ld->alias,
                 ld->alias, ld->ldef_index);
-        if( JDF_RANGE == ld->op ) 
+        if( JDF_RANGE == ld->op )
             coutput("    %s += %s;\n"
                     "    locals->ldef[%d].value = %s;\n",
                     ld->alias, dump_expr((void**)ld->jdf_ta3, &info),
-                    ld->ldef_index, ld->alias);            
+                    ld->ldef_index, ld->alias);
     }
     coutput("  __parsec_ret = %s;\n", dump_expr((void**)expr, &info));
     for(ld = jdf_expr_lv_first(expr->local_variables); NULL != ld; ld = jdf_expr_lv_next(expr->local_variables, ld)) {
@@ -2413,7 +2413,7 @@ static void jdf_generate_ctl_gather_compute(const jdf_t *jdf, const jdf_function
                     indent(nbopen), ld->alias, ld->ldef_index, dump_expr( (void**)ld, &info1 ));
             nbopen+=1;
         }
-        
+
     }
     for(pl = targetf->parameters, le = params; NULL != le; pl = pl->next, le = le->next) {
         if( le->op == JDF_RANGE ) {
@@ -2433,7 +2433,7 @@ static void jdf_generate_ctl_gather_compute(const jdf_t *jdf, const jdf_function
                     "%s  (void)%s_%s;\n",
                     indent(nbopen), targetf->fname, pl->name, dump_expr( (void**)le, &info1 ),
                     indent(nbopen), targetf->fname, pl->name);
-        }                    
+        }
     }
     coutput("%s  __nb_found++;\n", indent(nbopen));
     nbopen--;
@@ -3157,6 +3157,7 @@ static void jdf_generate_startup_tasks(const jdf_t *jdf, const jdf_function_entr
             "%s    vpid = (vpid + 1) %% context->nb_vp;  /* spread the initial joy */\n"
             "%s  }\n"
             "%s  new_task = (%s*)parsec_thread_mempool_allocate( context->virtual_processes[vpid]->execution_streams[0]->context_mempool );\n"
+            "%s  new_task->selected_device = NULL; new_task->selected_chore = -1; new_task->load = 0;\n"
             "%s  new_task->status = PARSEC_TASK_STATUS_NONE;\n",
             indent(nesting), f->predicate->func_or_mem,
             indent(nesting), f->predicate->func_or_mem, f->predicate->func_or_mem,
@@ -3168,6 +3169,7 @@ static void jdf_generate_startup_tasks(const jdf_t *jdf, const jdf_function_entr
             indent(nesting),
             indent(nesting),
             indent(nesting), parsec_get_name(jdf, f, "task_t"),
+            indent(nesting),
             indent(nesting));
 
     JDF_COUNT_LIST_ENTRIES(f->locals, jdf_variable_list_t, next, nb_locals);
@@ -3339,7 +3341,7 @@ static  void jdf_generate_deps_key_functions(const jdf_t *jdf, const jdf_functio
     jdf_variable_list_t *vl;
 
     (void)jdf;
-    
+
     if( f->parameters == NULL || (0 != (f->user_defines & JDF_FUNCTION_HAS_UD_MAKE_KEY)) ) {
         /* There are no parameters for this task class, or we don't know how to inverse the key.
          * If the user knows how to print properly, she can define the hash struct entirely;
@@ -3361,7 +3363,7 @@ static  void jdf_generate_deps_key_functions(const jdf_t *jdf, const jdf_functio
         expr_info_t info;
         int first_param = 1;
         int need_assignment = 0;
-        
+
         info.sa = sa_info;
         info.prefix = "";
         info.suffix = "";
@@ -3373,7 +3375,7 @@ static  void jdf_generate_deps_key_functions(const jdf_t *jdf, const jdf_functio
                 break;
             }
         }
-        
+
         coutput("static char *%s_key_print(char *buffer, size_t buffer_size, parsec_key_t __parsec_key_, void *user_data)\n"
                 "{\n"
                 "  uint64_t __parsec_key = (uint64_t)(uintptr_t)__parsec_key_;\n"
@@ -3386,7 +3388,7 @@ static  void jdf_generate_deps_key_functions(const jdf_t *jdf, const jdf_functio
                 UTIL_DUMP_LIST_FIELD(sa1, f->locals, next, name, dump_string, NULL,
                                      "  ", ".", ".value = 0, ", ".value = 0 "));
         string_arena_free(sa1);
-        
+
         for(vl = f->locals; vl != NULL; vl = vl->next) {
             if( local_is_parameter(f, vl) != NULL ) {
                 coutput("  int %s = (__parsec_key) %% __parsec_tp->%s_%s_range + __parsec_tp->%s_%s_min;\n",
@@ -3598,7 +3600,7 @@ static void jdf_generate_internal_init(const jdf_t *jdf, const jdf_function_entr
                                 indent(nesting), ld->alias,
                                 indent(nesting), ld->alias, ld->ldef_index, dump_expr((void**)ld, &info));
                         nesting++;
-                    } 
+                    }
                 }
                 coutput("%s    %s = %s;\n", indent(nesting), vl->name, dump_expr((void**)vl->expr, &info));
             } else {
@@ -3614,7 +3616,7 @@ static void jdf_generate_internal_init(const jdf_t *jdf, const jdf_function_entr
             nesting++;
             inner_vl = vl; /* remember what is the last local seen */
         }
-        
+
         if( need_min_max ) {
             for(vl = f->locals; vl != NULL; vl = vl->next) {
                 if ( NULL != vl->expr->local_variables) {
@@ -3625,7 +3627,7 @@ static void jdf_generate_internal_init(const jdf_t *jdf, const jdf_function_entr
                 }
             }
         }
-        
+
         string_arena_init(sa1);
         string_arena_init(sa2);
         coutput("%s  if( !%s_pred(%s) ) continue;\n",
@@ -3736,7 +3738,7 @@ static void jdf_generate_internal_init(const jdf_t *jdf, const jdf_function_entr
                 }
             }
         }
-        
+
         if(need_to_count_tasks) {
             coutput("%s   if( 0 != nb_tasks ) {\n"
                     "%s     (void)parsec_atomic_fetch_add_int32(&__parsec_tp->initial_number_tasks, nb_tasks);\n"
@@ -3860,7 +3862,7 @@ static void jdf_generate_internal_init(const jdf_t *jdf, const jdf_function_entr
     coutput("    parsec_mfence();  /* write memory barrier to guarantee that the scheduler gets the correct number of tasks */\n"
             "    parsec_taskpool_enable((parsec_taskpool_t*)__parsec_tp, &__parsec_tp->startup_queue,\n"
             "                           (parsec_task_t*)this_task, es, __parsec_tp->super.super.nb_pending_actions);\n"
-	    "    __parsec_tp->super.super.tdm.module->taskpool_ready(&__parsec_tp->super.super);\n");
+            "    __parsec_tp->super.super.tdm.module->taskpool_ready(&__parsec_tp->super.super);\n");
     if( profile_enabled(f->properties) ) {
         coutput("#if defined(PARSEC_PROF_TRACE) && defined(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT)\n"
                 "    PARSEC_PROFILING_TRACE(es->es_profile,\n"
@@ -4299,7 +4301,7 @@ static void jdf_generate_one_function( const jdf_t *jdf, jdf_function_entry_t *f
     } else {
         string_arena_add_string(sa, "  .update_deps = parsec_update_deps_with_counter,\n");
     }
-    
+
     if( !(f->flags & JDF_FUNCTION_FLAG_NO_SUCCESSORS) ) {
         sprintf(prefix, "iterate_successors_of_%s_%s", jdf_basename, f->fname);
         jdf_generate_code_iterate_successors_or_predecessors(jdf, f, prefix, JDF_DEP_FLOW_OUT);
@@ -4496,6 +4498,7 @@ static void jdf_generate_startup_hook( const jdf_t *jdf )
             "    parsec_task_t* task = (parsec_task_t*)parsec_thread_mempool_allocate(context->virtual_processes[0]->execution_streams[0]->context_mempool);\n"
             "    task->taskpool = (parsec_taskpool_t *)__parsec_tp;\n"
             "    task->chore_mask = PARSEC_DEV_CPU;\n"
+            "    task->selected_device = NULL; task->selected_chore = -1; task->load = 0;\n"
             "    task->status = PARSEC_TASK_STATUS_NONE;\n"
             "    memset(&task->locals, 0, sizeof(parsec_assignment_t) * MAX_LOCAL_COUNT);\n"
             "    PARSEC_LIST_ITEM_SINGLETON(task);\n"
@@ -4569,7 +4572,7 @@ static void jdf_generate_destructor( const jdf_t *jdf )
                 coutput("  parsec_hash_table_fini( (parsec_hash_table_t*)__parsec_tp->super.super.dependencies_array[%d] );\n"
                         "  PARSEC_OBJ_RELEASE(__parsec_tp->super.super.dependencies_array[%d]);\n",
                         f->task_class_id, f->task_class_id);
-            } 
+            }
         } else {
             coutput("  %s(__parsec_tp, __parsec_tp->super.super.dependencies_array[%d]);\n",
                     jdf_property_get_function(f->properties, JDF_PROP_UD_FREE_DEPS_FN_NAME, NULL),
@@ -4819,7 +4822,7 @@ static void jdf_generate_new_function( const jdf_t* jdf )
     if( jdf_uses_dynamic_termdet(jdf) ) {
         coutput("  __parsec_tp->initial_number_tasks = 0;\n");
     }
-    
+
     string_arena_init(sa1);
     string_arena_init(sa2);
     coutput("/* Prevent warnings related to not used hidden global variables */\n"
@@ -4850,14 +4853,14 @@ static void jdf_generate_hashfunction_for(const jdf_t *jdf, const jdf_function_e
         } else {
             coutput("  const __parsec_%s_internal_taskpool_t *__parsec_tp = (const __parsec_%s_internal_taskpool_t *)tp;\n"
                     "  const %s *assignment = (const %s*)as;\n"
-                    "  uint64_t __parsec_id = 0;\n", 
+                    "  uint64_t __parsec_id = 0;\n",
                     jdf_basename, jdf_basename,
                     parsec_get_name(jdf, f, "parsec_assignment_t"),
                     parsec_get_name(jdf, f, "parsec_assignment_t"));
             string_arena_init(sa_range_multiplier);
             for(vl = f->locals; vl != NULL; vl = vl->next) {
                 if( local_is_parameter(f, vl) != NULL ) {
-                    coutput("  __parsec_id += (assignment->%s.value - __parsec_tp->%s_%s_min)%s;\n", vl->name, f->fname, vl->name, 
+                    coutput("  __parsec_id += (assignment->%s.value - __parsec_tp->%s_%s_min)%s;\n", vl->name, f->fname, vl->name,
                             string_arena_get_string(sa_range_multiplier));
                     string_arena_add_string(sa_range_multiplier, " * __parsec_tp->%s_%s_range", f->fname, vl->name);
                 }
@@ -5760,7 +5763,7 @@ static void jdf_generate_code_flow_initialization(const jdf_t *jdf,
             "  consumed_entry_key = 0;\n"
             "  consumed_entry = NULL;\n"
             "  chunk = NULL;\n");
-    
+
     for(dl = flow->deps; dl != NULL; dl = dl->next) {
         if ( dl->dep_flags & JDF_DEP_FLOW_OUT ) {
             has_output_deps = 1;
@@ -5772,7 +5775,7 @@ static void jdf_generate_code_flow_initialization(const jdf_t *jdf,
     } else {
         coutput("\n    this_task->data._f_%s.data_out = NULL;  /* By default, if nothing matches */\n", flow->varname);
     }
-    
+
     sa  = string_arena_new(64);
 
     info.sa = sa;
@@ -5881,7 +5884,7 @@ static void jdf_generate_code_flow_initialization(const jdf_t *jdf,
             "}\n\n",
             flow->varname);/*    coutput("if(! this_task->data._f_%s.fulfill ){\n", flow->varname);*/
 
-    
+
     string_arena_free(sa);
     if( NULL != sa2 )
         string_arena_free(sa2);
@@ -6747,8 +6750,6 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
             "  __parsec_%s_internal_taskpool_t *__parsec_tp = (__parsec_%s_internal_taskpool_t *)this_task->taskpool;\n"
             "  parsec_gpu_task_t *gpu_task;\n"
             "  parsec_device_module_t *dev;\n"
-            "  int64_t __load;\n"
-            "  int dev_index;\n"
             "  %s\n"
             "  (void)es; (void)__parsec_tp;\n"
             "\n",
@@ -6764,31 +6765,21 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
     /* Get the hint for static and/or external gpu scheduling */
     jdf_find_property( body->properties, "device", &device_property );
     if ( NULL != device_property ) {
-        device = dump_expr((void**)device_property->expr, &info);
-        coutput("  dev_index = %s;\n"
-                "  if (dev_index < -1) {\n"
-                "    return PARSEC_HOOK_RETURN_NEXT;\n"
-                "  } else if (dev_index == -1) {\n"
-                "    dev_index = parsec_get_best_device((parsec_task_t*)this_task, &__load);\n"
-                "  } else {\n"
-                "    dev_index = (dev_index %% (parsec_mca_device_enabled()-2)) + 2;\n" //TODO: -2+2 not correct when recursive compiled out
-                "  }\n",
-                device);
-    } else {
-        coutput("  dev_index = parsec_get_best_device((parsec_task_t*)this_task, &__load);\n");
+#if 0
+        device = dump_expr((void**)device_property->expr, &info); // see TODO
+                                                                  // below
+#endif
+        coutput("#warning \"TODO device selection needs to go in custom task_class evaluate function\"\n");
     }
-    coutput("  assert(dev_index >= 0);\n"
-            "  if( !parsec_mca_device_is_gpu(dev_index) ) {\n"
-            "    return PARSEC_HOOK_RETURN_NEXT;  /* Fall back */\n"
-            "  }\n"
+    coutput("  dev = this_task->selected_device;\n"
+            "  assert(NULL != dev);\n"
+            "  assert(PARSEC_DEV_IS_GPU(dev->type));\n"
             "\n"
-            "  dev = parsec_mca_device_get(dev_index);\n"
             "  gpu_task = (parsec_gpu_task_t*)calloc(1, sizeof(parsec_gpu_task_t));\n"
             "  PARSEC_OBJ_CONSTRUCT(gpu_task, parsec_list_item_t);\n"
             "  gpu_task->ec = (parsec_task_t*)this_task;\n"
             "  gpu_task->submit = &%s_kernel_submit_%s_%s;\n"
             "  gpu_task->task_type = 0;\n"
-            "  gpu_task->load = __load;\n"
             "  gpu_task->last_data_check_epoch = -1;  /* force at least one validation for the task */\n",
             dev_lower, jdf_basename, f->fname);
 
@@ -7312,7 +7303,7 @@ static char *jdf_dump_context_assignment(string_arena_t *sa_open,
     jdf_expr_t *el;
 
     (void)sourcef;
-    
+
     string_arena_init(sa_open);
 
     /* Find the target function */
@@ -7397,7 +7388,7 @@ static char *jdf_dump_context_assignment(string_arena_t *sa_open,
             }
         }
     }
-    
+
     for(vl = targetf->locals, i = 0; vl != NULL; vl = vl->next, i++) {
 
         for(el  = call->parameters, nl = targetf->parameters;
@@ -7474,7 +7465,7 @@ static char *jdf_dump_context_assignment(string_arena_t *sa_open,
                     }
                 }
             }
-            
+
             if( JDF_RANGE == el->op ) {
                 string_arena_add_string(sa_open,
                                         "%s%s  int %s_%s;\n",
@@ -7652,7 +7643,7 @@ jdf_generate_code_iterate_successors_or_predecessors(const jdf_t *jdf,
     string_arena_t *sa_coutput    = string_arena_new(1024);
     string_arena_t *sa_deps       = string_arena_new(1024);
     string_arena_t *sa_datatype   = string_arena_new(1024);
-    
+
     string_arena_t *sa_tmp_arena  = string_arena_new(256);
     string_arena_t *sa_tmp_count  = string_arena_new(256);
     string_arena_t *sa_tmp_displ  = string_arena_new(256);
@@ -7700,7 +7691,8 @@ jdf_generate_code_iterate_successors_or_predecessors(const jdf_t *jdf,
             UTIL_DUMP_LIST_FIELD(sa1, f->locals, next, name,
                                  dump_string, NULL, "", "  (void)", ";", ";\n"));
 
-    coutput("  nc.taskpool  = this_task->taskpool;\n"
+    coutput("  PARSEC_OBJ_CONSTRUCT(&nc, parsec_task_t);\n"
+            "  nc.taskpool  = this_task->taskpool;\n"
             "  nc.priority  = this_task->priority;\n"
             "  nc.chore_mask  = PARSEC_DEV_ALL;\n");
     coutput("#if defined(DISTRIBUTED)\n"
@@ -7872,7 +7864,7 @@ jdf_generate_code_iterate_successors_or_predecessors(const jdf_t *jdf,
                     }
                 }
             }
-            
+
             switch( dl->guard->guard_type ) {
             case JDF_GUARD_UNCONDITIONAL:
                 if( NULL != dl->guard->calltrue->var) {
@@ -8130,7 +8122,7 @@ static void jdf_generate_inline_c_function(jdf_expr_t *expr)
                     expr->jdf_c_code.fname, jdf_basename);
         }
     }
-    
+
     string_arena_free(sa1);
     string_arena_free(sa2);
 
@@ -8207,7 +8199,7 @@ static void jdf_check_user_defined_internals(jdf_t *jdf)
          * xor off, as nb_local_tasks must be define globally for the taskpool in order
          * to enable the undetermined number of tasks feature. */
         f->user_defines |= global_user_defines;
-        
+
         if( NULL == jdf_property_get_string(f->properties, JDF_PROP_UD_HASH_STRUCT_NAME, NULL) ) {
             rc = asprintf(&tmp, JDF2C_NAMESPACE"key_fns_%s", f->fname);
             if (rc == -1) {
@@ -8221,7 +8213,7 @@ static void jdf_check_user_defined_internals(jdf_t *jdf)
         } else {
             f->user_defines |= JDF_FUNCTION_HAS_UD_HASH_STRUCT;
         }
-        
+
         if( NULL == jdf_property_get_string(f->properties, JDF_PROP_UD_MAKE_KEY_FN_NAME, NULL) ) {
             rc = asprintf(&tmp, JDF2C_NAMESPACE"make_key_%s", f->fname);
             if (rc == -1) {
@@ -8235,7 +8227,7 @@ static void jdf_check_user_defined_internals(jdf_t *jdf)
         } else {
             f->user_defines |= JDF_FUNCTION_HAS_UD_MAKE_KEY;
         }
-        
+
         if( NULL == (expr = jdf_find_property(f->properties, JDF_PROP_UD_STARTUP_TASKS_FN_NAME, &property)) ) {
             if( f->flags & JDF_FUNCTION_FLAG_CAN_BE_STARTUP ) {
                 rc = asprintf(&tmp, JDF2C_NAMESPACE"startup_%s", f->fname);
@@ -8391,10 +8383,10 @@ int jdf_force_termdet_dynamic(jdf_t* jdf)
     termdet_expr = jdf_find_property(jdf->global_properties, JDF_PROP_TERMDET_NAME, &property);
     if( NULL != termdet_expr && strcmp(termdet_expr->jdf_var, JDF_PROP_TERMDET_USER_TRIGGERED) == 0 ) {
         return rc; // We don't override a user-trigger termination detection selection
-    } 
+    }
     if( NULL != termdet_expr && strcmp(termdet_expr->jdf_var, JDF_PROP_TERMDET_DYNAMIC) == 0 ) {
         return rc; // The PTG developer already asked for dynamic termination detection
-    } 
+    }
     if(NULL != termdet_expr) {
         if(strcmp(termdet_expr->jdf_var, JDF_PROP_TERMDET_LOCAL) != 0) {
             jdf_warn(termdet_expr->super.lineno, "'%s' is not a recognized value for option '%s' -- option overwritten to '%s' because --termdet-dynamic is requested\n",
@@ -8437,15 +8429,15 @@ int jdf2c(const char *output_c, const char *output_h, const char *_jdf_basename,
     hfile = NULL;
 
 #if defined(PARSEC_HAVE_INDENT) && !(defined(__WINDOWS__) || defined(__MING64__) || defined(__CYGWIN__))
-    /* When we apply indent/awk to the output of jdf2c, we need to make 
-     * sure that the resultant file is flushed onto the filesystem before 
+    /* When we apply indent/awk to the output of jdf2c, we need to make
+     * sure that the resultant file is flushed onto the filesystem before
      * the rest of the compilation chain can takeover. An original version
      * was using rename(2) and temporary files to apply the indent/awk, but
-     * it turns out to be very difficult to portably ensure visibility of 
+     * it turns out to be very difficult to portably ensure visibility of
      * the rename in subsequent operations (see PR#32 for the discussion).
      * As an alternative, we use pipes between jdf2c and the system spawned
-     * indent/awk commands, so that we can spare the rename and rely on a 
-     * classic fsync on the output to ensure visibilitiy. 
+     * indent/awk commands, so that we can spare the rename and rely on a
+     * classic fsync on the output to ensure visibilitiy.
      */
     int child = -1;
     int cpipefd[2] = {-1,-1};
@@ -8571,7 +8563,7 @@ int jdf2c(const char *output_c, const char *output_h, const char *_jdf_basename,
             jdf_basename,
             jdf_basename, jdf_basename,
             jdf_basename, jdf_basename);
-    
+
     jdf_generate_new_function(jdf);
 
     free_name_placeholders();

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -6703,9 +6703,8 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
     coutput("#if defined(PARSEC_DEBUG_NOISIER)\n"
             "  {\n"
             "    char tmp[MAX_TASK_STRLEN];\n"
-            "    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, \"GPU[%%s]:\\tEnqueue on device %%s priority %%d\", gpu_device->super.name, \n"
-            "           parsec_task_snprintf(tmp, MAX_TASK_STRLEN, (parsec_task_t *)this_task),\n"
-            "           this_task->priority );\n"
+            "    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, \"GPU[%%d:%%s]:\\tEnqueue on device %%s\", gpu_device->super.device_index, gpu_device->super.name, \n"
+            "           parsec_task_snprintf(tmp, MAX_TASK_STRLEN, (parsec_task_t *)this_task));\n"
             "  }\n"
             "#endif /* defined(PARSEC_DEBUG_NOISIER) */\n");
 

--- a/parsec/mca/device/cuda/device_cuda_component.c
+++ b/parsec/mca/device/cuda/device_cuda_component.c
@@ -257,16 +257,16 @@ static int device_cuda_component_close(void)
         rc = parsec_cuda_module_fini((parsec_device_module_t*)cdev);
         if( PARSEC_SUCCESS != rc ) {
             PARSEC_DEBUG_VERBOSE(0, parsec_gpu_output_stream,
-                                 "GPU[%d] Failed to release resources on CUDA device\n",
-                                 cdev->cuda_index);
+                                 "GPU[%d:%s] Failed to release resources on CUDA device %d\n",
+                                 cdev->super.super.device_index, cdev->super.super.name, cdev->cuda_index);
         }
 
         /* unregister the device from PaRSEC */
         rc = parsec_mca_device_remove((parsec_device_module_t*)cdev);
         if( PARSEC_SUCCESS != rc ) {
             PARSEC_DEBUG_VERBOSE(0, parsec_gpu_output_stream,
-                                 "GPU[%d] Failed to unregister CUDA device %d\n",
-                                 cdev->cuda_index, cdev->cuda_index);
+                                 "GPU[%d:%s] Failed to unregister CUDA device %d\n",
+                                 cdev->super.super.device_index, cdev->super.super.name, cdev->cuda_index);
         }
 
         free(cdev);
@@ -279,9 +279,9 @@ static int device_cuda_component_close(void)
         if(PARSEC_DEV_CUDA != cdev->super.super.type) continue;
 
         PARSEC_DEBUG_VERBOSE(0, parsec_gpu_output_stream,
-                             "GPU[%d] CUDA device still registered with PaRSEC at the end of CUDA finalize.\n"
+                             "GPU[%d:%s] CUDA device %d still registered with PaRSEC at the end of CUDA finalize.\n"
                              " Please contact the developers or fill an issue.\n",
-                             cdev->cuda_index);
+                             cdev->super.super.device_index, cdev->super.super.name, cdev->cuda_index);
     }
 #endif  /* defined(PARSEC_DEBUG_NOISIER) */
 

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -180,10 +180,10 @@ int parsec_select_best_device( parsec_task_t* this_task ) {
         /* If the READ data has a preferred device, prefer it. */
         dev = parsec_mca_device_get(data_copy->original->preferred_device);
         if( NULL != dev && (dev->type & valid_types) && (tp->devices_index_mask & (1<<dev->device_index)) ) {
-            PARSEC_DEBUG_VERBOSE(30, parsec_device_output, "%s: Task %s favors device %d:%s because preferred by data %p flow AREAD in[%d]",
+            PARSEC_DEBUG_VERBOSE(30, parsec_device_output, "%s: Task %s set selected_device %d:%s because preferred by data %p flow AREAD in[%d]",
                                  __func__, tmp, dev->device_index, dev->name, data_copy->original, i);
-            rdata_dev = dev;
-            break;
+            this_task->selected_device = dev;
+            goto device_selected;
         }
         /* READ data is already located on a GPU device, prefer it */
         dev = parsec_mca_device_get(data_copy->original->owner_device);

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -85,7 +85,7 @@ static int64_t time_estimate(const parsec_task_t *this_task, parsec_device_modul
  * PARSEC_ERROR   - no device could be selected
  */
 int parsec_select_best_device( parsec_task_t* this_task ) {
-    int data_index;
+    parsec_data_copy_t* data_copy = NULL;
     parsec_taskpool_t* tp = this_task->taskpool;
     parsec_device_module_t *dev = NULL, *prefer_dev = NULL;
 
@@ -98,15 +98,16 @@ int parsec_select_best_device( parsec_task_t* this_task ) {
 #endif
     unsigned int chore_id = 0, valid_types = 0;
 
-    /* we did it before (this is a PARSEC_RETURN_ASYNC) */
+    /* we did it before (this is a PARSEC_RETURN_AGAIN/ASYNC?) */
     if( this_task->selected_device ) {
         goto device_selected;
     }
 
     /* Run the evaluates for the incarnation types to determine if they can
      * execute this task */
-    for(chore_id = 0; NULL != tc->incarnations[chore_id].hook; chore_id++) {
+    for(chore_id = 0; PARSEC_DEV_NONE != tc->incarnations[chore_id].type; chore_id++) {
         if( 0 == (this_task->chore_mask & (1<<chore_id)) ) continue;
+        if( NULL == tc->incarnations[chore_id].hook ) continue; /* dyld hook not found during initialization */
 
         if( NULL != (eval = tc->incarnations[chore_id].evaluate) ) {
             rc = eval(this_task);
@@ -122,78 +123,74 @@ int parsec_select_best_device( parsec_task_t* this_task ) {
             }
         }
         valid_types |= tc->incarnations[chore_id].type; /* the eval accepted the type, but no device specified yet */
+        /* Evaluate may have picked a device, abide by it */
+        if( NULL != this_task->selected_device ) {
+#if defined(PARSEC_DEBUG)
+            dev = this_task->selected_device;
+            assert( dev->type & valid_types );
+            PARSEC_DEBUG_VERBOSE(5, parsec_debug_output, "Task %s evaluate selected device %s",
+                             tmp, dev->name);
+#endif
+            goto device_selected;
+        }
     }
 
     if (!valid_types)
         goto no_valid_device;
 
-    /* Evaluate may have picked a device, abide by it */
-    if(this_task->selected_device != NULL) {
-#if defined(PARSEC_DEBUG)
-        dev = this_task->selected_device;
-        assert( dev->type & valid_types );
-        PARSEC_DEBUG_VERBOSE(5, parsec_debug_output, "Task %s evaluate selected device %s",
-                             tmp, dev->name);
-#endif
-        goto device_selected;
-    }
-
-    /* for all devices with matching incarnation type for the chore_id, which one is the best */
-
-    /* Select the location of the first data that is used in READ/WRITE or pick the
-     * location of one of the READ data. For now use the last one.
+    /* For all devices with matching incarnation type for the chore_id, which one is the best?
+     * We try to minimize the data movements, so favor devices that already
+     * hold the data:
+     *   Select the location of the first data that is used with ACCESS_WRITE (first loop)
+     *   or prefer the location of one of the READ data (second loop).
      */
-    for( int i = 0; i < this_task->task_class->nb_flows; i++ ) {
-        /* Make sure data_in is not NULL */
-        if( NULL == this_task->data[i].data_in ) continue;
-        /* And that we have a data (aka it is not NEW) */
-        if( NULL == this_task->data[i].source_repo_entry ) continue;
+    for( int i = 0; i < this_task->task_class->nb_flows; i++ ) { /* look for an ACCESS_WRITE data */
+        if( NULL == this_task->task_class->out[i]
+         || !(PARSEC_FLOW_ACCESS_WRITE & this_task->task_class->out[i]->flow_flags) ) continue; /* not ACCESS_WRITE, skip */
 
-        /* Data is updated by the task, and we try to minimize the data movements */
-        if( (NULL != this_task->task_class->out[i]) &&
-            (this_task->task_class->out[i]->flow_flags & PARSEC_FLOW_ACCESS_WRITE) ) {
+        data_copy = this_task->data[this_task->task_class->out[i]->flow_index].data_in;
+        if( NULL == data_copy ) continue; /* possible for NULL flows */
 
-            data_index = this_task->task_class->out[i]->flow_index;
-            /* If the data has a preferred device, try to obey it. */
-            dev = parsec_mca_device_get(this_task->data[data_index].data_in->original->preferred_device);
-            if( NULL != dev && (dev->type & valid_types) && (tp->devices_index_mask & (1<<dev->device_index)))
-                break;
-            /* Data is located on a device */
-            dev = parsec_mca_device_get(this_task->data[data_index].data_in->original->owner_device);
-            if( NULL != dev && (dev->type & valid_types) && (tp->devices_index_mask & (1<<dev->device_index)) && PARSEC_DEV_IS_GPU(dev->type) /* no CPU or recursive otherwise disable GPU execution */ )
-                break;
-            dev = NULL;
+        /* If the WRITE data has a preferred device, select it. */
+        dev = parsec_mca_device_get(data_copy->original->preferred_device);
+        if( NULL != dev && (dev->type & valid_types) && (tp->devices_index_mask & (1<<dev->device_index))) {
+            this_task->selected_device = dev;
+            goto device_selected;
         }
-        /* If we reach here, we cannot yet decide which device to run on based on the WRITE
-         * constraints, so let's pick the data for a READ flow.
-         */
-        data_index = this_task->task_class->in[i]->flow_index;
-        prefer_dev = parsec_mca_device_get(this_task->data[data_index].data_in->original->preferred_device);
-        if( NULL != prefer_dev && (prefer_dev->type & valid_types) && (tp->devices_index_mask & (1<<prefer_dev->device_index)) )
+        /* WRITE data is already located on a GPU device, select it */
+        dev = parsec_mca_device_get(data_copy->original->owner_device);
+        if( NULL != dev && (dev->type & valid_types) && (tp->devices_index_mask & (1<<dev->device_index)) && PARSEC_DEV_IS_GPU(dev->type) ) {
+            this_task->selected_device = dev;
+            goto device_selected;
+        }
+    }
+    /* If we reach here, we cannot yet decide which device to run on based on the task outputs */
+    for( int i = 0; i < this_task->task_class->nb_flows; i++ ) { /* look for an ACCESS_READ data */
+        if( NULL == this_task->task_class->in[i] ) continue; /* possible for WRITE (write-only) flows */
+
+        data_copy = this_task->data[this_task->task_class->in[i]->flow_index].data_in;
+        if( NULL == data_copy ) continue; /* possible for NULL flows */
+
+        /* If the READ data has a preferred device, prefer it. */
+        dev = parsec_mca_device_get(data_copy->original->preferred_device);
+        if( NULL != dev && (dev->type & valid_types) && (tp->devices_index_mask & (1<<dev->device_index)) ) {
+            prefer_dev = dev;
             break;
-        prefer_dev = parsec_mca_device_get(this_task->data[data_index].data_in->original->owner_device);
-        if( NULL != prefer_dev && (prefer_dev->type & valid_types) && (tp->devices_index_mask & (1<<prefer_dev->device_index)) && PARSEC_DEV_IS_GPU(prefer_dev->type) /* no CPU or recursive otherwise disable GPU execution */ )
+        }
+        /* READ data is already located on a GPU device, prefer it */
+        dev = parsec_mca_device_get(data_copy->original->owner_device);
+        if( NULL != dev && (dev->type & valid_types) && (tp->devices_index_mask & (1<<dev->device_index)) && PARSEC_DEV_IS_GPU(dev->type) /* no CPU or recursive, always true test would disable GPU execution */ ) {
+            prefer_dev = dev;
             break;
-        prefer_dev = NULL;
+        }
     }
 
-    if( NULL == dev ) {  /* We don't have a prefered or owner GPU device for this data, let's decide which device will work on it. */
-        int best_index;
+    assert( NULL == this_task->selected_device );
+    { /* lets consider the time_estimates to select the best device */
+        int best_index = -1;
         int64_t eta, best_eta = INT64_MAX; /* dev->device_load + time_estimate(this_task, dev); this commented out because we don't count cpu loads */
 
-        /* Warn if there is no valid device for this task */
-        for(best_index = 0; best_index < parsec_mca_device_enabled(); best_index++) {
-            dev = parsec_mca_device_get(best_index);
-
-            /* Skip the device if it is disabled for the taskpool */
-            if(!(tp->devices_index_mask & (1 << best_index))) continue;
-            /* Stop on this device if evaluate accepted the incarnation type */
-            if(dev->type & valid_types) break;
-        }
-        if(parsec_mca_device_enabled() == best_index) /* taskpool disabled all valid_types devices */
-            goto no_valid_device;
-
-        /* If we have a preferred device, start with it, but still consider
+        /* If we have a preferred device (from READ flows), start with it, but still consider
          * other options to have some load balance */
         if( NULL != prefer_dev ) {
             best_index = prefer_dev->device_index;
@@ -206,34 +203,38 @@ int parsec_select_best_device( parsec_task_t* this_task ) {
         /* Consider how adding the current task would change load balancing
          * between devices */
         for( int dev_index = 0; dev_index < parsec_mca_device_enabled(); dev_index++ ) {
-            /* Skip the device if it is not configured */
+            /* Skip the device if it is disabled for the taskpool */
             if(!(tp->devices_index_mask & (1 << dev_index))) continue;
             dev = parsec_mca_device_get(dev_index);
+            /* Skip the device if no incarnations for its type */
             if(!(dev->type & valid_types)) continue;
+            /* Skip recursive devices: time estimates are computed on the associated CPU device */
             if(dev->type == PARSEC_DEV_RECURSIVE) continue;
-#if 0
-            /* Skip cores/recursive devices */
-            if(!parsec_mca_device_is_gpu(dev_index)) continue;
-#endif
+
             eta = dev->device_load + time_estimate(this_task, dev);
-            PARSEC_DEBUG_VERBOSE(80, parsec_device_output, "+++ get_best_device considering %d (%s) with prior load %"PRIu64", new task eta would be %"PRIu64, dev_index, dev->name, dev->device_load, eta);
+            PARSEC_DEBUG_VERBOSE(80, parsec_device_output, "+++ select_best_device considering %d (%s) with prior load %"PRIi64", new task eta would be %"PRIi64, dev_index, dev->name, dev->device_load, eta);
             if( best_eta > eta ) {
                 best_index = dev_index;
                 best_eta = eta;
             }
         }
-        assert( parsec_mca_device_get(best_index)->type != PARSEC_DEV_RECURSIVE );
-        dev = parsec_mca_device_get(best_index);
+        if( -1 == best_index ) /* taskpool disabled all valid_types devices */
+            goto no_valid_device;
+
+        this_task->selected_device = parsec_mca_device_get(best_index);
+        assert( this_task->selected_device->type != PARSEC_DEV_RECURSIVE );
     }
-    this_task->selected_device = dev;
 
 device_selected:
-    assert( NULL != this_task->selected_device );
-    assert( tp->devices_index_mask & (1 << this_task->selected_device->device_index) );
-    for(chore_id = 0; tc->incarnations[chore_id].type != this_task->selected_device->type; chore_id++) /* found it? */;
+    dev = this_task->selected_device;
+    assert( NULL != dev );
+    assert( tp->devices_index_mask & (1 << dev->device_index) );
+    for(chore_id = 0; tc->incarnations[chore_id].type != dev->type; chore_id++)
+        assert(PARSEC_DEV_NONE != tc->incarnations[chore_id].type /* we have selected this device, so there *must* be an incarnation that matches */);
     this_task->selected_chore = chore_id;
-    this_task->load = time_estimate(this_task, this_task->selected_device);
-    PARSEC_DEBUG_VERBOSE(20, parsec_device_output, "get_best_device selected %d (%s) with prior load %"PRIu64", new task load would add %"PRIu64, this_task->selected_device->device_index, this_task->selected_device->name, this_task->selected_device->device_load, this_task->load);
+    this_task->load = time_estimate(this_task, dev);
+
+    PARSEC_DEBUG_VERBOSE(20, parsec_device_output, "select_best_device selected %d (%s) with prior load %"PRIi64", new task %s load %"PRIi64" has eta %"PRIi64, dev->device_index, dev->name, dev->device_load, parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task), this_task->load, dev->device_load+this_task->load);
 
 #if defined(PARSEC_DEBUG_PARANOID)
     /* Sanity check: if at least one of the data copies is not parsec
@@ -243,12 +244,12 @@ device_selected:
         /* Make sure data_in is not NULL */
         if (NULL == this_task->data[i].data_in) continue;
         if ((this_task->data[i].data_in->flags & PARSEC_DATA_FLAG_PARSEC_MANAGED) == 0 &&
-            this_task->data[i].data_in->device_index != this_task->selected_device->device_index) {
+            this_task->data[i].data_in->device_index != dev->device_index) {
             char task_str[MAX_TASK_STRLEN];
-            parsec_fatal("*** User-Managed Copy Error: Task %s is selected to run on device %d,\n"
+            parsec_fatal("*** User-Managed Copy Error: Task %s is selected to run on device %s,\n"
                          "*** but flow %d is represented by a data copy not managed by PaRSEC,\n"
                          "*** and does not have a copy on that device\n",
-                         parsec_task_snprintf(task_str, MAX_TASK_STRLEN, this_task), this_task->selected_device->device_index, i);
+                         parsec_task_snprintf(task_str, MAX_TASK_STRLEN, this_task), dev->name, i);
         }
     }
 #endif

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -191,12 +191,19 @@ extern int parsec_device_output;
 extern parsec_atomic_lock_t parsec_devices_mutex;
 
 /**
- * @brief Returns the parsec device index selected to run @p this_task,
- *    using this_task->task_class->time_estimate function to compute
- *    the task load (estimate of number of ns @p this_task will take on this
- *    device). Also returns the load on the selected device in @p task_load.
+ * @brief Find the best device to execute the kernel based on the compute
+ * capability of the device.
+ *
+ * Returns:
+ * PARSEC_SUCCESS - kernel must be executed by the device set in
+ *                  this_task->selected_device (for convenience
+ *                  this_task->selected_chore is also set)
+ *                  this_task->load is set based on the selected device and
+ *                  this_task->task_class->time_estimate function to compute
+ *                  the load.
+ * PARSEC_ERROR   - no device could be selected
  */
-PARSEC_DECLSPEC extern int parsec_get_best_device( parsec_task_t* this_task, int64_t *task_load );
+PARSEC_DECLSPEC extern int parsec_select_best_device( parsec_task_t* this_task);
 
 /**
  * Initialize the internal structures for managing external devices such as

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -2465,7 +2465,7 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
 #endif
     int pop_null = 0;
 
-    parsec_atomic_fetch_add_int64(&gpu_device->super.device_load, gpu_task->load);
+    parsec_atomic_fetch_add_int64(&gpu_device->super.device_load, gpu_task->ec->load);
 
 #if defined(PARSEC_PROF_TRACE)
     PARSEC_PROFILING_TRACE_FLAGS( es->es_profile,
@@ -2654,10 +2654,10 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
         goto remove_gpu_task;
     }
     parsec_device_kernel_epilog( gpu_device, gpu_task );
+    parsec_atomic_fetch_add_int64(&gpu_device->super.device_load, -gpu_task->ec->load);
     __parsec_complete_execution( es, gpu_task->ec );
     gpu_device->super.executed_tasks++;
  remove_gpu_task:
-    parsec_atomic_fetch_add_int64(&gpu_device->super.device_load, -gpu_task->load);
     PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,"GPU[%s]: gpu_task %p freed at %s:%d", gpu_device->super.name, 
                         gpu_task, __FILE__, __LINE__);
     free( gpu_task );

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -187,8 +187,8 @@ void* parsec_device_pop_workspace(parsec_device_gpu_module_t* gpu_device,
         for( int i = 0; i < PARSEC_GPU_MAX_WORKSPACE; i++ ) {
             gpu_stream->workspace->workspace[i] = zone_malloc( gpu_device->memory, size);
             PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                                 "GPU[%s] Succeeded Allocating workspace %d (device_ptr %p)",
-                                 gpu_device->super.name,
+                                 "GPU[%d:%s] Succeeded Allocating workspace %d (device_ptr %p)",
+                                 gpu_device->super.device_index, gpu_device->super.name,
                                  i, gpu_stream->workspace->workspace[i]);
 #if defined(PARSEC_PROF_TRACE)
             if((gpu_device->trackable_events & PARSEC_PROFILE_GPU_TRACK_MEM_USE) &&
@@ -242,8 +242,8 @@ int parsec_device_free_workspace(parsec_device_gpu_module_t * gpu_device)
                 }
 #endif
                 PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                                     "GPU[%s] Release workspace %d (device_ptr %p)",
-                                     gpu_device->super.name,
+                                     "GPU[%d:%s] Release workspace %d (device_ptr %p)",
+                                     gpu_device->super.device_index, gpu_device->super.name,
                                      j, gpu_stream->workspace->workspace[j]);
                 zone_free( gpu_device->memory, gpu_stream->workspace->workspace[j] );
             }
@@ -408,8 +408,8 @@ parsec_device_release_resources_prefetch_task(parsec_device_gpu_module_t* gpu_de
 #endif
     parsec_gpu_task_t *gpu_task = *out_task;
     (void)gpu_device;
-    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%s]: Releasing resources for task %s (%p with ec %p)",
-                         gpu_device->super.name, parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task),
+    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%d:%s]: Releasing resources for task %s (%p with ec %p)",
+                         gpu_device->super.device_index, gpu_device->super.name, parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task),
                          gpu_task, gpu_task->ec);
     assert( PARSEC_GPU_TASK_TYPE_PREFETCH == gpu_task->task_type );
     PARSEC_DATA_COPY_RELEASE( gpu_task->ec->data[0].data_in);
@@ -448,8 +448,8 @@ parsec_device_data_advise(parsec_device_module_t *dev, parsec_data_t *data, int 
     }
 #endif
 
-    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%s]: User provides advice %s of %s (%p)",
-                         gpu_device->super.name,
+    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%d:%s]: User provides advice %s of %s (%p)",
+                         gpu_device->super.device_index, gpu_device->super.name,
                          parsec_device_debug_advice_to_string(advice),
                          buffer,
                          data);
@@ -461,8 +461,8 @@ parsec_device_data_advise(parsec_device_module_t *dev, parsec_data_t *data, int 
     case PARSEC_DEV_DATA_ADVICE_PREFETCH:
         {
             if( parsec_type_contiguous(data->device_copies[ data->owner_device ]->dtt) != PARSEC_SUCCESS){
-                parsec_warning( "%s:%d %s", __FILE__, __LINE__,
-                                " PARSEC_DEV_DATA_ADVICE_PREFETCH cannot be applied to non contiguous types ");
+                parsec_warning( "GPU[%d:%s]: PARSEC_DEV_DATA_ADVICE_PREFETCH cannot be applied to non contiguous types @%s:%d",
+                                gpu_device->super.device_index, gpu_device->super.name, __func__, __LINE__);
                 return PARSEC_ERROR;
             }
             parsec_gpu_task_t* gpu_task = NULL;
@@ -475,18 +475,17 @@ parsec_device_data_advise(parsec_device_module_t *dev, parsec_data_t *data, int 
             gpu_task->flow_nb_elts[0] = data->device_copies[ data->owner_device ]->original->nb_elts;
             gpu_task->stage_in  = parsec_default_gpu_stage_in;
             gpu_task->stage_out = parsec_default_gpu_stage_out;
-            PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Retain data copy %p [ref_count %d] at %s:%d",
+            PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Retain data copy %p [ref_count %d]",
                                  data->device_copies[ data->owner_device ],
-                                 data->device_copies[ data->owner_device ]->super.super.obj_reference_count,
-                                 __FILE__, __LINE__);
+                                 data->device_copies[ data->owner_device ]->super.super.obj_reference_count);
             PARSEC_OBJ_RETAIN(data->device_copies[ data->owner_device ]);
             gpu_task->ec->data[0].data_in = data->device_copies[ data->owner_device ];
             gpu_task->ec->data[0].data_out = NULL;
             gpu_task->ec->data[0].source_repo_entry = NULL;
             gpu_task->ec->data[0].source_repo = NULL;
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "GPU[%s]: data copy %p [ref_count %d] linked to prefetch gpu task %p on GPU copy %p [ref_count %d]",
-                                 gpu_device->super.name, gpu_task->ec->data[0].data_in, gpu_task->ec->data[0].data_in->super.super.obj_reference_count,
+                                 "GPU[%d:%s]: data copy %p [ref_count %d] linked to prefetch gpu task %p on GPU copy %p [ref_count %d]",
+                                 gpu_device->super.device_index, gpu_device->super.name, gpu_task->ec->data[0].data_in, gpu_task->ec->data[0].data_in->super.super.obj_reference_count,
                                  gpu_task, gpu_task->ec->data[0].data_out, gpu_task->ec->data[0].data_out->super.super.obj_reference_count);
             parsec_fifo_push( &(gpu_device->pending), (parsec_list_item_t*)gpu_task );
             return PARSEC_SUCCESS;
@@ -548,7 +547,8 @@ parsec_device_taskpool_register(parsec_device_module_t* device,
     if( PARSEC_SUCCESS != rc ) {
         tp->devices_index_mask &= ~(1 << device->device_index);  /* drop support for this device */
         parsec_debug_verbose(10, parsec_gpu_output_stream,
-                             "Device %d (%s) disabled for taskpool %p", device->device_index, device->name, tp);
+                             "Device %d:%s disabled for taskpool %d:%s (%p)", device->device_index, device->name,
+                             tp->taskpool_id, tp->taskpool_name, tp);
     }
     return rc;
 }
@@ -612,8 +612,8 @@ parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device,
 
     if( number_blocks != -1 ) {
         if( number_blocks == 0 ) {
-            parsec_warning("GPU[%s] Invalid argument: requesting 0 bytes of memory",
-                           gpu_device->super.name);
+            parsec_warning("GPU[%d:%s] Invalid argument: requesting 0 bytes of memory",
+                           gpu_device->super.device_index, gpu_device->super.name);
             return PARSEC_ERROR;
         } else {
             how_much_we_allocate = number_blocks * eltsize;
@@ -627,16 +627,16 @@ parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device,
          *  and eleventh case of computer scientists who don't know how
          *  to divide a number by another
          */
-        parsec_warning("GPU[%s] Requested %zd bytes on GPU device, but only %zd bytes are available -- reducing allocation to max available",
-                       gpu_device->super.name, how_much_we_allocate, initial_free_mem);
+        parsec_warning("GPU[%d:%s] Requested %zd bytes on GPU device, but only %zd bytes are available -- reducing allocation to max available",
+                       gpu_device->super.device_index, gpu_device->super.name, how_much_we_allocate, initial_free_mem);
         how_much_we_allocate = initial_free_mem;
     }
     if( how_much_we_allocate < eltsize ) {
         /** Handle another kind of jokers entirely, and cases of
          *  not enough memory on the device
          */
-        parsec_warning("GPU[%s] Cannot allocate at least one element",
-                       gpu_device->super.name);
+        parsec_warning("GPU[%d:%s] Cannot allocate at least one element",
+                       gpu_device->super.device_index, gpu_device->super.name);
         return PARSEC_ERROR;
     }
 
@@ -655,35 +655,35 @@ parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device,
         if(PARSEC_SUCCESS != rc) {
             size_t _free_mem, _total_mem;
             gpu_device->memory_info(gpu_device, &_free_mem, &_total_mem );
-            parsec_inform("GPU[%s] Per context: free mem %zu total mem %zu (allocated tiles %u)",
-                            gpu_device->super.name,_free_mem, _total_mem, mem_elem_per_gpu);
+            parsec_inform("GPU[%d:%s] Per context: free mem %zu total mem %zu (allocated tiles %u)",
+                          gpu_device->super.device_index, gpu_device->super.name,_free_mem, _total_mem, mem_elem_per_gpu);
             break;
         }
         gpu_elem = PARSEC_OBJ_NEW(parsec_data_copy_t);
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                            "GPU[%s] Allocate GPU copy %p [ref_count %d] for data [%p]",
-                             gpu_device->super.name,gpu_elem, gpu_elem->super.obj_reference_count, NULL);
+                            "GPU[%d:%s] Allocate GPU copy %p [ref_count %d] for data [%p]",
+                            gpu_device->super.device_index, gpu_device->super.name,gpu_elem, gpu_elem->super.obj_reference_count, NULL);
         gpu_elem->device_private = (void*)(long)device_ptr;
         gpu_elem->flags |= PARSEC_DATA_FLAG_PARSEC_OWNED;
         gpu_elem->device_index = gpu_device->super.device_index;
         mem_elem_per_gpu++;
         PARSEC_OBJ_RETAIN(gpu_elem);
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                            "GPU[%s] Retain and insert GPU copy %p [ref_count %d] in LRU",
-                             gpu_device->super.name, gpu_elem, gpu_elem->super.obj_reference_count);
+                            "GPU[%d:%s] Retain and insert GPU copy %p [ref_count %d] in LRU",
+                            gpu_device->super.device_index, gpu_device->super.name, gpu_elem, gpu_elem->super.obj_reference_count);
         parsec_list_push_back( &gpu_device->gpu_mem_lru, (parsec_list_item_t*)gpu_elem );
         gpu_device->memory_info( gpu_device, &free_mem, &total_mem );
     }
     if( 0 == mem_elem_per_gpu && parsec_list_is_empty( &gpu_device->gpu_mem_lru ) ) {
-        parsec_warning("GPU[%s] Cannot allocate memory on GPU %s. Skip it!", gpu_device->super.name, gpu_device->super.name);
+        parsec_warning("GPU[%d:%s] Cannot allocate memory on GPU %s. Skip it!", gpu_device->super.device_index, gpu_device->super.name, gpu_device->super.name);
     }
     else {
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s] Allocate %u tiles on the GPU memory",
-                             gpu_device->super.name, mem_elem_per_gpu );
+                             "GPU[%d:%s] Allocate %u tiles on the GPU memory",
+                             gpu_device->super.device_index, gpu_device->super.name, mem_elem_per_gpu );
     }
     PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                         "GPU[%s] Allocate %u tiles on the GPU memory", gpu_device->super.name, mem_elem_per_gpu);
+                         "GPU[%d:%s] Allocate %u tiles on the GPU memory", gpu_device->super.device_index, gpu_device->super.name, mem_elem_per_gpu);
 #else
     if( NULL == gpu_device->memory ) {
         void* base_ptr;
@@ -701,8 +701,8 @@ parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device,
         }
         rc = gpu_device->memory_allocate(gpu_device, total_size, &base_ptr);
         if(PARSEC_SUCCESS != rc) {
-            parsec_warning("GPU[%s] Allocating %zu bytes of memory on the GPU device failed",
-                           gpu_device->super.name, total_size);
+            parsec_warning("GPU[%d:%s] Allocating %zu bytes of memory on the GPU device failed",
+                           gpu_device->super.device_index, gpu_device->super.name, total_size);
             gpu_device->memory = NULL;
             return PARSEC_ERROR;
         }
@@ -710,13 +710,13 @@ parsec_device_memory_reserve( parsec_device_gpu_module_t* gpu_device,
         gpu_device->memory = zone_malloc_init( base_ptr, mem_elem_per_gpu, eltsize );
 
         if( gpu_device->memory == NULL ) {
-            parsec_warning("GPU[%s] Cannot allocate memory on GPU %s. Skip it!",
-                           gpu_device->super.name, gpu_device->super.name);
+            parsec_warning("GPU[%d:%s] Cannot allocate memory on GPU %s. Skip it!",
+                           gpu_device->super.device_index, gpu_device->super.name, gpu_device->super.name);
             return PARSEC_ERROR;
         }
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                            "GPU[%s] Allocate %u segments of size %d on the GPU memory",
-                             gpu_device->super.name, mem_elem_per_gpu, eltsize );
+                            "GPU[%d:%s] Allocate %u segments of size %d on the GPU memory",
+                            gpu_device->super.device_index, gpu_device->super.name, mem_elem_per_gpu, eltsize );
     }
 #endif
     gpu_device->mem_block_size = eltsize;
@@ -735,14 +735,14 @@ static void parsec_device_memory_release_list(parsec_device_gpu_module_t* gpu_de
         parsec_data_t* original = gpu_copy->original;
 
         PARSEC_DEBUG_VERBOSE(35, parsec_gpu_output_stream,
-                            "GPU[%s] Release GPU copy %p (device_ptr %p) [ref_count %d: must be 1], attached to %p, in map %p",
-                             gpu_device->super.name, gpu_copy, gpu_copy->device_private, gpu_copy->super.super.obj_reference_count,
+                            "GPU[%d:%s] Release GPU copy %p (device_ptr %p) [ref_count %d: must be 1], attached to %p, in map %p",
+                            gpu_device->super.device_index, gpu_device->super.name, gpu_copy, gpu_copy->device_private, gpu_copy->super.super.obj_reference_count,
                              original, (NULL != original ? original->dc : NULL));
         assert( gpu_copy->device_index == gpu_device->super.device_index );
 
         if( PARSEC_DATA_COHERENCY_OWNED == gpu_copy->coherency_state ) {
-            parsec_warning("GPU[%s] still OWNS the master memory copy for data %d and it is discarding it!",
-                          gpu_device->super.name, original->key);
+            parsec_warning("GPU[%d:%s] still OWNS the master memory copy for data %d and it is discarding it!",
+                           gpu_device->super.device_index, gpu_device->super.name, original->key);
         }
         assert(0 != (gpu_copy->flags & PARSEC_DATA_FLAG_PARSEC_OWNED) );
 
@@ -790,8 +790,8 @@ parsec_device_flush_lru( parsec_device_module_t *device )
     parsec_device_free_workspace(gpu_device);
 #if !defined(PARSEC_GPU_ALLOC_PER_TILE) && !defined(_NDEBUG)
     if( (in_use = zone_in_use(gpu_device->memory)) != 0 ) {
-        parsec_warning("GPU[%s] memory leak detected: %lu bytes still allocated on GPU",
-                       device->name, in_use);
+        parsec_warning("GPU[%d:%s] memory leak detected: %lu bytes still allocated on GPU",
+                       device->device_index, device->name, in_use);
         zone_debug(gpu_device->memory, 0, parsec_gpu_output_stream, "flush_lru: ");
         assert(!in_use);
     }
@@ -823,7 +823,8 @@ parsec_device_memory_release( parsec_device_gpu_module_t* gpu_device )
     void* ptr = zone_malloc_fini(&gpu_device->memory);
     rc = gpu_device->memory_free(gpu_device, ptr);
     if(PARSEC_SUCCESS != rc) {
-        parsec_warning("Failed to free the GPU backend memory.");
+        parsec_warning("GPU[%d:%s]: Failed to free the GPU backend memory.",
+                       gpu_device->super.device_index, gpu_device->super.name);
         return rc;
     }
 #endif
@@ -872,8 +873,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
         if(PARSEC_FLOW_ACCESS_NONE == (PARSEC_FLOW_ACCESS_MASK & flow->flow_flags)) continue;
 
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:%s: Investigating flow %s:%d",
-                             gpu_device->super.name, task_name, flow->name, i);
+                             "GPU[%d:%s]:%s: Investigating flow %s:%d",
+                             gpu_device->super.device_index, gpu_device->super.name, task_name, flow->name, i);
         temp_loc[i] = NULL;
         if (this_task->data[i].data_in == NULL)
             continue;
@@ -886,8 +887,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
         /* There is already a copy on the device */
         if( NULL != gpu_elem ) {
             PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                 "GPU[%s]:%s: Flow %s:%i has a copy on the device %p%s",
-                                 gpu_device->super.name, task_name,
+                                 "GPU[%d:%s]:%s: Flow %s:%i has a copy on the device %p%s",
+                                 gpu_device->super.device_index, gpu_device->super.name, task_name,
                                  flow->name, i, gpu_elem,
                                  gpu_elem->data_transfer_status == PARSEC_DATA_STATUS_UNDER_TRANSFER ? " [in transfer]" : "");
             if ( gpu_elem->data_transfer_status == PARSEC_DATA_STATUS_UNDER_TRANSFER ) {
@@ -904,8 +905,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
 #if !defined(PARSEC_GPU_ALLOC_PER_TILE)
         gpu_elem = PARSEC_OBJ_NEW(parsec_data_copy_t);
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:%s: Allocate GPU copy %p sz %zu [ref_count %d] for data %p",
-                             gpu_device->super.name, task_name,
+                             "GPU[%d:%s]:%s: Allocate GPU copy %p sz %zu [ref_count %d] for data %p",
+                             gpu_device->super.device_index, gpu_device->super.name, task_name,
                              gpu_elem, gpu_task->flow_nb_elts[i], gpu_elem->super.super.obj_reference_count, master);
         gpu_elem->flags = PARSEC_DATA_FLAG_PARSEC_OWNED | PARSEC_DATA_FLAG_PARSEC_MANAGED;
     malloc_data:
@@ -926,8 +927,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
             release_temp_and_return:
 #if defined(PARSEC_DEBUG_NOISIER)
                 PARSEC_DEBUG_VERBOSE(2, parsec_gpu_output_stream,
-                                     "GPU[%s]:%s:\tRequest space on GPU failed for flow %s index %d/%d for task %s",
-                                     gpu_device->super.name, task_name,
+                                     "GPU[%d:%s]:%s:\tRequest space on GPU failed for flow %s index %d/%d for task %s",
+                                     gpu_device->super.device_index, gpu_device->super.name, task_name,
                                      flow->name, i, this_task->task_class->nb_flows, task_name );
 #endif  /* defined(PARSEC_DEBUG_NOISIER) */
                 for( j = 0; j <= i; j++ ) {
@@ -936,8 +937,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
                     /* This flow could be non-parsec-owned, in which case we can't reclaim it */
                     if( 0 == (temp_loc[j]->flags & PARSEC_DATA_FLAG_PARSEC_OWNED) ) continue;
                     PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                         "GPU[%s]:%s:\tAdd copy %p [ref_count %d] back to the LRU list",
-                                         gpu_device->super.name, task_name,
+                                         "GPU[%d:%s]:%s:\tAdd copy %p [ref_count %d] back to the LRU list",
+                                         gpu_device->super.device_index, gpu_device->super.name, task_name,
                                          temp_loc[j], temp_loc[j]->super.super.obj_reference_count);
                     /* push them at the head to reach them again at the next iteration */
                     parsec_list_push_front(&gpu_device->gpu_mem_lru, (parsec_list_item_t*)temp_loc[j]);
@@ -951,15 +952,15 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
 
             PARSEC_LIST_ITEM_SINGLETON(lru_gpu_elem);
             PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                 "GPU[%s]:%s: Evaluate LRU-retrieved GPU copy %p [ref_count %d] original %p",
-                                 gpu_device->super.name, task_name,
+                                 "GPU[%d:%s]:%s: Evaluate LRU-retrieved GPU copy %p [ref_count %d] original %p",
+                                 gpu_device->super.device_index, gpu_device->super.name, task_name,
                                  lru_gpu_elem, lru_gpu_elem->super.super.obj_reference_count,
                                  lru_gpu_elem->original);
 
             if( gpu_mem_lru_cycling == lru_gpu_elem ) {
                 PARSEC_DEBUG_VERBOSE(2, parsec_gpu_output_stream,
-                                     "GPU[%s]: Cycle detected on allocating memory for %s",
-                                     gpu_device->super.name, task_name);
+                                     "GPU[%d:%s]: Cycle detected on allocating memory for %s",
+                                     gpu_device->super.device_index, gpu_device->super.name, task_name);
                 temp_loc[i] = lru_gpu_elem;  /* save it such that it gets pushed back into the LRU */
                 goto release_temp_and_return;
             }
@@ -970,8 +971,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
              */
             if( 0 != lru_gpu_elem->readers ) {
                 PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                     "GPU[%s]:%s: Drop LRU-retrieved GPU copy %p [readers %d, ref_count %d] original %p",
-                                     gpu_device->super.name, task_name,
+                                     "GPU[%d:%s]:%s: Drop LRU-retrieved GPU copy %p [readers %d, ref_count %d] original %p",
+                                     gpu_device->super.device_index, gpu_device->super.name, task_name,
                                      lru_gpu_elem, lru_gpu_elem->readers, lru_gpu_elem->super.super.obj_reference_count, lru_gpu_elem->original);
                 /* We do not add the copy back into the LRU. This means that for now this copy is not
                  * tracked via the LRU (despite being only used in read mode) and instead is dangling
@@ -994,8 +995,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
                  * LRU is only modified by a single thread (in this case the current thread).
                  */
                 PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                     "GPU[%s]:%s: Push back LRU-retrieved GPU copy %p [readers %d, ref_count %d] original %p",
-                                     gpu_device->super.name, task_name,
+                                     "GPU[%d:%s]:%s: Push back LRU-retrieved GPU copy %p [readers %d, ref_count %d] original %p",
+                                     gpu_device->super.device_index, gpu_device->super.name, task_name,
                                      lru_gpu_elem, lru_gpu_elem->readers, lru_gpu_elem->super.super.obj_reference_count, lru_gpu_elem->original);
                 assert(0 != (lru_gpu_elem->flags & PARSEC_DATA_FLAG_PARSEC_OWNED) );
                 parsec_list_push_back(&gpu_device->gpu_mem_lru, &lru_gpu_elem->super);
@@ -1021,8 +1022,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
                     if( NULL == this_task->data[j].data_in ) continue;
                     if( this_task->data[j].data_in->original == oldmaster ) {
                         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                             "GPU[%s]:%s: Drop LRU-retrieved GPU copy %p [ref_count %d] already in use by same task %d:%d original %p",
-                                             gpu_device->super.name, task_name,
+                                             "GPU[%d:%s]:%s: Drop LRU-retrieved GPU copy %p [ref_count %d] already in use by same task %d:%d original %p",
+                                             gpu_device->super.device_index, gpu_device->super.name, task_name,
                                              lru_gpu_elem, lru_gpu_elem->super.super.obj_reference_count, i, j, lru_gpu_elem->original);
                         /* If we are the owner of this tile we need to make sure it remains available for
                          * other tasks or we run in deadlock situations.
@@ -1042,8 +1043,8 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
                     parsec_list_push_back(&gpu_device->gpu_mem_lru, &lru_gpu_elem->super);
                     gpu_mem_lru_cycling = (NULL == gpu_mem_lru_cycling) ? lru_gpu_elem : gpu_mem_lru_cycling;  /* update the cycle detector */
                     PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                         "GPU[%s]:%s: Push back LRU-retrieved GPU copy %p [readers %d, ref_count %d] original %p : Concurrent accesses",
-                                         gpu_device->super.name, task_name,
+                                         "GPU[%d:%s]:%s: Push back LRU-retrieved GPU copy %p [readers %d, ref_count %d] original %p : Concurrent accesses",
+                                         gpu_device->super.device_index, gpu_device->super.name, task_name,
                                          lru_gpu_elem, lru_gpu_elem->readers, lru_gpu_elem->super.super.obj_reference_count,
                                          lru_gpu_elem->original);
                     parsec_atomic_unlock( &oldmaster->lock );
@@ -1061,21 +1062,21 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
                 /* The data is not used, it's not one of ours, and it has been detached from the device
                  * so no other device can use it as a source for their copy : we can free it or reuse it */
                 PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                     "GPU[%s]:%s:\ttask %s:%d repurpose copy %p [ref_count %d] to data %p instead of %p",
-                                     gpu_device->super.name, task_name, this_task->task_class->name, i, lru_gpu_elem,
+                                     "GPU[%d:%s]:%s:\ttask %s:%d repurpose copy %p [ref_count %d] to data %p instead of %p",
+                                     gpu_device->super.device_index, gpu_device->super.name, task_name, this_task->task_class->name, i, lru_gpu_elem,
                                      lru_gpu_elem->super.super.obj_reference_count, master, oldmaster);
             }
             else {
                 PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                     "GPU[%s]:%s:\ttask %s:%d found detached memory from previously destructed data %p",
-                                     gpu_device->super.name, task_name, this_task->task_class->name, i, lru_gpu_elem);
+                                     "GPU[%d:%s]:%s:\ttask %s:%d found detached memory from previously destructed data %p",
+                                     gpu_device->super.device_index, gpu_device->super.name, task_name, this_task->task_class->name, i, lru_gpu_elem);
                 oldmaster = NULL;
             }
 #if !defined(PARSEC_GPU_ALLOC_PER_TILE)
             /* Let's free this space, and try again to malloc some space */
             PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                 "GPU[%s] Release GPU copy %p (device_ptr %p) [ref_count %d: must be 1], attached to %p",
-                                 gpu_device->super.name,
+                                 "GPU[%d:%s] Release GPU copy %p (device_ptr %p) [ref_count %d: must be 1], attached to %p",
+                                 gpu_device->super.device_index, gpu_device->super.name,
                                  lru_gpu_elem, lru_gpu_elem->device_private, lru_gpu_elem->super.super.obj_reference_count,
                                  oldmaster);
 #if defined(PARSEC_PROF_TRACE)
@@ -1097,16 +1098,16 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
             lru_gpu_elem->device_private = NULL;
             data_avail_epoch++;
             PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                                 "GPU[%s]:%s: Release LRU-retrieved GPU copy %p [ref_count %d: must be 1]",
-                                 gpu_device->super.name, task_name,
+                                 "GPU[%d:%s]:%s: Release LRU-retrieved GPU copy %p [ref_count %d: must be 1]",
+                                 gpu_device->super.device_index, gpu_device->super.name, task_name,
                                  lru_gpu_elem, lru_gpu_elem->super.super.obj_reference_count);
             PARSEC_OBJ_RELEASE(lru_gpu_elem);
             assert( NULL == lru_gpu_elem );
             goto malloc_data;
         }
         PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                             "GPU[%s] Succeeded Allocating GPU copy %p at real address %p [ref_count %d] for data %p",
-                             gpu_device->super.name,
+                             "GPU[%d:%s] Succeeded Allocating GPU copy %p at real address %p [ref_count %d] for data %p",
+                             gpu_device->super.device_index, gpu_device->super.name,
                              gpu_elem, gpu_elem->device_private, gpu_elem->super.super.obj_reference_count, master);
 #if defined(PARSEC_PROF_TRACE)
         if((gpu_device->trackable_events & PARSEC_PROFILE_GPU_TRACK_MEM_USE) &&
@@ -1136,18 +1137,17 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
         gpu_elem->coherency_state = PARSEC_DATA_COHERENCY_INVALID;
         gpu_elem->version = UINT_MAX;  /* scrap value for now */
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                             "GPU[%s]: GPU copy %p [ref_count %d] gets created with version 0 at %s:%d",
-                             gpu_device->super.name,
-                             gpu_elem, gpu_elem->super.super.obj_reference_count,
-                             __FILE__, __LINE__);
+                             "GPU[%d:%s]: GPU copy %p [ref_count %d] gets created with version 0",
+                             gpu_device->super.device_index, gpu_device->super.name,
+                             gpu_elem, gpu_elem->super.super.obj_reference_count);
         parsec_data_copy_attach(master, gpu_elem, gpu_device->super.device_index);
         this_task->data[i].data_out = gpu_elem;
         /* set the new datacopy type to the correct one */
         this_task->data[i].data_out->dtt = this_task->data[i].data_in->dtt;
         temp_loc[i] = gpu_elem;
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:%s: Retain and insert GPU copy %p [ref_count %d] in LRU",
-                             gpu_device->super.name, task_name,
+                             "GPU[%d:%s]:%s: Retain and insert GPU copy %p [ref_count %d] in LRU",
+                             gpu_device->super.device_index, gpu_device->super.name, task_name,
                              gpu_elem, gpu_elem->super.super.obj_reference_count);
         assert(0 != (gpu_elem->flags & PARSEC_DATA_FLAG_PARSEC_OWNED) );
         parsec_atomic_unlock(&master->lock);
@@ -1282,8 +1282,8 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
 
     if( gpu_task->task_type == PARSEC_GPU_TASK_TYPE_PREFETCH ) {
         PARSEC_DEBUG_VERBOSE(5, parsec_gpu_output_stream,
-                             "GPU[%s]: Prefetch task %p is staging in",
-                             gpu_device->super.name, gpu_task);
+                             "GPU[%d:%s]: Prefetch task %p is staging in",
+                             gpu_device->super.device_index, gpu_device->super.name, gpu_task);
     }
 
     parsec_atomic_lock( &original->lock );
@@ -1296,15 +1296,14 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
     if( PARSEC_FLOW_ACCESS_WRITE & type ) {
         if (gpu_elem->readers > 0 ) {
             if( !((1 == gpu_elem->readers) && (PARSEC_FLOW_ACCESS_READ & type)) ) {
-                parsec_warning("GPU[%s]:\tWrite access to data copy %p [ref_count %d] with existing readers [%d] "
-                               "(possible anti-dependency,\n"
-                               "or concurrent accesses), please prevent that with CTL dependencies\n",
-                               gpu_device->super.name, gpu_elem, gpu_elem->super.super.obj_reference_count, gpu_elem->readers);
+                parsec_warning("GPU[%d:%s]:\tWrite access to data copy %p [ref_count %d] with existing readers [%d]\n"
+                               "\tPossible anti-dependency, or concurrent accesses: please prevent that with CTL dependencies\n",
+                               gpu_device->super.device_index, gpu_device->super.name, gpu_elem, gpu_elem->super.super.obj_reference_count, gpu_elem->readers);
             }
         }
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:\tDetach writable GPU copy %p [ref_count %d] from any lists",
-                             gpu_device->super.name, gpu_elem, gpu_elem->super.super.obj_reference_count);
+                             "GPU[%d:%s]:\tDetach writable GPU copy %p [ref_count %d] from any lists",
+                             gpu_device->super.device_index, gpu_device->super.name, gpu_elem, gpu_elem->super.super.obj_reference_count);
         /* make sure the element is not in any tracking lists */
         parsec_list_item_ring_chop((parsec_list_item_t*)gpu_elem);
         PARSEC_LIST_ITEM_SINGLETON(gpu_elem);
@@ -1335,8 +1334,8 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
         }
 
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                             "GPU[%s]:\t\tNO Move for data copy %p v%d [ref_count %d, key %x]",
-                             gpu_device->super.name,
+                             "GPU[%d:%s]:\t\tNO Move for data copy %p v%d [ref_count %d, key %x]",
+                             gpu_device->super.device_index, gpu_device->super.name,
                              gpu_elem, gpu_elem->version, gpu_elem->super.super.obj_reference_count, original->key);
         parsec_atomic_unlock( &original->lock );
         /* TODO: data keeps the same coherence flags as before */
@@ -1346,8 +1345,8 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
      * This happens if the task refers twice (or more) to the same input flow */
     if( gpu_elem->data_transfer_status == PARSEC_DATA_STATUS_UNDER_TRANSFER ) {
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                             "GPU[%s]:\t\tMove data copy %p [ref_count %d, key %x] of %zu bytes: data copy is already under transfer, ignoring double request",
-                             gpu_device->super.name,
+                             "GPU[%d:%s]:\t\tMove data copy %p [ref_count %d, key %x] of %zu bytes: data copy is already under transfer, ignoring double request",
+                             gpu_device->super.device_index, gpu_device->super.name,
                              gpu_elem, gpu_elem->super.super.obj_reference_count, original->key, nb_elts);
         parsec_atomic_unlock( &original->lock );
         return 1;  /* positive returns have special meaning and are used for optimizations */
@@ -1359,14 +1358,14 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
     if( (PARSEC_FLOW_ACCESS_READ & type) && !(PARSEC_FLOW_ACCESS_WRITE & type) ) {
         int potential_alt_src = 0;
         PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                             "GPU[%s]:\tSelecting candidate data copy %p [ref_count %d] on data %p",
-                             gpu_device->super.name, task_data->data_in, task_data->data_in->super.super.obj_reference_count, original);
+                             "GPU[%d:%s]:\tSelecting candidate data copy %p [ref_count %d] on data %p",
+                             gpu_device->super.device_index, gpu_device->super.name, task_data->data_in, task_data->data_in->super.super.obj_reference_count, original);
         if( gpu_device->super.type == candidate_dev->super.type ) {
             if( gpu_device->peer_access_mask & (1 << candidate_dev->super.device_index) ) {
                 /* We can directly do D2D, so let's skip the selection */
                 PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                                     "GPU[%s]:\tskipping candidate lookup: data_in copy %p on %s has PEER ACCESS",
-                                     gpu_device->super.name, task_data->data_in, candidate_dev->super.name);
+                                     "GPU[%d:%s]:\tskipping candidate lookup: data_in copy %p on %s has PEER ACCESS",
+                                     gpu_device->super.device_index, gpu_device->super.name, task_data->data_in, candidate_dev->super.name);
                 goto src_selected;
             }
         }
@@ -1375,8 +1374,8 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
          * and we're not going to transfer from another source, skip the selection */
         if( gpu_elem->coherency_state != PARSEC_DATA_COHERENCY_INVALID ) {
             PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                                 "GPU[%s]:\tskipping candidate lookup: VALID COPY for %p already on this GPU at %p",
-                                 gpu_device->super.name, task_data->data_in, gpu_elem);
+                                 "GPU[%d:%s]:\tskipping candidate lookup: VALID COPY for %p already on this GPU at %p",
+                                 gpu_device->super.device_index, gpu_device->super.name, task_data->data_in, gpu_elem);
             goto src_selected;
         }
 
@@ -1384,8 +1383,8 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
             parsec_device_gpu_module_t *target = (parsec_device_gpu_module_t*)parsec_mca_device_get(t);
             if( !(gpu_device->peer_access_mask & (1 << target->super.device_index)) ) {
                 PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                                     "GPU[%s]:\tskipping device: %s has NO PEER ACCESS",
-                                     gpu_device->super.name, target->super.name);
+                                     "GPU[%d:%s]:\tskipping device: %s has NO PEER ACCESS",
+                                     gpu_device->super.device_index, gpu_device->super.name, target->super.name);
                 continue;
             }
             assert( PARSEC_DEV_IS_GPU(target->super.type) );
@@ -1393,23 +1392,23 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
             candidate = original->device_copies[t];
             if( (NULL == candidate) || (candidate->version != task_data->data_in->version) ) {
                 PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,
-                                     "GPU[%s]:\tcopy %p:%d cannot be a candidate VERSION MISMATCH with %p:%d",
-                                     gpu_device->super.name,
+                                     "GPU[%d:%s]:\tcopy %p:%d cannot be a candidate VERSION MISMATCH with %p:%d",
+                                     gpu_device->super.device_index, gpu_device->super.name,
                                      candidate, candidate?(int)candidate->version:-1, task_data->data_in, task_data->data_in->version);
                 continue;
             }
 
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "GPU[%s]:\tData copy %p [ref_count %d] on GPU device %d is a potential alternative source for data_in %p on data %p",
-                                 gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.device_index, task_data->data_in, original);
+                                 "GPU[%d:%s]:\tData copy %p [ref_count %d] on GPU device %d is a potential alternative source for data_in %p on data %p",
+                                 gpu_device->super.device_index, gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.device_index, task_data->data_in, original);
             if(PARSEC_DATA_COHERENCY_INVALID == candidate->coherency_state) {
                 /* We're already pulling this data on candidate...
                  * If there is another candidate that already has it, we'll use
                  * that one; otherwise, we'll fall back on the CPU version. */
                 potential_alt_src = 1;
                 PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                     "GPU[%s]:\tData copy %p [ref_count %d] on GPU device %d is invalid, continuing to look for alternatives",
-                                     gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.device_index);
+                                     "GPU[%d:%s]:\tData copy %p [ref_count %d] on GPU device %d is invalid, continuing to look for alternatives",
+                                     gpu_device->super.device_index, gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.device_index);
                 continue;
             }
             /* We have a candidate for the d2d transfer. */
@@ -1421,15 +1420,15 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
                  */
                 if( (candidate->original == original) && (candidate->version == task_data->data_in->version) ) {
                     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                         "GPU[%s]:\tData copy %p [ref_count %d] on PaRSEC device %s is the best candidate to do Device to Device copy, increasing its readers to %d",
-                                         gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.name, candidate->readers+1);
+                                         "GPU[%d:%s]:\tData copy %p [ref_count %d] on PaRSEC device %s is the best candidate to do Device to Device copy, increasing its readers to %d",
+                                         gpu_device->super.device_index, gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.name, candidate->readers+1);
                     candidate_dev = target;
                     goto src_selected;
                 }
             }
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "GPU[%s]:\tCandidate %p [ref_count %d] on PaRSEC device %s is being repurposed by owner device. Looking for another candidate",
-                                 gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.name);
+                                 "GPU[%d:%s]:\tCandidate %p [ref_count %d] on PaRSEC device %s is being repurposed by owner device. Looking for another candidate",
+                                 gpu_device->super.device_index, gpu_device->super.name, candidate, candidate->super.super.obj_reference_count, target->super.name);
             /* We are trying to use a candidate that is repurposed by the owner device. Let's find another one */
             parsec_atomic_fetch_add_int32(&candidate->readers, -1);
         }
@@ -1439,8 +1438,8 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
             /** TODO: when considering RW accesses, don't forget to chop gpu_elem
              *        from its queue... */
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "GPU[%s]:\tThere is a potential alternative source for data_in %p [ref_count %d] in original %p to go in copy %p [ref_count %d], but it is not ready, falling back on CPU source",
-                                 gpu_device->super.name, task_data->data_in, task_data->data_in->super.super.obj_reference_count, original, gpu_elem, gpu_elem->super.super.obj_reference_count);
+                                 "GPU[%d:%s]:\tThere is a potential alternative source for data_in %p [ref_count %d] in original %p to go in copy %p [ref_count %d], but it is not ready, falling back on CPU source",
+                                 gpu_device->super.device_index, gpu_device->super.name, task_data->data_in, task_data->data_in->super.super.obj_reference_count, original, gpu_elem, gpu_elem->super.super.obj_reference_count);
             //return PARSEC_HOOK_RETURN_NEXT;
         }
 
@@ -1450,8 +1449,8 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
 
  src_selected:
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                         "GPU[%s]:\t\tMove %s data copy %p [ref_count %d, key %x] of %zu bytes\t(src dev: %d, v:%d, ptr:%p, copy:%p [ref_count %d, under_transfer: %d, coherency_state: %d] / dst dev: %d, v:%d, ptr:%p)",
-                         gpu_device->super.name,
+                         "GPU[%d:%s]:\t\tMove %s data copy %p [ref_count %d, key %x] of %zu bytes\t(src dev: %d, v:%d, ptr:%p, copy:%p [ref_count %d, under_transfer: %d, coherency_state: %d] / dst dev: %d, v:%d, ptr:%p)",
+                         gpu_device->super.device_index, gpu_device->super.name,
                          PARSEC_DEV_IS_GPU(candidate_dev->super.type) ? "D2D": "H2D",
                          gpu_elem, gpu_elem->super.super.obj_reference_count, original->key, nb_elts,
                          candidate_dev->super.device_index, candidate->version, (void*)candidate->device_private,
@@ -1504,18 +1503,14 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
 #endif
     gpu_task->sources[flow->flow_index] = candidate;  /* save the candidate for release on transfer completion */
     /* Push data into the GPU from the source device */
-    if(PARSEC_SUCCESS != (gpu_task->stage_in ? gpu_task->stage_in(gpu_task, (1U << flow->flow_index), gpu_stream): PARSEC_SUCCESS)) {
-        parsec_warning( "%s:%d %s", __FILE__, __LINE__, "gpu_task->stage_in");
-        if( candidate_dev->super.type != gpu_device->super.type ) {
-            parsec_warning("<<%p>> -> <<%p on GPU device %d>> [%zu, H2D]",
-                           candidate->device_private, gpu_elem->device_private, gpu_device->super.device_index,
-                           nb_elts);
-        } else {
-            parsec_warning("<<%p on GPU device %d>> -> <<%p on GPU device %d>> [%zu, D2D]",
-                           candidate->device_private, candidate_dev->super.device_index,
-                           gpu_elem->device_private, gpu_device->super.device_index,
-                           nb_elts);
-        }
+    int rc = gpu_task->stage_in ? gpu_task->stage_in(gpu_task, (1U << flow->flow_index), gpu_stream): PARSEC_SUCCESS;
+    if(PARSEC_SUCCESS != rc) {
+        parsec_warning( "GPU[%d:%s]: gpu_task->stage_in to device rc=%d @%s:%d\n"
+                        "\t<<%p on device %d:%s>> -> <<%p on device %d:%s>> [%zu, %s]",
+                        gpu_device->super.device_index, gpu_device->super.name, rc, __func__, __LINE__,
+                        candidate->device_private, candidate_dev->super.device_index, candidate_dev->super.name,
+                        gpu_elem->device_private, gpu_device->super.device_index, gpu_device->super.name,
+                        nb_elts, (candidate_dev->super.type != gpu_device->super.type)? "H2D": "D2D");
         parsec_atomic_unlock( &original->lock );
         assert(0);
         return PARSEC_HOOK_RETURN_ERROR;
@@ -1536,10 +1531,9 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
         gpu_elem->version = candidate->version;
     gpu_elem->data_transfer_status = PARSEC_DATA_STATUS_UNDER_TRANSFER;
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                         "GPU[%s]: GPU copy %p [ref_count %d] gets the version %d from copy %p version %d [ref_count %d] at %s:%d",
-                         gpu_device->super.name,
-                         gpu_elem, gpu_elem->super.super.obj_reference_count, gpu_elem->version, candidate, candidate->version, candidate->super.super.obj_reference_count,
-                         __FILE__, __LINE__);
+                         "GPU[%d:%s]: GPU copy %p [ref_count %d] gets the version %d from copy %p version %d [ref_count %d]",
+                         gpu_device->super.device_index, gpu_device->super.name,
+                         gpu_elem, gpu_elem->super.super.obj_reference_count, gpu_elem->version, candidate, candidate->version, candidate->super.super.obj_reference_count);
 
     parsec_atomic_unlock( &original->lock );
     return 1;  /* positive returns have special meaning and are used for optimizations */
@@ -1621,11 +1615,11 @@ parsec_device_send_transfercomplete_cmd_to_device(parsec_data_copy_t *copy,
 #endif
     (void)current_dev;
     PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,
-                         "GPU[%s]: data copy %p [ref_count %d] D2D transfer is complete, sending order to count it "
-                         "to GPU Device %s",
-                         current_dev->name, gpu_task->ec->data[0].data_out,
+                         "GPU[%d:%s]: data copy %p [ref_count %d] D2D transfer is complete, sending order to count it "
+                         "to GPU Device %d:%s",
+                         current_dev->device_index, current_dev->name, gpu_task->ec->data[0].data_out,
                          gpu_task->ec->data[0].data_out->super.super.obj_reference_count,
-                         dst_dev->name);
+                         dst_dev->device_index, dst_dev->name);
     parsec_fifo_push( &(((parsec_device_gpu_module_t*)dst_dev)->pending), (parsec_list_item_t*)gpu_task );
 }
 
@@ -1652,8 +1646,8 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
     assert(gpu_stream == gpu_device->exec_stream[0]);
     task = gtask->ec;
     PARSEC_DEBUG_VERBOSE(19, parsec_gpu_output_stream,
-                         "GPU[%s]: parsec_device_callback_complete_push, PUSH of %s",
-                         gpu_device->super.name, parsec_task_snprintf(task_str, MAX_TASK_STRLEN, task));
+                         "GPU[%d:%s]: parsec_device_callback_complete_push, PUSH of %s",
+                         gpu_device->super.device_index, gpu_device->super.name, parsec_task_snprintf(task_str, MAX_TASK_STRLEN, task));
 
     for( i = 0; i < task->task_class->nb_flows; i++ ) {
         /* Make sure data_in is not NULL */
@@ -1724,16 +1718,16 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
                     parsec_atomic_lock( &source->original->lock );
                     int readers = parsec_atomic_fetch_sub_int32(&source->readers, 1) - 1;
                     PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                         "GPU[%s]:\tExecuting D2D transfer complete for copy %p [ref_count %d] for "
+                                         "GPU[%d:%s]:\tExecuting D2D transfer complete for copy %p [ref_count %d] for "
                                          "device %s -- readers now %d",
-                                         gpu_device->super.name, source,
+                                         gpu_device->super.device_index, gpu_device->super.name, source,
                                          source->super.super.obj_reference_count, src_device->super.name,
                                          readers);
                     assert(readers >= 0);
                     if(0 == readers) {
                         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                             "GPU[%s]:\tMake read-only copy %p [ref_count %d] available",
-                                             gpu_device->super.name, source,
+                                             "GPU[%d:%s]:\tMake read-only copy %p [ref_count %d] available",
+                                             gpu_device->super.device_index, gpu_device->super.name, source,
                                              source->super.super.obj_reference_count);
                         parsec_list_item_ring_chop((parsec_list_item_t*)source);
                         PARSEC_LIST_ITEM_SINGLETON(source);
@@ -1746,9 +1740,9 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
                     assert(rc);
                 } else {
                     PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                         "GPU[%s]:\tSending D2D transfer complete command to %s for copy %p "
+                                         "GPU[%d:%s]:\tSending D2D transfer complete command to %s for copy %p "
                                          "[ref_count %d] -- readers is still %d",
-                                         gpu_device->super.name, src_device->super.name, source,
+                                         gpu_device->super.device_index, gpu_device->super.name, src_device->super.name, source,
                                          source->super.super.obj_reference_count, source->readers);
                     parsec_device_send_transfercomplete_cmd_to_device(source,
                                                                       (parsec_device_module_t*)gpu_device,
@@ -1758,8 +1752,8 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
             continue;
         }
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:\tparsec_device_callback_complete_push, PUSH of %s: task->data[%d].data_out = %p [ref_count = %d], and %s because transfer_status is %d",
-                             gpu_device->super.name, parsec_task_snprintf(task_str, MAX_TASK_STRLEN, task),
+                             "GPU[%d:%s]:\tparsec_device_callback_complete_push, PUSH of %s: task->data[%d].data_out = %p [ref_count = %d], and %s because transfer_status is %d",
+                             gpu_device->super.device_index, gpu_device->super.name, parsec_task_snprintf(task_str, MAX_TASK_STRLEN, task),
                              i, task->data[i].data_out, task->data[i].data_out->super.super.obj_reference_count,
                              (task->data[i].data_out->data_transfer_status != PARSEC_DATA_STATUS_UNDER_TRANSFER) ? "all is good" : "Assertion",
                              task->data[i].data_out->data_transfer_status);
@@ -1784,8 +1778,8 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
             snprintf(tmp, MAX_TASK_STRLEN, "unbound data");
 #endif
         PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,
-                             "GPU[%s]:\tPrefetch for data copy %p [ref_count %d] (%s) done. readers = %d, device_index = %d, version = %d, flags = %d, state = %d, data_transfer_status = %d",
-                             gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count,
+                             "GPU[%d:%s]:\tPrefetch for data copy %p [ref_count %d] (%s) done. readers = %d, device_index = %d, version = %d, flags = %d, state = %d, data_transfer_status = %d",
+                             gpu_device->super.device_index, gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count,
                              tmp,
                              gpu_copy->readers, gpu_copy->device_index, gpu_copy->version,
                              gpu_copy->flags, gpu_copy->coherency_state, gpu_copy->data_transfer_status);
@@ -1794,8 +1788,8 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
             parsec_list_item_ring_chop((parsec_list_item_t*)gpu_copy);
             PARSEC_LIST_ITEM_SINGLETON(gpu_copy);
             PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,
-                                 "GPU[%s]:\tMake copy %p [ref_count %d] available after prefetch from gpu_task %p, ec %p",
-                                 gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, gtask, gtask->ec);
+                                 "GPU[%d:%s]:\tMake copy %p [ref_count %d] available after prefetch from gpu_task %p, ec %p",
+                                 gpu_device->super.device_index, gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, gtask, gtask->ec);
             parsec_list_push_back(&gpu_device->gpu_mem_lru, (parsec_list_item_t*)gpu_copy);
         }
         (void)parsec_device_release_resources_prefetch_task(gpu_device, gpu_task);
@@ -1848,10 +1842,10 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
             /* Save the task for the next step */
             task = *out_task = stream->tasks[stream->end];
             PARSEC_DEBUG_VERBOSE(19, parsec_gpu_output_stream,
-                                 "GPU[%s]: Completed %s priority %d on stream %s{%p}",
-                                 gpu_device->super.name,
+                                 "GPU[%d:%s]: Completed %s on stream %s{%p}",
+                                 gpu_device->super.device_index, gpu_device->super.name,
                                  parsec_task_snprintf(task_str, MAX_TASK_STRLEN, task->ec),
-                                 task->ec->priority, stream->name, (void*)stream);
+                                 stream->name, (void*)stream);
             stream->tasks[stream->end]    = NULL;
             stream->end = (stream->end + 1) % stream->max_events;
 
@@ -1865,8 +1859,8 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
             if( PARSEC_HOOK_RETURN_AGAIN == task->last_status ) {
                 /* we can now reschedule the task on the same execution stream */
                 PARSEC_DEBUG_VERBOSE(2, parsec_gpu_output_stream,
-                                     "GPU[%s]: GPU task %p[%p] is ready to be rescheduled on the same GPU device and same stream",
-                                     gpu_device->super.name, (void*)task, (void*)task->ec);
+                                     "GPU[%d:%s]: GPU task %p[%p] is ready to be rescheduled on the same GPU device and same stream",
+                                     gpu_device->super.device_index, gpu_device->super.name, (void*)task, (void*)task->ec);
                 *out_task = NULL;
                 goto schedule_task;
             }
@@ -1909,9 +1903,9 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
          * execution stream pending list (to be executed again).
          */
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                             "GPU[%s]: GPU task %p has returned with ASYNC or AGAIN. Once the event "
+                             "GPU[%d:%s]: GPU task %p has returned with ASYNC or AGAIN. Once the event "
                              "trigger the task will be handled accordingly",
-                             gpu_device->super.name, (void*)task);
+                             gpu_device->super.device_index, gpu_device->super.name, (void*)task);
     }
     task->last_status = rc;
     /**
@@ -1925,9 +1919,9 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
     stream->tasks[stream->start] = task;
     stream->start = (stream->start + 1) % stream->max_events;
     PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                         "GPU[%s]: Submitted %s(task %p) priority %d on stream %s{%p}",
-                         gpu_device->super.name,
-                         task->ec->task_class->name, (void*)task->ec, task->ec->priority,
+                         "GPU[%d:%s]: Submitted %s(task %p) on stream %s{%p}",
+                         gpu_device->super.device_index, gpu_device->super.name,
+                         task->ec->task_class->name, (void*)task->ec,
                          stream->name, (void*)stream);
 
     task = NULL;
@@ -1962,16 +1956,16 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
     if( gpu_task->last_data_check_epoch == gpu_device->data_avail_epoch )
         return PARSEC_HOOK_RETURN_AGAIN;
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                         "GPU[%s]: Try to Push %s",
-                         gpu_device->super.name,
+                         "GPU[%d:%s]: Try to Push %s",
+                         gpu_device->super.device_index, gpu_device->super.name,
                          parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task) );
 
     if( PARSEC_GPU_TASK_TYPE_PREFETCH == gpu_task->task_type ) {
         if( NULL == gpu_task->ec->data[0].data_in->original ) {
             /* The PREFETCH order comes after the copy was detached and released, ignore it */
             PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,
-                                 "GPU[%s]: %s has been released already, destroying prefetch request",
-                                 gpu_device->super.name,
+                                 "GPU[%d:%s]: %s has been released already, destroying prefetch request",
+                                 gpu_device->super.device_index, gpu_device->super.name,
                                  parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task));
             parsec_device_release_resources_prefetch_task(gpu_device, &gpu_task);
             return PARSEC_HOOK_RETURN_ASYNC;
@@ -1980,8 +1974,8 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
             gpu_task->ec->data[0].data_in->original->owner_device == gpu_device->super.device_index ) {
             /* There is already a copy of this data in the GPU */
             PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,
-                                 "GPU[%s]: %s data_copy at index %d is %p, destroying prefetch request",
-                                 gpu_device->super.name,
+                                 "GPU[%d:%s]: %s data_copy at index %d is %p, destroying prefetch request",
+                                 gpu_device->super.device_index, gpu_device->super.name,
                                  parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task),
                                  gpu_device->super.device_index,
                                  gpu_task->ec->data[0].data_in->original->device_copies[gpu_device->super.device_index]);
@@ -2014,8 +2008,8 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
         assert( NULL != parsec_data_copy_get_ptr(this_task->data[i].data_in) );
 
         PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                             "GPU[%s]:\t\tIN  Data of %s <%x> on GPU",
-                             gpu_device->super.name, flow->name,
+                             "GPU[%d:%s]:\t\tIN  Data of %s <%x> on GPU",
+                             gpu_device->super.device_index, gpu_device->super.name, flow->name,
                              this_task->data[i].data_out->original->key);
         ret = parsec_device_data_stage_in( gpu_device, flow,
                                            &(this_task->data[i]), gpu_task, gpu_stream );
@@ -2026,8 +2020,8 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
     }
 
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                         "GPU[%s]: Push task %s DONE",
-                         gpu_device->super.name,
+                         "GPU[%d:%s]: Push task %s DONE",
+                         gpu_device->super.device_index, gpu_device->super.name,
                          parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task) );
     gpu_task->complete_stage = parsec_device_callback_complete_push;
 #if defined(PARSEC_PROF_TRACE)
@@ -2053,9 +2047,9 @@ parsec_device_kernel_exec( parsec_device_gpu_module_t      *gpu_device,
 
 #if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
-    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, "GPU[%s]:\tEnqueue on device %s stream %s priority %d"     ,
-                         gpu_device->super.name, parsec_task_snprintf(tmp, MAX_TASK_STRLEN,
-                         (parsec_task_t *) this_task), gpu_stream->name, this_task->priority);
+    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, "GPU[%d:%s]:\tEnqueue on device %s stream %s"     ,
+                         gpu_device->super.device_index, gpu_device->super.name, parsec_task_snprintf(tmp, MAX_TASK_STRLEN,
+                         (parsec_task_t *) this_task), gpu_stream->name);
 #endif /* defined(PARSEC_DEBUG_NOISIER) */
 #if defined(PARSEC_PROF_TRACE)
     if (gpu_stream->prof_event_track_enable &&
@@ -2106,7 +2100,7 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
     parsec_data_t              *original;
     size_t                      nb_elts;
     const parsec_flow_t        *flow;
-    int return_code = 0, how_many = 0, i, update_data_epoch = 0;
+    int return_code = 0, rc, how_many = 0, i, update_data_epoch = 0;
 #if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
 #endif
@@ -2117,10 +2111,12 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
             /* If the gpu copy is not owned by parsec, we don't manage it at all */
             if( 0 == (gpu_copy->flags & PARSEC_DATA_FLAG_PARSEC_OWNED) ) continue;
             original = gpu_copy->original;
-            if(PARSEC_SUCCESS != gpu_task->stage_out? gpu_task->stage_out(gpu_task, (1U << i), gpu_stream): PARSEC_SUCCESS){
-                parsec_warning( "%s:%d %s", __FILE__, __LINE__,
-                                "gpu_task->stage_out from device ");
-                parsec_warning("data %s <<%p>> -> <<%p>>\n", this_task->task_class->out[i]->name,
+            rc = gpu_task->stage_out? gpu_task->stage_out(gpu_task, (1U << i), gpu_stream): PARSEC_SUCCESS;
+            if(PARSEC_SUCCESS != rc) {
+                parsec_warning( "GPU[%d:%s]: gpu_task->stage_out from device rc=%d @%s:%d\n"
+                                "\tdata %s <<%p>> -> <<%p>>\n",
+                                gpu_device->super.device_index, gpu_device->super.name, rc, __func__, __LINE__,
+                                this_task->task_class->out[i]->name,
                                 gpu_copy->device_private, original->device_copies[0]->device_private);
                 return_code = PARSEC_HOOK_RETURN_DISABLE;
                 goto release_and_return_error;
@@ -2130,8 +2126,8 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
     }
 
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                        "GPU[%s]: Try to Pop %s",
-                        gpu_device->super.name,
+                        "GPU[%d:%s]: Try to Pop %s",
+                        gpu_device->super.device_index, gpu_device->super.name,
                         parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task) );
 
     for( i = 0; i < this_task->task_class->nb_flows; i++ ) {
@@ -2157,8 +2153,8 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
             /* Do not propagate GPU copies to successors (temporary solution) */
             this_task->data[i].data_out = original->device_copies[0];
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "GPU[%s]: pop %s swap %d GPU read-only data_out %p [ref_count %d] with the corresponding CPU copy %p [ref_count %d] original %p",
-                                     gpu_device->super.name,
+                                 "GPU[%d:%s]: pop %s swap %d GPU read-only data_out %p [ref_count %d] with the corresponding CPU copy %p [ref_count %d] original %p",
+                                 gpu_device->super.device_index, gpu_device->super.name,
                                      parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task), i,
                                      gpu_copy, gpu_copy->super.super.obj_reference_count,
                                      this_task->data[i].data_out, this_task->data[i].data_out->super.super.obj_reference_count,
@@ -2169,8 +2165,8 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
             int current_readers = parsec_atomic_fetch_sub_int32(&gpu_copy->readers, 1) - 1;
             if( current_readers < 0 ) {
                 PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                     "GPU[%s]: While trying to Pop %s, gpu_copy %p [ref_count %d] on flow %d with original %p had a negative number of readers (%d)",
-                                     gpu_device->super.name,
+                                     "GPU[%d:%s]: While trying to Pop %s, gpu_copy %p [ref_count %d] on flow %d with original %p had a negative number of readers (%d)",
+                                     gpu_device->super.device_index, gpu_device->super.name,
                                      parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task),
                                      gpu_copy, gpu_copy->super.super.obj_reference_count,
                                      i, original, current_readers);
@@ -2178,8 +2174,8 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
             assert(current_readers >= 0);
             if( (0 == current_readers) && !(flow->flow_flags & PARSEC_FLOW_ACCESS_WRITE) ) {
                  PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                     "GPU[%s]:\tMake read-only copy %p [ref_count %d] available on flow %s",
-                                     gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, flow->name);
+                                     "GPU[%d:%s]:\tMake read-only copy %p [ref_count %d] available on flow %s",
+                                     gpu_device->super.device_index, gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, flow->name);
                 parsec_list_item_ring_chop((parsec_list_item_t*)gpu_copy);
                 PARSEC_LIST_ITEM_SINGLETON(gpu_copy); /* TODO: singleton instead? */
                 parsec_list_push_back(&gpu_device->gpu_mem_lru, (parsec_list_item_t*)gpu_copy);
@@ -2188,15 +2184,15 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
                 continue;  /* done with this element, go for the next one */
             }
             PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                 "GPU[%s]:\tread copy %p [ref_count %d] on flow %s has readers (%i)",
-                                 gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, flow->name, current_readers);
+                                 "GPU[%d:%s]:\tread copy %p [ref_count %d] on flow %s has readers (%i)",
+                                 gpu_device->super.device_index, gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, flow->name, current_readers);
         }
         if( flow->flow_flags & PARSEC_FLOW_ACCESS_WRITE ) {
             assert( gpu_copy == parsec_data_get_copy(gpu_copy->original, gpu_device->super.device_index) );
 
             PARSEC_DEBUG_VERBOSE(20, parsec_gpu_output_stream,
-                                "GPU[%s]:\tOUT Data copy %p [ref_count %d] for flow %s",
-                                 gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, flow->name);
+                                "GPU[%d:%s]:\tOUT Data copy %p [ref_count %d] for flow %s",
+                                gpu_device->super.device_index, gpu_device->super.name, gpu_copy, gpu_copy->super.super.obj_reference_count, flow->name);
 
             /* Stage the transfer of the data back to main memory */
             gpu_device->super.required_data_out += nb_elts;
@@ -2208,8 +2204,8 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
                 /* TODO: make sure no readers are working on the CPU version */
                 original = gpu_copy->original;
                 PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                    "GPU[%s]:\tMove D2H data <%s:%x> copy %p [ref_count %d] -- D:%p -> H:%p requested",
-                                     gpu_device->super.name, flow->name, original->key, gpu_copy, gpu_copy->super.super.obj_reference_count,
+                                    "GPU[%d:%s]:\tMove D2H data <%s:%x> copy %p [ref_count %d] -- D:%p -> H:%p requested",
+                                    gpu_device->super.device_index, gpu_device->super.name, flow->name, original->key, gpu_copy, gpu_copy->super.super.obj_reference_count,
                                      (void*)gpu_copy->device_private, original->device_copies[0]->device_private);
 #if defined(PARSEC_PROF_TRACE)
                 if( gpu_stream->prof_event_track_enable ) {
@@ -2236,11 +2232,13 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
                 }
 #endif
                 /* Move the data back into main memory */
-                if( PARSEC_SUCCESS != gpu_task->stage_out? gpu_task->stage_out(gpu_task, (1U << flow->flow_index), gpu_stream): PARSEC_SUCCESS) {
-                    parsec_warning( "%s:%d %s", __FILE__, __LINE__,
-                                    "gpu_task->stage_out from device ");
-                    parsec_warning("data %s <<%p>> -> <<%p>>\n", this_task->task_class->out[i]->name,
-                                   gpu_copy->device_private, original->device_copies[0]->device_private);
+                rc = gpu_task->stage_out? gpu_task->stage_out(gpu_task, (1U << flow->flow_index), gpu_stream): PARSEC_SUCCESS;
+                if(PARSEC_SUCCESS != rc) {
+                    parsec_warning( "GPU[%d:%s]: gpu_task->stage_out from device rc=%d @%s:%d\n"
+                                    "\tdata %s <<%p>> -> <<%p>>\n",
+                                    gpu_device->super.device_index, gpu_device->super.name, rc, __func__, __LINE__,
+                                    this_task->task_class->out[i]->name,
+                                    gpu_copy->device_private, original->device_copies[0]->device_private);
                     return_code = PARSEC_HOOK_RETURN_DISABLE;
                     parsec_atomic_unlock(&original->lock);
                     goto release_and_return_error;
@@ -2259,8 +2257,8 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
         gpu_device->data_avail_epoch++;
     }
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                         "GPU[%s]: Pop %s DONE (return %d data epoch %"PRIu64")",
-                         gpu_device->super.name,
+                         "GPU[%d:%s]: Pop %s DONE (return %d data epoch %"PRIu64")",
+                         gpu_device->super.device_index, gpu_device->super.name,
                          parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task), return_code, gpu_device->data_avail_epoch );
 
     return (return_code < 0 ? return_code : how_many);
@@ -2281,8 +2279,8 @@ parsec_device_kernel_epilog( parsec_device_gpu_module_t *gpu_device,
 #if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                         "GPU[%s]: Epilog of %s",
-                         gpu_device->super.name,
+                         "GPU[%d:%s]: Epilog of %s",
+                         gpu_device->super.device_index, gpu_device->super.name,
                          parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task) );
 #endif
 
@@ -2326,10 +2324,9 @@ parsec_device_kernel_epilog( parsec_device_gpu_module_t *gpu_device,
 
         cpu_copy->version = gpu_copy->version;
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                             "GPU[%s]: CPU copy %p [ref_count %d] gets the same version %d as GPU copy %p [ref_count %d] at %s:%d",
-                             gpu_device->super.name,
-                             cpu_copy, cpu_copy->super.super.obj_reference_count, cpu_copy->version, gpu_copy, gpu_copy->super.super.obj_reference_count,
-                             __FILE__, __LINE__);
+                             "GPU[%d:%s]: CPU copy %p [ref_count %d] gets the same version %d as GPU copy %p [ref_count %d]",
+                             gpu_device->super.device_index, gpu_device->super.name,
+                             cpu_copy, cpu_copy->super.super.obj_reference_count, cpu_copy->version, gpu_copy, gpu_copy->super.super.obj_reference_count);
 
         /**
          * Let's lie to the engine by reporting that working version of this
@@ -2385,9 +2382,9 @@ parsec_device_kernel_cleanout( parsec_device_gpu_module_t *gpu_device,
 #if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                        "GPU[%s]: Cleanup of %s",
-                        gpu_device->super.name,
-                        parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task) );
+                         "GPU[%d:%s]: Cleanup of %s",
+                         gpu_device->super.device_index, gpu_device->super.name,
+                         parsec_task_snprintf(tmp, MAX_TASK_STRLEN, this_task) );
 #endif
 
     for( i = 0; i < this_task->task_class->nb_flows; i++ ) {
@@ -2487,8 +2484,8 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
         parsec_fifo_push( &(gpu_device->pending), (parsec_list_item_t*)gpu_task );
         return PARSEC_HOOK_RETURN_ASYNC;
     }
-    PARSEC_DEBUG_VERBOSE(5, parsec_gpu_output_stream,"GPU[%s]: Entering GPU management at %s:%d",
-                         gpu_device->super.name, __FILE__, __LINE__);
+    PARSEC_DEBUG_VERBOSE(5, parsec_gpu_output_stream, "GPU[%d:%s]: Entering GPU management",
+                         gpu_device->super.device_index, gpu_device->super.name);
 
 #if defined(PARSEC_PROF_TRACE)
     if( gpu_device->trackable_events & PARSEC_PROFILE_GPU_TRACK_OWN )
@@ -2503,10 +2500,9 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
  check_in_deps:
     if( NULL != gpu_task ) {
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                             "GPU[%s]:\tUpload data (if any) for %s priority %d",
-                             gpu_device->super.name,
-                             parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task),
-                             gpu_task->ec->priority );
+                             "GPU[%d:%s]:\tUpload data (if any) for %s",
+                             gpu_device->super.device_index, gpu_device->super.name,
+                             parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task));
     }
     rc = parsec_device_progress_stream( gpu_device,
                                         gpu_device->exec_stream[0],
@@ -2537,9 +2533,8 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
     /* Stage-in completed for this task: it is ready to be executed */
     exec_stream = (exec_stream + 1) % (gpu_device->num_exec_streams - 2);  /* Choose an exec_stream */
     if( NULL != gpu_task ) {
-        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%s]:\tExecute %s priority %d", gpu_device->super.name,
-                             parsec_task_snprintf(tmp, MAX_TASK_STRLEN, gpu_task->ec),
-                             gpu_task->ec->priority );
+        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%d:%s]:\tExecute %s", gpu_device->super.device_index, gpu_device->super.name,
+                             parsec_task_snprintf(tmp, MAX_TASK_STRLEN, gpu_task->ec));
     }
     rc = parsec_device_progress_stream( gpu_device,
                                         gpu_device->exec_stream[2+exec_stream],
@@ -2571,9 +2566,8 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
 
  get_data_out_of_device:
     if( NULL != gpu_task ) {  /* This task has completed its execution */
-        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%s]:\tRetrieve data (if any) for %s priority %d", gpu_device->super.name,
-                            parsec_task_snprintf(tmp, MAX_TASK_STRLEN, gpu_task->ec),
-                            gpu_task->ec->priority );
+        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%d:%s]:\tRetrieve data (if any) for %s", gpu_device->super.device_index, gpu_device->super.name,
+                            parsec_task_snprintf(tmp, MAX_TASK_STRLEN, gpu_task->ec));
     }
     /* Task is ready to move the data back to main memory */
     rc = parsec_device_progress_stream( gpu_device,
@@ -2605,25 +2599,24 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
     if( NULL != gpu_task ) {
         pop_null = 0;
         gpu_task->last_data_check_epoch = gpu_device->data_avail_epoch - 1;  /* force at least one tour */
-        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%s]:\tGet from shared queue %s priority %d", gpu_device->super.name,
-                             parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task),
-                             gpu_task->ec->priority);
+        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%d:%s]:\tGet from shared queue %s", gpu_device->super.device_index, gpu_device->super.name,
+                             parsec_device_describe_gpu_task(tmp, MAX_TASK_STRLEN, gpu_task));
         if( PARSEC_GPU_TASK_TYPE_D2D_COMPLETE == gpu_task->task_type ) {
             goto get_data_out_of_device;
         }
     } else {
         pop_null++;
         if( pop_null % 1024 == 1023 ) {
-            PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,  "GPU[%s]:\tStill waiting for %d tasks to execute, but poped NULL the last %d times I tried to pop something...",
-                                 gpu_device->super.name, gpu_device->mutex, pop_null);
+            PARSEC_DEBUG_VERBOSE(30, parsec_gpu_output_stream,  "GPU[%d:%s]:\tStill waiting for %d tasks to execute, but poped NULL the last %d times I tried to pop something...",
+                                 gpu_device->super.device_index, gpu_device->super.name, gpu_device->mutex, pop_null);
         }
     }
     goto check_in_deps;
 
  complete_task:
     assert( NULL != gpu_task );
-    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%s]:\tComplete %s",
-                         gpu_device->super.name,
+    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "GPU[%d:%s]:\tComplete %s",
+                         gpu_device->super.device_index, gpu_device->super.name,
                          parsec_task_snprintf(tmp, MAX_TASK_STRLEN, gpu_task->ec));
     /* Everything went fine so far, the result is correct and back in the main memory */
     PARSEC_LIST_ITEM_SINGLETON(gpu_task);
@@ -2641,8 +2634,9 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
     __parsec_complete_execution( es, gpu_task->ec );
     gpu_device->super.executed_tasks++;
  remove_gpu_task:
-    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,"GPU[%s]: gpu_task %p freed at %s:%d", gpu_device->super.name,
-                        gpu_task, __FILE__, __LINE__);
+    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, "GPU[%d:%s]: gpu_task %p freed",
+                         gpu_device->super.device_index, gpu_device->super.name,
+                         gpu_task);
     free( gpu_task );
     rc = parsec_atomic_fetch_dec_int32( &(gpu_device->mutex) );
     if( 1 == rc ) {  /* I was the last one */
@@ -2651,8 +2645,8 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
             PARSEC_PROFILING_TRACE( es->es_profile, parsec_gpu_own_GPU_key_end,
                                     (unsigned long)es, PROFILE_OBJECT_ID_NULL, NULL );
 #endif  /* defined(PARSEC_PROF_TRACE) */
-        PARSEC_DEBUG_VERBOSE(5, parsec_gpu_output_stream,"GPU[%s]: Leaving GPU management at %s:%d",
-                             gpu_device->super.name, __FILE__, __LINE__);
+        PARSEC_DEBUG_VERBOSE(5, parsec_gpu_output_stream, "GPU[%d:%s]: Leaving GPU management",
+                             gpu_device->super.device_index, gpu_device->super.name);
         /* inform the upper layer not to use the task argument, it has been long gone */
         return PARSEC_HOOK_RETURN_ASYNC;
     }
@@ -2663,6 +2657,7 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
     /* Something wrong happened. Push all the pending tasks back on the
      * cores, and disable the gpu.
      */
-    parsec_warning("Critical issue related to the GPU discovered. Giving up\n");
+    parsec_warning("GPU[%d:%s]: Critical issue related to the GPU discovered. Giving up",
+                   gpu_device->super.device_index, gpu_device->super.name);
     return PARSEC_HOOK_RETURN_DISABLE;
 }

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -401,7 +401,7 @@ static parsec_task_class_t parsec_device_data_prefetch_tc = {
 
 static int
 parsec_device_release_resources_prefetch_task(parsec_device_gpu_module_t* gpu_device,
-					    parsec_gpu_task_t** out_task)
+                        parsec_gpu_task_t** out_task)
 {
 #if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
@@ -823,7 +823,7 @@ parsec_device_memory_release( parsec_device_gpu_module_t* gpu_device )
     void* ptr = zone_malloc_fini(&gpu_device->memory);
     rc = gpu_device->memory_free(gpu_device, ptr);
     if(PARSEC_SUCCESS != rc) {
-        parsec_warning("Failed to free the GPU backend memory."); 
+        parsec_warning("Failed to free the GPU backend memory.");
         return rc;
     }
 #endif
@@ -923,7 +923,7 @@ parsec_device_data_reserve_space( parsec_device_gpu_module_t* gpu_device,
                 /* We can't find enough room on the GPU. Insert the tiles in the begining of
                  * the LRU (in order to be reused asap) and return with error.
                  */
-	        release_temp_and_return:
+            release_temp_and_return:
 #if defined(PARSEC_DEBUG_NOISIER)
                 PARSEC_DEBUG_VERBOSE(2, parsec_gpu_output_stream,
                                      "GPU[%s]:%s:\tRequest space on GPU failed for flow %s index %d/%d for task %s",
@@ -1250,7 +1250,7 @@ parsec_default_gpu_stage_out(parsec_gpu_task_t        *gtask,
                                          source->device_private,
                                          count,
                                          dir );
-            if(PARSEC_SUCCESS != ret) { 
+            if(PARSEC_SUCCESS != ret) {
                 return PARSEC_HOOK_RETURN_ERROR;
             }
         }
@@ -1312,7 +1312,7 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
 
     transfer_from = parsec_data_start_transfer_ownership_to_copy(original, gpu_device->super.device_index, (uint8_t)type);
 
-    /* If data is from NEW (it doesn't have a source_repo_entry and is not a direct data collection reference), 
+    /* If data is from NEW (it doesn't have a source_repo_entry and is not a direct data collection reference),
      * and nobody has touched it yet, then we don't need to pull it in, we have created it already, that's enough. */
     /*
      * TODO: this test is not correct for anything but PTG
@@ -1612,7 +1612,7 @@ parsec_device_send_transfercomplete_cmd_to_device(parsec_data_copy_t *copy,
     gpu_task->stage_in  = parsec_default_gpu_stage_in;
     gpu_task->stage_out = parsec_default_gpu_stage_out;
     gpu_task->ec->data[0].data_in = copy;  /* We need to set not-null in data_in, so that the fake flow is
-                                            * not ignored when poping the data from the fake task */ 
+                                            * not ignored when poping the data from the fake task */
     gpu_task->ec->data[0].data_out = copy; /* We "free" data[i].data_out if its readers reaches 0 */
     gpu_task->ec->data[0].source_repo_entry = NULL;
     gpu_task->ec->data[0].source_repo = NULL;
@@ -2041,7 +2041,7 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
  * setup the profiling information and then calls directly into the task submission body. Upon
  * return from the body handle the state machine of the task, taking care of the special cases
  * such as AGAIN and ASYNC.
- * @returns An error if anything unexpected came out of the task submission body, otherwise 
+ * @returns An error if anything unexpected came out of the task submission body, otherwise
  */
 static int
 parsec_device_kernel_exec( parsec_device_gpu_module_t      *gpu_device,
@@ -2330,20 +2330,6 @@ parsec_device_kernel_epilog( parsec_device_gpu_module_t *gpu_device,
                              gpu_device->super.name,
                              cpu_copy, cpu_copy->super.super.obj_reference_count, cpu_copy->version, gpu_copy, gpu_copy->super.super.obj_reference_count,
                              __FILE__, __LINE__);
-        /**
-         *  We already incremented the gpu_copy during the data_stage_in if needed, but we
-         *  need to bump it a second time because the cpu_copy will be incremented in
-         *  task completion, and thus would end-up with version+1 w.r.t. this gpu_copy.
-         *  We could set the cpu_copy->version to gpu_copy->version-1 but we
-         *  thought that double incrementing versions on gpu_copy is less dangerous than
-         *  setting an older version on the cpu_copy while a prior copy may
-         *  already have the same version-1 for real.
-         */
-        gpu_copy->version++;
-        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                             "GPU[%s]: GPU copy %p [ref_count %d] gets version %d because CPU copy %p will be updated during complete_execution",
-                             gpu_device->super.name,
-                             gpu_copy, gpu_copy->super.super.obj_reference_count, gpu_copy->version, cpu_copy);
 
         /**
          * Let's lie to the engine by reporting that working version of this
@@ -2658,7 +2644,7 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
     __parsec_complete_execution( es, gpu_task->ec );
     gpu_device->super.executed_tasks++;
  remove_gpu_task:
-    PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,"GPU[%s]: gpu_task %p freed at %s:%d", gpu_device->super.name, 
+    PARSEC_DEBUG_VERBOSE(3, parsec_gpu_output_stream,"GPU[%s]: gpu_task %p freed at %s:%d", gpu_device->super.name,
                         gpu_task, __FILE__, __LINE__);
     free( gpu_task );
     rc = parsec_atomic_fetch_dec_int32( &(gpu_device->mutex) );
@@ -2668,9 +2654,9 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
             PARSEC_PROFILING_TRACE( es->es_profile, parsec_gpu_own_GPU_key_end,
                                     (unsigned long)es, PROFILE_OBJECT_ID_NULL, NULL );
 #endif  /* defined(PARSEC_PROF_TRACE) */
-        PARSEC_DEBUG_VERBOSE(2, parsec_gpu_output_stream,"GPU[%s]: Leaving GPU management at %s:%d", 
+        PARSEC_DEBUG_VERBOSE(2, parsec_gpu_output_stream,"GPU[%s]: Leaving GPU management at %s:%d",
                              gpu_device->super.name, __FILE__, __LINE__);
-	/* inform the upper layer not to use the task argument, it has been long gone */
+        /* inform the upper layer not to use the task argument, it has been long gone */
         return PARSEC_HOOK_RETURN_ASYNC;
     }
     gpu_task = progress_task;

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -94,8 +94,6 @@ struct parsec_gpu_task_s {
         struct {
             parsec_task_t            *ec;
             uint64_t                  last_data_check_epoch;
-            uint64_t                  load;  /* computational load imposed on the device */
-            /* These should be set by the DSL */
             const parsec_flow_t      *flow[MAX_PARAM_COUNT];  /* There is no consistent way to access the flows from the task_class,
                                                                * so the DSL need to provide these flows here.
                                                                */

--- a/parsec/mca/device/transfer_gpu.c
+++ b/parsec/mca/device/transfer_gpu.c
@@ -248,6 +248,7 @@ parsec_gpu_create_w2r_task(parsec_device_gpu_module_t *gpu_device,
                     parsec_atomic_unlock( &gpu_copy->original->lock );
                     return NULL;
                 }
+                PARSEC_OBJ_CONSTRUCT(d2h_task, parsec_task_t);
             }
             parsec_list_item_ring_chop((parsec_list_item_t*)gpu_copy);
             PARSEC_LIST_ITEM_SINGLETON(gpu_copy);
@@ -269,7 +270,6 @@ parsec_gpu_create_w2r_task(parsec_device_gpu_module_t *gpu_device,
 
     d2h_task->priority        = INT32_MAX;
     d2h_task->task_class      = &parsec_gpu_d2h_task_class;
-    d2h_task->status          = PARSEC_TASK_STATUS_NONE;
     d2h_task->taskpool        = NULL;
     d2h_task->locals[0].value = nb_cleaned;
 

--- a/parsec/mca/device/transfer_gpu.c
+++ b/parsec/mca/device/transfer_gpu.c
@@ -256,8 +256,8 @@ parsec_gpu_create_w2r_task(parsec_device_gpu_module_t *gpu_device,
             d2h_task->data[nb_cleaned].data_out = gpu_copy;
             gpu_copy->data_transfer_status = PARSEC_DATA_STATUS_UNDER_TRANSFER;  /* mark the copy as in transfer */
             parsec_atomic_unlock( &gpu_copy->original->lock );
-            PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "D2H[%s] task %p:\tdata %d -> %p [%p] readers %d",
-                                 gpu_device->super.name, (void*)d2h_task,
+            PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "D2H[%d:%s] task %p:\tdata %d -> %p [%p] readers %d",
+                                 gpu_device->super.device_index, gpu_device->super.name, (void*)d2h_task,
                                  nb_cleaned, gpu_copy, gpu_copy->original, gpu_copy->readers);
             nb_cleaned++;
             if (MAX_PARAM_COUNT == nb_cleaned)
@@ -297,8 +297,8 @@ int parsec_gpu_complete_w2r_task(parsec_device_gpu_module_t *gpu_device,
     parsec_gpu_d2h_task_t* task = (parsec_gpu_d2h_task_t*)gpu_task->ec;
     parsec_data_t* original;
 
-    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "D2H[%s] task %p: %d data transferred to host",
-                         gpu_device->super.name, (void*)task, task->locals[0].value);
+    PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,  "D2H[%d:%s] task %p: %d data transferred to host",
+                         gpu_device->super.device_index, gpu_device->super.name, (void*)task, task->locals[0].value);
     assert(gpu_task->task_type == PARSEC_GPU_TASK_TYPE_D2HTRANSFER);
     for( int i = 0; i < task->locals[0].value; i++ ) {
         gpu_copy = task->data[i].data_out;
@@ -315,20 +315,20 @@ int parsec_gpu_complete_w2r_task(parsec_device_gpu_module_t *gpu_device,
         if( cpu_copy->version < gpu_copy->version ) {
             /* the GPU version has been acquired by a new task that is waiting for submission */
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "D2H[%s] task %p:%i GPU data copy %p [%p] has a backup in memory",
-                                 gpu_device->super.name, (void*)task, i, gpu_copy, gpu_copy->original);
+                                 "D2H[%d:%s] task %p:%i GPU data copy %p [%p] has a backup in memory",
+                                 gpu_device->super.device_index, gpu_device->super.name, (void*)task, i, gpu_copy, gpu_copy->original);
         } else {
             gpu_copy->coherency_state = PARSEC_DATA_COHERENCY_SHARED;
             cpu_copy->coherency_state =  PARSEC_DATA_COHERENCY_SHARED;
             cpu_copy->version = gpu_copy->version;
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "GPU[%s]: CPU copy %p gets the same version %d as GPU copy %p at %s:%d",
-                                 gpu_device->super.name,
+                                 "D2H[%d:%s]: CPU copy %p gets the same version %d as GPU copy %p at %s:%d",
+                                 gpu_device->super.device_index, gpu_device->super.name,
                                  cpu_copy, cpu_copy->version, gpu_copy,
                                  __FILE__, __LINE__);
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
-                                 "D2H[%s] task %p:%i GPU data copy %p [%p] now available",
-                                 gpu_device->super.name, (void*)task, i, gpu_copy, gpu_copy->original);
+                                 "D2H[%d:%s] task %p:%i GPU data copy %p [%p] now available",
+                                 gpu_device->super.device_index, gpu_device->super.name, (void*)task, i, gpu_copy, gpu_copy->original);
             parsec_list_push_back(&gpu_device->gpu_mem_lru, (parsec_list_item_t*)gpu_copy);
         }
         parsec_atomic_unlock(&gpu_copy->original->lock);

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -209,9 +209,12 @@ PARSEC_OBJ_CLASS_INSTANCE(parsec_taskpool_t, parsec_list_item_t,
                           __parsec_taskpool_constructor, __parsec_taskpool_destructor);
 
 static void __parsec_task_constructor(parsec_task_t* task) {
+    /* no allocation here, only initalizations: the task_t will be constructed
+     * multiple times when push-poped from the mempool */
     task->selected_device = NULL;
     task->selected_chore = -1;
     task->load = 0;
+    task->status = PARSEC_TASK_STATUS_NONE;
 }
 
 /*
@@ -1710,7 +1713,6 @@ parsec_release_local_OUT_dependencies(parsec_execution_stream_t* es,
             parsec_task_t *new_context = (parsec_task_t *) parsec_thread_mempool_allocate(es->context_mempool);
 
             PARSEC_COPY_EXECUTION_CONTEXT(new_context, task);
-            new_context->status = PARSEC_TASK_STATUS_NONE;
             PARSEC_AYU_ADD_TASK(new_context);
 
             PARSEC_DEBUG_VERBOSE(6, parsec_debug_output,
@@ -2572,7 +2574,6 @@ parsec_debug_taskpool_count_local_tasks( parsec_taskpool_t *tp,
     task.taskpool = tp;
     task.task_class = tc;
     task.priority = -1;
-    task.status = PARSEC_TASK_STATUS_NONE;
     memset( task.data, 0, MAX_PARAM_COUNT * sizeof(parsec_data_pair_t) );
 
     *nlocal = 0;

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -1716,12 +1716,11 @@ parsec_release_local_OUT_dependencies(parsec_execution_stream_t* es,
             PARSEC_AYU_ADD_TASK(new_context);
 
             PARSEC_DEBUG_VERBOSE(6, parsec_debug_output,
-                   "%s becomes ready from %s on thread %d:%d, with mask 0x%04x and priority %d",
+                   "%s becomes ready from %s on thread %d:%d, with mask 0x%04x",
                    tmp1,
                    parsec_task_snprintf(tmp2, MAX_TASK_STRLEN, origin),
                    es->th_id, es->virtual_process->vp_id,
-                   *deps,
-                   task->priority);
+                   *deps);
 
             assert( dest_flow->flow_index <= new_context->task_class->nb_flows);
             memset( new_context->data, 0, sizeof(parsec_data_pair_t) * new_context->task_class->nb_flows);

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -208,10 +208,16 @@ static void __parsec_taskpool_destructor(parsec_taskpool_t* tp)
 PARSEC_OBJ_CLASS_INSTANCE(parsec_taskpool_t, parsec_list_item_t,
                           __parsec_taskpool_constructor, __parsec_taskpool_destructor);
 
+static void __parsec_task_constructor(parsec_task_t* task) {
+    task->selected_device = NULL;
+    task->selected_chore = -1;
+    task->load = 0;
+}
+
 /*
  * Taskpool based task definition (no specialized constructor and destructor) */
 PARSEC_OBJ_CLASS_INSTANCE(parsec_task_t, parsec_list_item_t,
-                   NULL, NULL);
+                   __parsec_task_constructor, NULL);
 
 static void parsec_taskpool_release_resources(void);
 

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -519,7 +519,9 @@ PARSEC_DECLSPEC extern int parsec_runtime_keep_highest_priority_task;
     int32_t                        priority;         \
     uint8_t                        status;           \
     uint8_t                        chore_mask;       \
-    uint8_t                        unused[2];        \
+    int16_t                        selected_chore;   \
+    parsec_device_module_t        *selected_device;  \
+    uint64_t                       load;             \
     struct data_repo_entry_s      *repo_entry; /* The task contains its own data repo entry;
                                                 * It is created during datalookup if it hasn't
                                                 * been already created by a predecessor

--- a/parsec/parsec_internal.h
+++ b/parsec/parsec_internal.h
@@ -565,6 +565,7 @@ PARSEC_DECLSPEC PARSEC_OBJ_CLASS_DECLARATION(parsec_task_t);
                 sizeof(struct parsec_minimal_execution_context_s) - sizeof(parsec_list_item_t) ); \
         (dest)->mempool_owner = _mpool;                                 \
         (dest)->repo_entry = NULL;                                      \
+        PARSEC_OBJ_CONSTRUCT(dest, parsec_task_t); /* reset defaults */ \
     } while (0)
 
 /**

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -24,7 +24,7 @@
 
 #include "parsec/parsec_internal.h"
 
-#if defined(PARSEC_DEBUG)
+#if defined(PARSEC_DEBUG_NOISIER)
 static int64_t count_reshaping = 0;
 #endif
 
@@ -681,7 +681,7 @@ void parsec_local_reshape_cb(parsec_base_future_t *future, ... )
 
         parsec_future_set(future, reshape_data);
 
-#if defined(PARSEC_DEBUG)
+#if defined(PARSEC_DEBUG_NOISIER)
         parsec_atomic_fetch_add_int64(&count_reshaping,1);
 #endif
         return;
@@ -1446,7 +1446,7 @@ static int local_dep_nothread_reshape(parsec_execution_stream_t* es,
     /*Not working if rescheduled by commthread, thus future trigger routines return ASYNC */
     /*__parsec_schedule(es, item->cmd.memcpy_reshape.task, 0);*/
 
-#if defined(PARSEC_DEBUG)
+#if defined(PARSEC_DEBUG_NOISIER)
     parsec_atomic_fetch_add_int64(&count_reshaping,1);
 #endif
 

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -141,10 +141,10 @@ int __parsec_execute( parsec_execution_stream_t* es,
         parsec_atomic_fetch_add_int64(&task->selected_device->device_load, task->load);
     }
 
-    PARSEC_DEBUG_VERBOSE(5, parsec_debug_output, "Thread %d of VP %d Execute %s[%d] chore %d",
+    PARSEC_DEBUG_VERBOSE(5, parsec_debug_output, "Thread %d of VP %d Execute %s chore %d device %d:%s",
                          es->th_id, es->virtual_process->vp_id,
-                         tmp, tc->incarnations[task->selected_chore].type,
-                         task->selected_chore);
+                         tmp, task->selected_chore,
+                         task->selected_device->device_index, task->selected_device->name);
 
     parsec_hook_t *hook = tc->incarnations[task->selected_chore].hook;
     assert( NULL != hook );
@@ -825,7 +825,7 @@ int parsec_context_add_taskpool( parsec_context_t* context, parsec_taskpool_t* t
     PARSEC_PINS_TASKPOOL_INIT(tp);  /* PINS taskpool initialization */
 
     /* If the DSL did not install a termination detection module,
-     * assume that the old behavior (local detection when local 
+     * assume that the old behavior (local detection when local
      * number of tasks is 0) is expected: install the local termination
      * detection module, and declare the taskpool as ready */
     if( tp->tdm.module == NULL ) {

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -96,7 +96,7 @@ int __parsec_context_wait_task( parsec_execution_stream_t* es,
     (void)es;
     switch(task->status) {
     case PARSEC_TASK_STATUS_NONE:
-#if defined(PARSEC_DEBUG)
+#if defined(PARSEC_DEBUG_NOISIER)
         char tmp[MAX_TASK_STRLEN];
         parsec_debug_verbose(5, parsec_debug_output, "thread %d of VP %d Execute %s\n", es->th_id, es->virtual_process->vp_id,
                              parsec_task_snprintf(tmp, MAX_TASK_STRLEN, task));
@@ -127,7 +127,7 @@ int __parsec_execute( parsec_execution_stream_t* es,
 {
     const parsec_task_class_t* tc = task->task_class;
     int rc;
-#if defined(PARSEC_DEBUG)
+#if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
     parsec_task_snprintf(tmp, MAX_TASK_STRLEN, task);
 #endif


### PR DESCRIPTION
new: rework get_best_device to lock-in the device used (it still use the evaluate functions), this will let us consolidate version management for GPU and CPU for all DSLs

This incidentally make potrf_dtd -g 2  work (while it was suspicious before)

New: parsec_select_best_device
Removed: parsec_get_best_device

* [x] stress and stage crash when no GPU available at runtime (defer to #644)
* [x] testing_best_device computes wrong values under some cases (on b00 notably)
* [x] re-enable the PTG device=123 body decorator
* [x] compute CPU versions upfront to enable TTG
* [ ] optional: stop lying about data_out and data_in being the CPU copy all the time when it most of the time is a GPU copy that we are just passing down directly, there are complexities with updating the right copy->readers (especially in dtd)

