### PR TITLE
C11  atomic lock alignment in data_t

### DIFF
--- a/parsec/class/parsec_datacopy_future.c
+++ b/parsec/class/parsec_datacopy_future.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 The University of Tennessee and The University
+ * Copyright (c) 2018-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
@@ -238,8 +238,7 @@ static parsec_future_fn_t parsec_datacopy_future_functions = {
  */
 static void parsec_datacopy_future_construct(parsec_base_future_t* future)
 {
-    parsec_atomic_lock_t temp = PARSEC_ATOMIC_UNLOCKED;
-    future->future_lock = temp;
+    parsec_atomic_lock_init(&future->future_lock);
     parsec_datacopy_future_t* d_fut = (parsec_datacopy_future_t*)future;
     d_fut->super.future_class = &parsec_datacopy_future_functions;
     d_fut->super.status = 0;

--- a/parsec/class/parsec_future.c
+++ b/parsec/class/parsec_future.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 The University of Tennessee and The University
+ * Copyright (c) 2018-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
@@ -125,20 +125,18 @@ static void parsec_base_future_construct(parsec_base_future_t* future)
     future->status = 0;
     future->cb_fulfill = NULL;
     future->tracked_data = NULL;
-    parsec_atomic_lock_t temp = PARSEC_ATOMIC_UNLOCKED;
-    future->future_lock = temp;
+    parsec_atomic_lock_init(&future->future_lock);
 }
 
 static void parsec_countable_future_construct(parsec_base_future_t* future)
 {
-    parsec_atomic_lock_t temp = PARSEC_ATOMIC_UNLOCKED;
-    future->future_lock = temp;
     parsec_countable_future_t* c_fut = (parsec_countable_future_t*)future;
     c_fut->super.future_class = &parsec_countable_future_functions;
     c_fut->super.status = 0;
     c_fut->super.cb_fulfill = NULL;
     c_fut->super.tracked_data = NULL;
     c_fut->count = 1;
+    parsec_atomic_lock_init(&future->future_lock);
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_base_future_t, parsec_list_item_t,/*parsec_object_t,*/

--- a/parsec/data.c
+++ b/parsec/data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 The University of Tennessee and The University
+ * Copyright (c) 2012-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -60,7 +60,6 @@ PARSEC_OBJ_CLASS_INSTANCE(parsec_data_copy_t, parsec_list_item_t,
 
 static void parsec_data_construct(parsec_data_t* obj )
 {
-    parsec_atomic_lock_t unlocked = PARSEC_ATOMIC_UNLOCKED;
     obj->owner_device     = -1;
     obj->preferred_device = -1;
     obj->key              = 0;
@@ -68,7 +67,7 @@ static void parsec_data_construct(parsec_data_t* obj )
     for( uint32_t i = 0; i < parsec_nb_devices;
          obj->device_copies[i] = NULL, i++ );
     obj->dc               = NULL;
-    obj->lock             = unlocked; /* Can't directly assign to PARSEC_ATOMIC_UNLOCKED because of C syntax */
+    parsec_atomic_lock_init(&obj->lock);
     PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Allocate data %p", obj);
 }
 

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -35,7 +35,7 @@ static int parsec_device_verbose = 0;
 uint32_t parsec_nb_devices = 0;
 static uint32_t parsec_nb_max_devices = 0;
 static uint32_t parsec_mca_device_are_freezed = 0;
-parsec_atomic_lock_t parsec_devices_mutex = PARSEC_ATOMIC_UNLOCKED;
+static parsec_atomic_lock_t parsec_devices_mutex = PARSEC_ATOMIC_UNLOCKED;
 static parsec_device_module_t** parsec_devices = NULL;
 
 static parsec_device_module_t* parsec_device_cpus = NULL;

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 The University of Tennessee and The University
+ * Copyright (c) 2013-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
@@ -189,7 +189,6 @@ PARSEC_OBJ_CLASS_DECLARATION(parsec_device_module_t);
 
 extern uint32_t parsec_nb_devices;
 extern int parsec_device_output;
-extern parsec_atomic_lock_t parsec_devices_mutex;
 
 /**
  * @brief Find the best device to execute the kernel based on the compute


### PR DESCRIPTION
c11 atomic_flag can be shorter (bool) than the volatile int type used in atomic_external.h, leading to misaligned static structures (like data_t) so, when C11 atomics are enabled, we force the size of atomic_lock_t to be at least one int long, regardless, to match the expected alignment.