### PR TITLE
Add a function to pre-set infos for all streams/devices/...

### DIFF
--- a/parsec/class/info.c
+++ b/parsec/class/info.c
@@ -318,3 +318,18 @@ void *parsec_info_get(parsec_info_object_array_t *oa, parsec_info_id_t iid)
     }
     return ret;
 }
+
+void parsec_info_set_all(parsec_info_t *nfo, parsec_info_id_t iid)
+{
+    parsec_list_item_t *li;
+    parsec_info_object_array_t *oa;
+
+    parsec_list_lock(&nfo->ioa_list);
+    for(li =  PARSEC_LIST_ITERATOR_FIRST(&nfo->ioa_list);
+        li != PARSEC_LIST_ITERATOR_END(&nfo->ioa_list);
+        li =  PARSEC_LIST_ITERATOR_NEXT(li)) {
+            oa = (parsec_info_object_array_t*)li;
+            parsec_info_get(oa, iid);
+    }
+    parsec_list_unlock(&nfo->ioa_list);
+}

--- a/parsec/class/info.h
+++ b/parsec/class/info.h
@@ -150,7 +150,7 @@ parsec_info_id_t parsec_info_register(parsec_info_t *nfo, const char *name,
                                       parsec_info_destructor_t destructor, void *des_data,
                                       parsec_info_constructor_t constructor, void *cons_data,
                                       void *cb_data);
-    
+
 /**
  * @brief unregisters an info key using its ID.
  *
@@ -234,6 +234,19 @@ void *parsec_info_test_and_set(parsec_info_object_array_t *oa, parsec_info_id_t 
  *    info with this iid
  */
 void *parsec_info_get(parsec_info_object_array_t *oa, parsec_info_id_t info_id);
+
+/**
+ * @brief (pre)set the info object for all registered stream/device/...
+ * 
+ * @details
+ *   @param[IN] nfo: the info collection that needs to be pre-set
+ *   @param[IN] iid: the index of the info to set
+ * This will call @fn parsec_info_get on each stream or device registered
+ * with @p nfo for the index @p iid, potentially calling the @p constructor
+ * callback for the objects that do not have an entry in the object array
+ * already.
+ */
+void parsec_info_set_all(parsec_info_t *nfo, parsec_info_id_t iid);
 
 
 END_C_DECLS

--- a/tests/runtime/cuda/nvlink_wrapper.c
+++ b/tests/runtime/cuda/nvlink_wrapper.c
@@ -119,6 +119,8 @@ parsec_taskpool_t* testing_nvlink_New( parsec_context_t *ctx, int depth, int mb 
                                                  create_cublas_handle, NULL,
                                                  NULL);
     assert(CuHI != -1);
+    /* Pre-set the cublas handle for all streams */
+    parsec_info_set_all(&parsec_per_stream_infos, CuHI);
 #else
     int CuHI = -1;
 #endif


### PR DESCRIPTION
Lazy/dynamic allocation of infos can be convenient for the users, but also detrimental to predictive behaviors. Examples of drawbacks are when testing memory constrained setups (e.g., when the test uses zone_malloc to dynamically allocate objects in the info object constructor, that may fail nondeterministically because it depends how many streams call the constructor), or small scale performance runs where the number of cublas objects to initialize vary depending on the run. Calling the new function incurs deterministic overheads.