### PR TITLE
w2r task should unlock the lock if readers are not 0

### DIFF
--- a/parsec/mca/device/transfer_gpu.c
+++ b/parsec/mca/device/transfer_gpu.c
@@ -263,7 +263,7 @@ parsec_gpu_create_w2r_task(parsec_device_gpu_module_t *gpu_device,
             if (MAX_PARAM_COUNT == nb_cleaned)
                 break;
         } else {
-            parsec_atomic_lock( &gpu_copy->original->lock );
+            parsec_atomic_unlock( &gpu_copy->original->lock );
         }
     }
 


### PR DESCRIPTION
Hotfix for #678 