### PR TITLE
Suffix-increment is deprecated on volatile variables in C++

### DIFF
--- a/parsec/class/list_item.h
+++ b/parsec/class/list_item.h
@@ -203,7 +203,7 @@ parsec_list_item_ring_chop( parsec_list_item_t* item )
     item->list_prev->list_next = item->list_next;
     item->list_next->list_prev = item->list_prev;
 #if defined(PARSEC_DEBUG_PARANOID)
-    if(item->refcount) item->refcount--;
+    if(item->refcount) item->refcount = item->refcount-1;
     item->list_prev = (parsec_list_item_t*)(void*)0xdeadbeefL;
     item->list_next = (parsec_list_item_t*)(void*)0xdeadbeefL;
 #endif
@@ -285,7 +285,7 @@ parsec_list_item_ring_push_sorted( parsec_list_item_t* ring,
 #define PARSEC_ITEM_ATTACH(LIST, ITEM)                                  \
     do {                                                                \
         parsec_list_item_t *_item_ = (ITEM);                            \
-        _item_->refcount++;                                             \
+        _item_->refcount = _item_->refcount+1;                          \
         assert( 1 == _item_->refcount );                                \
         _item_->belong_to = (LIST);                                     \
     } while(0)
@@ -309,7 +309,7 @@ parsec_list_item_ring_push_sorted( parsec_list_item_t* ring,
         assert( _item->belong_to != (void*)_item );                     \
         _item->list_prev = (parsec_list_item_t*)(void*)0xdeadbeefL;     \
         _item->list_next = (parsec_list_item_t*)(void*)0xdeadbeefL;     \
-        _item->refcount--;                                              \
+        _item->refcount = _item->refcount-1;                            \
         assert( 0 == _item->refcount );                                 \
     } while (0)
 #else


### PR DESCRIPTION
Starting with C++20, suffix increment/decrement have been deprecated. The list header are consumed by C++ code (TTG) so let's play nice.

No performance impact.

Fixes https://github.com/ICLDisco/parsec/issues/588