### PR TITLE
The device task is now released by the DSL

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2023      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2023-2024 NVIDIA Corporation.  All rights reserved.
  */
 
 /* **************************************************************************** */
@@ -2281,7 +2281,7 @@ static parsec_hook_return_t parsec_dtd_gpu_task_submit(parsec_execution_stream_t
     parsec_dtd_task_class_t *dtd_tc = (parsec_dtd_task_class_t*)this_task->task_class;
     parsec_gpu_task_t *gpu_task = (parsec_gpu_task_t *) calloc(1, sizeof(parsec_gpu_task_t));
     PARSEC_OBJ_CONSTRUCT(gpu_task, parsec_list_item_t);
-
+    gpu_task->release_device_task = free;  /* by default free the device task */
     gpu_task->ec = (parsec_task_t *) this_task;
     gpu_task->submit = dtd_tc->gpu_func_ptr;
     gpu_task->task_type = 0;

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -6811,6 +6811,7 @@ static void jdf_generate_code_hook_gpu(const jdf_t *jdf,
             "\n"
             "  gpu_task = (parsec_gpu_task_t*)calloc(1, sizeof(parsec_gpu_task_t));\n"
             "  PARSEC_OBJ_CONSTRUCT(gpu_task, parsec_list_item_t);\n"
+            "  gpu_task->release_device_task = free;  /* by default free the device task */\n"
             "  gpu_task->ec = (parsec_task_t*)this_task;\n"
             "  gpu_task->submit = &%s_kernel_submit_%s_%s;\n"
             "  gpu_task->task_type = 0;\n"

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2021-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #ifndef PARSEC_DEVICE_GPU_H
@@ -76,44 +77,51 @@ typedef int (parsec_stage_out_function_t)(parsec_gpu_task_t        *gtask,
                                           uint32_t                  flow_mask,
                                           parsec_gpu_exec_stream_t *gpu_stream);
 
+/* Function type for releasing a device task. The DSL is responsible for allocating such tasks,
+ * and this function allows the device engine to delegate the release of such tasks back into
+ * the DSL. Once this task called, the device task should not be accessed by the device.
+ */
+typedef void (*parsec_release_device_task_function_t)(void*);
+
 struct parsec_gpu_task_s {
-    parsec_list_item_t                list_item;
-    uint16_t                          task_type;
-    uint16_t                          pushout;
-    int32_t                           last_status;
-    parsec_advance_task_function_t    submit;
-    parsec_complete_stage_function_t  complete_stage;
-    parsec_stage_in_function_t       *stage_in;
-    parsec_stage_out_function_t      *stage_out;
+    parsec_list_item_t                     list_item;
+    uint16_t                               task_type;
+    uint16_t                               pushout;
+    int32_t                                last_status;
+    parsec_advance_task_function_t         submit;
+    parsec_complete_stage_function_t       complete_stage;
+    parsec_stage_in_function_t            *stage_in;
+    parsec_stage_out_function_t           *stage_out;
+    parsec_release_device_task_function_t  release_device_task;
 #if defined(PARSEC_PROF_TRACE)
-    int                               prof_key_end;
-    uint64_t                          prof_event_id;
-    uint32_t                          prof_tp_id;
+    int                                    prof_key_end;
+    uint64_t                               prof_event_id;
+    uint32_t                               prof_tp_id;
 #endif
     union {
         struct {
-            parsec_task_t            *ec;
-            uint64_t                  last_data_check_epoch;
-            const parsec_flow_t      *flow[MAX_PARAM_COUNT];  /* There is no consistent way to access the flows from the task_class,
-                                                               * so the DSL need to provide these flows here.
-                                                               */
-            size_t                    flow_nb_elts[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
-                                                                      * on the GPU.
-                                                                      */
-            parsec_data_collection_t *flow_dc[MAX_PARAM_COUNT];     /* for each flow, data collection from which the data
-                                                                     * to be transferred logically belongs to.
-                                                                     * This gives the user the chance to indicate on the JDF
-                                                                     * a data collection to inspect during GPU transfer.
-                                                                     * User may want info from the DC (e.g. mtype),
-                                                                     * & otherwise remote copies don't have any info.
-                                                                     */
+            parsec_task_t                 *ec;
+            uint64_t                       last_data_check_epoch;
+            const parsec_flow_t           *flow[MAX_PARAM_COUNT];  /* There is no consistent way to access the flows from the task_class,
+                                                                    * so the DSL need to provide these flows here.
+                                                                    */
+            size_t                         flow_nb_elts[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
+                                                                           * on the GPU.
+                                                                           */
+            parsec_data_collection_t      *flow_dc[MAX_PARAM_COUNT];     /* for each flow, data collection from which the data
+                                                                          * to be transferred logically belongs to.
+                                                                          * This gives the user the chance to indicate on the JDF
+                                                                          * a data collection to inspect during GPU transfer.
+                                                                          * User may want info from the DC (e.g. mtype),
+                                                                          * & otherwise remote copies don't have any info.
+                                                                          */
             /* These are private and should not be used outside the device driver */
-            parsec_data_copy_t       *sources[MAX_PARAM_COUNT];  /* If the driver decides to acquire the data from a different
-                                                                  * source, it will temporary store the best candidate here.
-                                                                  */
+            parsec_data_copy_t            *sources[MAX_PARAM_COUNT];  /* If the driver decides to acquire the data from a different
+                                                                       * source, it will temporary store the best candidate here.
+                                                                       */
         };
         struct {
-            parsec_data_copy_t        *copy;
+            parsec_data_copy_t            *copy;
         };
     };
 };

--- a/parsec/mca/device/transfer_gpu.c
+++ b/parsec/mca/device/transfer_gpu.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -277,12 +278,13 @@ parsec_gpu_create_w2r_task(parsec_device_gpu_module_t *gpu_device,
 
     w2r_task = (parsec_gpu_task_t *)malloc(sizeof(parsec_gpu_task_t));
     PARSEC_OBJ_CONSTRUCT(w2r_task, parsec_list_item_t);
-    w2r_task->ec               = (parsec_task_t*)d2h_task;
-    w2r_task->task_type        = PARSEC_GPU_TASK_TYPE_D2HTRANSFER;
+    w2r_task->release_device_task   = free;  /* by default free the device task */
+    w2r_task->ec                    = (parsec_task_t*)d2h_task;
+    w2r_task->task_type             = PARSEC_GPU_TASK_TYPE_D2HTRANSFER;
     w2r_task->last_data_check_epoch = gpu_device->data_avail_epoch - 1;
-    w2r_task->stage_in         = NULL;
-    w2r_task->stage_out        = &parsec_default_gpu_stage_out;
-    w2r_task->complete_stage   = NULL;
+    w2r_task->stage_in              = NULL;
+    w2r_task->stage_out             = &parsec_default_gpu_stage_out;
+    w2r_task->complete_stage        = NULL;
 
     (void)es;
     return w2r_task;


### PR DESCRIPTION
This makes the lifecycle of the device tasks symmetric: they are allocated by the DSL and therefore shall be freed by the DSL.

This addresses the request from #686.