### PR TITLE
Refactored CI

### DIFF
--- a/.github/CI/build.sh
+++ b/.github/CI/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+source .github/CI/env_setup.sh
+
+cmake --build .

--- a/.github/CI/configure.sh
+++ b/.github/CI/configure.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+source .github/CI/env_setup.sh
+
+cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_CONFIG
+
+

--- a/.github/CI/env_setup.sh
+++ b/.github/CI/env_setup.sh
@@ -1,0 +1,38 @@
+# This file should be "sourced" into your environment
+
+# Show the executed command, but don't affect spawned shells
+trap 'echo "# $BASH_COMMAND"' DEBUG # Show commands
+
+echo "Loading environment"
+if [[ -z "$SPACK_SETUP" || ! -e "$SPACK_SETUP" ]]; then
+   echo Error! Environment variable \$SPACK_SETUP must point
+   echo to a valid setup-env.sh Spack setup script.
+   exit 1
+fi
+source $SPACK_SETUP
+spack env activate parsec
+
+DEBUG=ON
+[ $BUILD_TYPE = "Release" ] && DEBUG=OFF
+
+if [ -z "$BUILD_DIRECTORY" ]; then
+   echo Error! ENV \$BUILD_DIRECTORY is undefined.
+   exit 1
+fi
+
+if [ -z "$INSTALL_DIRECTORY" ]; then
+   echo Error! ENV \$INSTALL_DIRECTORY is undefined.
+   exit 1
+fi
+
+! read -d '' BUILD_CONFIG << EOF
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        -DPARSEC_DEBUG_NOISIER=$DEBUG
+        -DPARSEC_DEBUG_PARANOID=$DEBUG
+        -DBUILD_SHARED_LIBS=$SHARED_TYPE
+        -DPARSEC_PROF_TRACE=$PROFILING
+        -DMPIEXEC_PREFLAGS='--bind-to;none;--oversubscribe'
+        -DCMAKE_INSTALL_PREFIX=$INSTALL_DIRECTORY
+EOF
+export BUILD_CONFIG

--- a/.github/CI/install.sh
+++ b/.github/CI/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+source .github/CI/env_setup.sh
+
+cmake --build . --target install

--- a/.github/CI/setup.sh
+++ b/.github/CI/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+source .github/CI/env_setup.sh
+
+cmake -E make_directory $BUILD_DIRECTORY

--- a/.github/CI/test.sh
+++ b/.github/CI/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+source .github/CI/env_setup.sh
+
+if [ "$BUILD_TYPE" = "Release" ]; then
+   # enable devices only in tests that explicitely require them
+   PARSEC_MCA_device_cuda_enabled=0
+   PARSEC_MCA_device_hip_enabled=0
+   # restrict memory use for oversubscribed runners
+   PARSEC_MCA_device_cuda_memory_use=10
+   PARSEC_MCA_device_hip_memory_use=10
+
+   ctest --output-on-failure
+fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+name: CI Build
+
+# Triggers on push and branches on the master
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  all:
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type : [ Debug, Release ]
+        shared_type : [ OFF, ON ]
+        profiling : [ OFF, ON ]
+        exclude:
+          - build_type: Debug
+            profiling: OFF
+          - build_type: Release
+            shared_type: OFF
+    name: "${{matrix.build_type}} Shared=${{matrix.shared_type}} Profile=${{matrix.profiling}}"
+    env:
+      BUILD_TYPE:  ${{matrix.build_type}}
+      SHARED_TYPE: ${{matrix.shared_type}}
+      PROFILING:   ${{matrix.profiling}}
+      BUILD_DIRECTORY: build
+      INSTALL_DIRECTORY: install
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Build Environment ${{ runner.os }}
+      run: .github/CI/setup.sh
+
+    - name: Configure CMake
+      run: .github/CI/configure.sh
+
+    - name: Build
+      run: .github/CI/build.sh
+
+    - name: Install
+      run: .github/CI/install.sh
+
+    - name: Test
+      run: .github/CI/test.sh
+
+    - name: Save Artifact
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: CMake-error-log
+        path: CMakeFiles/CMakeError.log


### PR DESCRIPTION
This is a refactoring of the current CI jobs such that the jobs no longer rely on building the dependencies using spack.  The script instead load the dependencies from a pre-built spack environment. This should decrease the failure rate of the CI jobs due to dependency building issues.