### PR TITLE
Offload device task release to worker threads

### DIFF
--- a/parsec/include/parsec/execution_stream.h
+++ b/parsec/include/parsec/execution_stream.h
@@ -141,6 +141,8 @@ struct parsec_context_s {
     parsec_hash_table_t  dtd_arena_datatypes_hash_table; /**< Hash table that stores the arena datatypes used by DTD */
     int                  dtd_arena_datatypes_next_id;    /**< Next ID to use for the next Arena Datatype by DTD */
 
+    parsec_lifo_t        activities; /**< list of tasks with outstanding activities, high-priority */
+
 #if defined(PARSEC_SIM)
     int largest_simulation_date;
 #endif

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -2623,14 +2623,20 @@ parsec_device_kernel_scheduler( parsec_device_module_t *module,
         gpu_task->ec = NULL;
         goto remove_gpu_task;
     }
+
     parsec_device_kernel_epilog( gpu_device, gpu_task );
-    __parsec_complete_execution( es, gpu_task->ec );
+    __parsec_schedule_activity( es, gpu_task->ec );
     gpu_device->super.executed_tasks++;
+
  remove_gpu_task:
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, "GPU[%d:%s]: gpu_task %p freed",
                          gpu_device->super.device_index, gpu_device->super.name,
                          gpu_task);
+
+    // TODO: this should only be done for internal gpu tasks
+    //       and the DSL should be responsible for freeing the memory it allocated
     free( gpu_task );
+
     rc = parsec_atomic_fetch_dec_int32( &(gpu_device->mutex) );
     if( 1 == rc ) {  /* I was the last one */
 #if defined(PARSEC_PROF_TRACE)

--- a/parsec/scheduling.h
+++ b/parsec/scheduling.h
@@ -68,6 +68,9 @@ int __parsec_schedule_vp( parsec_execution_stream_t*,
                           parsec_task_t**,
                           int32_t distance);
 
+int __parsec_schedule_activity( parsec_execution_stream_t *es,
+                                parsec_task_t *task);
+
 /**
  * @brief Reschedule a task on the most appropriate resource.
  *


### PR DESCRIPTION
Add a LIFO for task activities that are high-priority to the context. These activities are picked up by worker threads. With GPU execution, worker threads are mostly idle so they can spare cycles handling the release of successor tasks, including potential communication.

A similar mechanism could apply to incoming communication to relieve the communication thread and offload task release upon completion of a remote dep receive.