### PR TITLE
Initialize the parsec's HWLOC subsystem before starting threads.

### DIFF
--- a/tests/class/atomics.c
+++ b/tests/class/atomics.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2018-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2023-2024 NVIDIA CORPORATION. All rights reserved.
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -7,6 +14,7 @@
 #include "parsec/sys/atomic.h"
 #include "parsec/bindthread.h"
 #include "parsec/class/barrier.h"
+#include "parsec/parsec_hwloc.h"
 
 typedef struct {
     int32_t      mo32;
@@ -283,6 +291,9 @@ int main(int argc, char *argv[])
         values[i].ma128 = 0; values[i].ma128 = ~values[i].ma128;
 #endif
     }
+
+    /* Make sure the HWLOC subsystem is ready for binding */
+    parsec_hwloc_init();
 
     for(i = 0; i < nb_threads; i++) {
         params[i].nb_tests = nb_tests;

--- a/tests/class/future.c
+++ b/tests/class/future.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 The University of Tennessee and The University
+ * Copyright (c) 2018-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
@@ -13,7 +13,6 @@
 #include <signal.h>
 #include <stdarg.h>
 #include "parsec/parsec_config.h"
-#include "parsec/bindthread.h"
 #include "parsec/parsec_hwloc.h"
 #include "parsec/os-spec-timing.h"
 #include "parsec/utils/mca_param.h"

--- a/tests/class/future_datacopy.c
+++ b/tests/class/future_datacopy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 The University of Tennessee and The University
+ * Copyright (c) 2018-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
@@ -13,8 +13,6 @@
 #include <signal.h>
 #include <stdarg.h>
 #include "parsec/parsec_config.h"
-#include "parsec/bindthread.h"
-#include "parsec/parsec_hwloc.h"
 #include "parsec/os-spec-timing.h"
 #include "parsec/utils/mca_param.h"
 

--- a/tests/class/lifo.c
+++ b/tests/class/lifo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -20,7 +20,6 @@
 
 #include "parsec/class/lifo.h"
 #include "parsec/os-spec-timing.h"
-#include "parsec/bindthread.h"
 
 static unsigned int NBELT = 8192;
 static unsigned int NBTIMES = 1000000;

--- a/tests/class/list.c
+++ b/tests/class/list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -20,7 +20,6 @@
 #endif
 #include "parsec/class/list.h"
 #include "parsec/os-spec-timing.h"
-#include "parsec/bindthread.h"
 
 static unsigned int NBELT = 8192;
 static unsigned int NBTIMES = 1000000;


### PR DESCRIPTION
extracted from #515 for fastracking