### PR TITLE
bugfix: cpu loads are not computed, hence it makes no sense to target CPUs for load balancing

### DIFF
--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -227,6 +227,8 @@ int parsec_select_best_device( parsec_task_t* this_task ) {
             if(!(dev->type & valid_types)) continue;
             /* Skip recursive devices: time estimates are computed on the associated CPU device */
             if(dev->type == PARSEC_DEV_RECURSIVE) continue;
+            /* Skip CPU devices: we do not compute loads on CPUs correctly anyway */
+            if(dev->type == PARSEC_DEV_CPU) continue;
 
             eta = dev->device_load + time_estimate(this_task, dev);
             if( best_eta > eta ) {


### PR DESCRIPTION
In some cases CPU SYRKs would execute when there is a valid GPU hook, because the CPU load (which is never updated hence is always having an eta of 0+time_estimate) would be lower than the data AREAD preferred GPU load+time_estimate. 

Since the CPU loads are always 0 this is not accurate, and we should load balance only between GPUs. 