### PR TITLE
Use red-black-tree in zone_malloc

### DIFF
--- a/parsec/CMakeLists.txt
+++ b/parsec/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BASE_SOURCES
   class/parsec_value_array.c
   class/parsec_hash_table.c
   class/parsec_rwlock.c
+  class/parsec_rbtree.c
   class/parsec_future.c
   class/parsec_datacopy_future.c
   class/info.c
@@ -323,6 +324,7 @@ install(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/class/list.h
         ${CMAKE_CURRENT_SOURCE_DIR}/class/info.h
         ${CMAKE_CURRENT_SOURCE_DIR}/class/parsec_future.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/class/parsec_rbtree.h
         DESTINATION ${PARSEC_INSTALL_INCLUDEDIR}/parsec/class)
 install(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/scheduling.h

--- a/parsec/class/parsec_rbtree.c
+++ b/parsec/class/parsec_rbtree.c
@@ -23,9 +23,17 @@ PARSEC_OBJ_CLASS_INSTANCE(parsec_rbtree_node_t, parsec_list_item_t,
                           parsec_rbtree_node_construct, NULL);
 
 void parsec_rbtree_init(parsec_rbtree_t* tree, size_t offset) {
-    tree->nil = PARSEC_OBJ_NEW(parsec_rbtree_node_t);
+    PARSEC_OBJ_CONSTRUCT(&tree->nil_element, parsec_rbtree_node_t);
+    tree->nil = &tree->nil_element;
     tree->root = tree->nil;
     tree->comp_offset = offset;
+}
+
+void parsec_rbtree_fini(parsec_rbtree_t* tree) {
+    PARSEC_OBJ_DESTRUCT(&tree->nil_element);
+    tree->nil = NULL;
+    tree->root = NULL;
+    tree->comp_offset = 0;
 }
 
 static inline

--- a/parsec/class/parsec_rbtree.c
+++ b/parsec/class/parsec_rbtree.c
@@ -1,0 +1,331 @@
+#include <stdbool.h>
+
+#include "parsec/parsec_config.h"
+
+#include "parsec/class/parsec_rbtree.h"
+#include "parsec/constants.h"
+
+/* left and right children, using list pointers */
+#define LEFT(node)  (*(parsec_rbtree_node_t**)&node->super.list_prev)
+#define RIGHT(node) (*(parsec_rbtree_node_t**)&node->super.list_next)
+
+
+/**
+ * The list_item object instance.
+ */
+static inline void
+parsec_rbtree_node_construct( parsec_rbtree_node_t* item )
+{
+    item->color = PARSEC_RBTREE_BLACK;
+}
+
+PARSEC_OBJ_CLASS_INSTANCE(parsec_rbtree_node_t, parsec_list_item_t,
+                          parsec_rbtree_node_construct, NULL);
+
+void parsec_rbtree_init(parsec_rbtree_t* tree, size_t offset) {
+    tree->nil = PARSEC_OBJ_NEW(parsec_rbtree_node_t);
+    tree->root = tree->nil;
+    tree->comp_offset = offset;
+}
+
+static inline
+void parsec_rbtree_left_rotate(parsec_rbtree_t *tree, parsec_rbtree_node_t *x) {
+    parsec_rbtree_node_t *y = RIGHT(x);
+    RIGHT(x) = LEFT(y);
+    if (LEFT(y) != tree->nil) {
+        LEFT(y)->parent = x;
+    }
+    y->parent = x->parent;
+    if (x->parent == tree->nil) {
+        tree->root = y;
+    } else if (x == LEFT(x->parent)) {
+        LEFT(x->parent) = y;
+    } else {
+        RIGHT(x->parent) = y;
+    }
+    LEFT(y) = x;
+    x->parent = y;
+}
+
+static inline
+void parsec_rbtree_right_rotate(parsec_rbtree_t *tree, parsec_rbtree_node_t *y) {
+    parsec_rbtree_node_t *x = LEFT(y);
+    LEFT(y) = RIGHT(x);
+    if (RIGHT(x) != tree->nil) {
+        RIGHT(x)->parent = y;
+    }
+    x->parent = y->parent;
+    if (y->parent == tree->nil) {
+        tree->root = x;
+    } else if (y == LEFT(y->parent)) {
+        LEFT(y->parent) = x;
+    } else {
+        RIGHT(y->parent) = x;
+    }
+    RIGHT(x) = y;
+    y->parent = x;
+}
+
+static void parsec_rbtree_insert_fixup(parsec_rbtree_t *tree, parsec_rbtree_node_t *z) {
+    while (z->parent->color == PARSEC_RBTREE_RED) {
+        if (z->parent == LEFT(z->parent->parent)) {
+            parsec_rbtree_node_t *y = RIGHT(z->parent->parent);
+            if (y->color == PARSEC_RBTREE_RED) {
+                z->parent->color = PARSEC_RBTREE_BLACK;
+                y->color = PARSEC_RBTREE_BLACK;
+                z->parent->parent->color = PARSEC_RBTREE_RED;
+                z = z->parent->parent;
+            } else {
+                if (z == RIGHT(z->parent)) {
+                    z = z->parent;
+                    parsec_rbtree_left_rotate(tree, z);
+                }
+                z->parent->color = PARSEC_RBTREE_BLACK;
+                z->parent->parent->color = PARSEC_RBTREE_RED;
+                parsec_rbtree_right_rotate(tree, z->parent->parent);
+            }
+        } else {
+            parsec_rbtree_node_t *y = LEFT(z->parent->parent);
+            if (y->color == PARSEC_RBTREE_RED) {
+                z->parent->color = PARSEC_RBTREE_BLACK;
+                y->color = PARSEC_RBTREE_BLACK;
+                z->parent->parent->color = PARSEC_RBTREE_RED;
+                z = z->parent->parent;
+            } else {
+                if (z == LEFT(z->parent)) {
+                    z = z->parent;
+                    parsec_rbtree_right_rotate(tree, z);
+                }
+                z->parent->color = PARSEC_RBTREE_BLACK;
+                z->parent->parent->color = PARSEC_RBTREE_RED;
+                parsec_rbtree_left_rotate(tree, z->parent->parent);
+            }
+        }
+    }
+    tree->root->color = PARSEC_RBTREE_BLACK;
+}
+
+void parsec_rbtree_insert(parsec_rbtree_t *tree, parsec_rbtree_node_t *node) {
+    node->color = PARSEC_RBTREE_RED;
+    node->parent = tree->nil;
+    parsec_rbtree_node_t *z = node;
+    parsec_rbtree_node_t *y = tree->nil;
+    parsec_rbtree_node_t *x = tree->root;
+    while (x != tree->nil) {
+        y = x;
+        if (A_LOWER_PRIORITY_THAN_B(z, x, tree->comp_offset)) {
+            x = LEFT(x);
+        } else {
+            x = RIGHT(x);
+        }
+    }
+    z->parent = y;
+    if (y == tree->nil) {
+        tree->root = z;
+    } else if (A_LOWER_PRIORITY_THAN_B(z, y, tree->comp_offset)) {
+        LEFT(y) = z;
+    } else {
+        RIGHT(y) = z;
+    }
+    LEFT(z) = tree->nil;
+    RIGHT(z) = tree->nil;
+    z->color = PARSEC_RBTREE_RED;
+    parsec_rbtree_insert_fixup(tree, z);
+}
+
+static void parsec_rbtree_delete_fixup(parsec_rbtree_t *tree, parsec_rbtree_node_t *x) {
+    while (x != tree->root && x->color == PARSEC_RBTREE_BLACK) {
+        if (x == LEFT(x->parent)) {
+            parsec_rbtree_node_t *w = RIGHT(x->parent);
+            if (w->color == PARSEC_RBTREE_RED) {
+                w->color = PARSEC_RBTREE_BLACK;
+                x->parent->color = PARSEC_RBTREE_RED;
+                parsec_rbtree_left_rotate(tree, x->parent);
+                w = RIGHT(x->parent);
+            }
+            if (LEFT(w)->color == PARSEC_RBTREE_BLACK && RIGHT(w)->color == PARSEC_RBTREE_BLACK) {
+                w->color = PARSEC_RBTREE_RED;
+                x = x->parent;
+            } else {
+                if (RIGHT(w)->color == PARSEC_RBTREE_BLACK) {
+                    LEFT(w)->color = PARSEC_RBTREE_BLACK;
+                    w->color = PARSEC_RBTREE_RED;
+                    parsec_rbtree_right_rotate(tree, w);
+                    w = RIGHT(x->parent);
+                }
+                w->color = x->parent->color;
+                x->parent->color = PARSEC_RBTREE_BLACK;
+                RIGHT(w)->color = PARSEC_RBTREE_BLACK;
+                parsec_rbtree_left_rotate(tree, x->parent);
+                x = tree->root;
+            }
+        } else {
+            parsec_rbtree_node_t *w = LEFT(x->parent);
+            if (w->color == PARSEC_RBTREE_RED) {
+                w->color = PARSEC_RBTREE_BLACK;
+                x->parent->color = PARSEC_RBTREE_RED;
+                parsec_rbtree_right_rotate(tree, x->parent);
+                w = LEFT(x->parent);
+            }
+            if (RIGHT(w)->color == PARSEC_RBTREE_BLACK && LEFT(w)->color == PARSEC_RBTREE_BLACK) {
+                w->color = PARSEC_RBTREE_RED;
+                x = x->parent;
+            } else {
+                if (LEFT(w)->color == PARSEC_RBTREE_BLACK) {
+                    RIGHT(w)->color = PARSEC_RBTREE_BLACK;
+                    w->color = PARSEC_RBTREE_RED;
+                    parsec_rbtree_left_rotate(tree, w);
+                    w = LEFT(x->parent);
+                }
+                w->color = x->parent->color;
+                x->parent->color = PARSEC_RBTREE_BLACK;
+                LEFT(w)->color = PARSEC_RBTREE_BLACK;
+                parsec_rbtree_right_rotate(tree, x->parent);
+                x = tree->root;
+            }
+        }
+    }
+    x->color = PARSEC_RBTREE_BLACK;
+}
+
+static inline void parsec_rbtree_transplant(parsec_rbtree_t *tree, parsec_rbtree_node_t *u, parsec_rbtree_node_t *v) {
+    if (u->parent == tree->nil) {
+        tree->root = v;
+    } else if (u == LEFT(u->parent)) {
+        LEFT(u->parent) = v;
+    } else {
+        RIGHT(u->parent) = v;
+    }
+    v->parent = u->parent;
+}
+
+parsec_rbtree_node_t* parsec_rbtree_minimum(parsec_rbtree_t *tree, parsec_rbtree_node_t *x) {
+    while (LEFT(x) != tree->nil) {
+        x = LEFT(x);
+    }
+    return x;
+}
+
+void parsec_rbtree_remove(parsec_rbtree_t *tree, parsec_rbtree_node_t *z) {
+    parsec_rbtree_node_t *y = z;
+    parsec_rbtree_node_t *x;
+    parsec_rbtree_color_e y_original_color = y->color;
+    if (LEFT(z) == tree->nil) {
+        x = RIGHT(z);
+        parsec_rbtree_transplant(tree, z, RIGHT(z));
+    } else if (RIGHT(z) == tree->nil) {
+        x = LEFT(z);
+        parsec_rbtree_transplant(tree, z, LEFT(z));
+    } else {
+        y = parsec_rbtree_minimum(tree, RIGHT(z));
+        y_original_color = y->color;
+        x = RIGHT(y);
+        if (y->parent == z) {
+            x->parent = y;
+        } else {
+            parsec_rbtree_transplant(tree, y, RIGHT(y));
+            RIGHT(y) = RIGHT(z);
+            RIGHT(y)->parent = y;
+        }
+        parsec_rbtree_transplant(tree, z, y);
+        LEFT(y) = LEFT(z);
+        LEFT(y)->parent = y;
+        y->color = z->color;
+    }
+    if (y_original_color == PARSEC_RBTREE_BLACK) {
+        parsec_rbtree_delete_fixup(tree, x);
+    }
+}
+
+parsec_rbtree_node_t* parsec_rbtree_find(parsec_rbtree_t *tree, int data) {
+    parsec_rbtree_node_t *current = tree->root;
+    while (current != tree->nil) {
+        int compval = COMPARISON_VAL(current, tree->comp_offset);
+        if (compval == data) {
+            return current;
+        } else if (compval < data) {
+            current = RIGHT(current);
+        } else {
+            current = LEFT(current);
+        }
+    }
+    return NULL; // data not found
+}
+
+parsec_rbtree_node_t* parsec_rbtree_find_or_larger(parsec_rbtree_t *tree, int data) {
+    parsec_rbtree_node_t *current = tree->root;
+    parsec_rbtree_node_t *larger  = tree->nil;
+    while (current != tree->nil) {
+        int compval = COMPARISON_VAL(current, tree->comp_offset);
+        if (compval == data) {
+            return current;
+        } else if (compval < data) {
+            current = RIGHT(current);
+        } else {
+            larger  = current;
+            current = LEFT(current);
+        }
+    }
+    if (larger == tree->nil) return NULL;
+    return larger; // data not found
+}
+
+
+int parsec_rbtree_update_node(parsec_rbtree_t *tree, parsec_rbtree_node_t *node, int newdata)
+{
+    bool needs_reinsert = false;
+    parsec_rbtree_node_t *parent = node->parent;
+    /* check whether parent and left/right nodes would still be in the right place */
+    if (parent != tree->nil) {
+        if (LEFT(parent) == node && COMPARISON_VAL(parent, tree->comp_offset) <= newdata) {
+            if (COMPARISON_VAL(parent, tree->comp_offset) == newdata) {
+                return PARSEC_ERR_EXISTS;
+            }
+            needs_reinsert = true; // node grew past the parent
+        } else if (RIGHT(parent) == node && COMPARISON_VAL(parent, tree->comp_offset) > newdata) {
+            /* no need to check for equality again here */
+            needs_reinsert = true; // node shrunk past the parent
+        } else if (LEFT(node) != tree->nil && COMPARISON_VAL(LEFT(node), tree->comp_offset) >= newdata) {
+            if (COMPARISON_VAL(LEFT(node), tree->comp_offset) == newdata) {
+                return PARSEC_ERR_EXISTS;
+            }
+            needs_reinsert = true; // node shrunk past its left child
+        } else if (RIGHT(node) != tree->nil && COMPARISON_VAL(RIGHT(node), tree->comp_offset) < newdata) {
+            if (COMPARISON_VAL(RIGHT(node), tree->comp_offset) == newdata) {
+                return PARSEC_ERR_EXISTS;
+            }
+            needs_reinsert = true; // node grew past its right child
+        }
+
+        if (needs_reinsert) {
+            /* remove and reinsert to ensure balancing */
+            parsec_rbtree_remove(tree, node);
+            COMPARISON_VAL(node, tree->comp_offset) = newdata;
+            parsec_rbtree_insert(tree, node);
+        } else {
+            /* simply update the node value */
+            COMPARISON_VAL(node, tree->comp_offset) = newdata;
+        }
+    }
+
+    return PARSEC_SUCCESS;
+}
+
+static void parsec_rbtree_foreach_node(
+    parsec_rbtree_t* tree,
+    parsec_rbtree_node_t* node,
+    parsec_rbtree_visitor_cb *fn,
+    void *cbdata)
+{
+    if (tree->nil != node) {
+        parsec_rbtree_foreach_node(tree, LEFT(node), fn, cbdata);
+        fn(node, cbdata);
+        parsec_rbtree_foreach_node(tree, RIGHT(node), fn, cbdata);
+    }
+}
+
+void parsec_rbtree_foreach(parsec_rbtree_t *tree, parsec_rbtree_visitor_cb *fn, void *cbdata) {
+    if (NULL != tree) {
+        parsec_rbtree_foreach_node(tree, tree->root, fn, cbdata);
+    }
+}

--- a/parsec/class/parsec_rbtree.c
+++ b/parsec/class/parsec_rbtree.c
@@ -5,10 +5,17 @@
 #include "parsec/class/parsec_rbtree.h"
 #include "parsec/constants.h"
 
-/* left and right children, using list pointers */
-#define LEFT(node)  (*(parsec_rbtree_node_t**)&node->super.list_prev)
-#define RIGHT(node) (*(parsec_rbtree_node_t**)&node->super.list_next)
+static inline parsec_rbtree_node_t** left_node(parsec_rbtree_node_t* node) {
+  return (parsec_rbtree_node_t**)&node->super.list_prev;
+}
 
+static inline parsec_rbtree_node_t** right_node(parsec_rbtree_node_t* node) {
+  return (parsec_rbtree_node_t**)&node->super.list_next;
+}
+
+/* left and right children, using list pointers */
+#define LEFT(node) (*left_node(node))
+#define RIGHT(node) (*right_node(node))
 
 /**
  * The list_item object instance.

--- a/parsec/class/parsec_rbtree.c
+++ b/parsec/class/parsec_rbtree.c
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2026      Stony Brook University.  All rights reserved.
+ */
+
 #include <stdbool.h>
 
 #include "parsec/parsec_config.h"
@@ -289,38 +293,56 @@ parsec_rbtree_node_t* parsec_rbtree_find_or_larger(parsec_rbtree_t *tree, int da
 int parsec_rbtree_update_node(parsec_rbtree_t *tree, parsec_rbtree_node_t *node, int newdata)
 {
     bool needs_reinsert = false;
-    parsec_rbtree_node_t *parent = node->parent;
-    /* check whether parent and left/right nodes would still be in the right place */
-    if (parent != tree->nil) {
-        if (LEFT(parent) == node && COMPARISON_VAL(parent, tree->comp_offset) <= newdata) {
-            if (COMPARISON_VAL(parent, tree->comp_offset) == newdata) {
-                return PARSEC_ERR_EXISTS;
-            }
-            needs_reinsert = true; // node grew past the parent
-        } else if (RIGHT(parent) == node && COMPARISON_VAL(parent, tree->comp_offset) > newdata) {
-            /* no need to check for equality again here */
-            needs_reinsert = true; // node shrunk past the parent
-        } else if (LEFT(node) != tree->nil && COMPARISON_VAL(LEFT(node), tree->comp_offset) >= newdata) {
-            if (COMPARISON_VAL(LEFT(node), tree->comp_offset) == newdata) {
-                return PARSEC_ERR_EXISTS;
-            }
-            needs_reinsert = true; // node shrunk past its left child
-        } else if (RIGHT(node) != tree->nil && COMPARISON_VAL(RIGHT(node), tree->comp_offset) < newdata) {
-            if (COMPARISON_VAL(RIGHT(node), tree->comp_offset) == newdata) {
-                return PARSEC_ERR_EXISTS;
-            }
-            needs_reinsert = true; // node grew past its right child
-        }
 
-        if (needs_reinsert) {
-            /* remove and reinsert to ensure balancing */
-            parsec_rbtree_remove(tree, node);
-            COMPARISON_VAL(node, tree->comp_offset) = newdata;
-            parsec_rbtree_insert(tree, node);
+    /* Find the in-order predecessor: rightmost node in the left subtree, or
+     * the first ancestor reached by walking up while on a left-child path. */
+    {
+        parsec_rbtree_node_t *pred;
+        if (LEFT(node) != tree->nil) {
+            pred = LEFT(node);
+            while (RIGHT(pred) != tree->nil) pred = RIGHT(pred);
         } else {
-            /* simply update the node value */
-            COMPARISON_VAL(node, tree->comp_offset) = newdata;
+            parsec_rbtree_node_t *x = node, *y = node->parent;
+            while (y != tree->nil && x == LEFT(y)) { x = y; y = y->parent; }
+            pred = y;
         }
+        if (pred != tree->nil) {
+            int pk = COMPARISON_VAL(pred, tree->comp_offset);
+            if (pk == newdata) return PARSEC_ERR_EXISTS;
+            if (pk  > newdata) needs_reinsert = true;
+        }
+    }
+
+    /* Find the in-order successor: leftmost node in the right subtree, or
+     * the first ancestor reached by walking up while on a right-child path. */
+    if (!needs_reinsert) {
+        parsec_rbtree_node_t *succ;
+        if (RIGHT(node) != tree->nil) {
+            succ = RIGHT(node);
+            while (LEFT(succ) != tree->nil) succ = LEFT(succ);
+        } else {
+            parsec_rbtree_node_t *x = node, *y = node->parent;
+            while (y != tree->nil && x == RIGHT(y)) { x = y; y = y->parent; }
+            succ = y;
+        }
+        if (succ != tree->nil) {
+            int sk = COMPARISON_VAL(succ, tree->comp_offset);
+            if (sk == newdata) return PARSEC_ERR_EXISTS;
+            if (sk  < newdata) needs_reinsert = true;
+        }
+    }
+
+    if (needs_reinsert) {
+        /* The new key requires moving the node.  Check for a duplicate first
+         * so the caller can merge lists rather than creating two nodes with
+         * the same key. */
+        if (parsec_rbtree_find(tree, newdata) != NULL) return PARSEC_ERR_EXISTS;
+        parsec_rbtree_remove(tree, node);
+        COMPARISON_VAL(node, tree->comp_offset) = newdata;
+        parsec_rbtree_insert(tree, node);
+    } else {
+        /* New key fits in the same BST position: update in place. */
+        COMPARISON_VAL(node, tree->comp_offset) = newdata;
     }
 
     return PARSEC_SUCCESS;

--- a/parsec/class/parsec_rbtree.h
+++ b/parsec/class/parsec_rbtree.h
@@ -1,0 +1,41 @@
+#ifndef PARSEC_RBTREE_H
+#define PARSEC_RBTREE_H
+
+#include "parsec/class/list_item.h"
+
+
+typedef enum parsec_rbtree_color_e { PARSEC_RBTREE_RED, PARSEC_RBTREE_BLACK } parsec_rbtree_color_e;
+
+typedef struct parsec_rbtree_node_t {
+    parsec_list_item_t super; // use prev/next for left/right
+    parsec_rbtree_color_e color;
+    struct parsec_rbtree_node_t *parent;
+} parsec_rbtree_node_t;
+
+PARSEC_DECLSPEC PARSEC_OBJ_CLASS_DECLARATION(parsec_rbtree_node_t);
+
+typedef struct parsec_rbtree_t {
+    parsec_rbtree_node_t *root;
+    parsec_rbtree_node_t *nil;
+    size_t comp_offset;
+} parsec_rbtree_t;
+
+typedef void (parsec_rbtree_visitor_cb)(parsec_rbtree_node_t*, void*);
+
+void parsec_rbtree_init(parsec_rbtree_t *tree, size_t compare_offset);
+
+void parsec_rbtree_insert(parsec_rbtree_t *tree, parsec_rbtree_node_t *node);
+
+parsec_rbtree_node_t* parsec_rbtree_minimum(parsec_rbtree_t *tree, parsec_rbtree_node_t *x);
+
+void parsec_rbtree_remove(parsec_rbtree_t *tree, parsec_rbtree_node_t *z);
+
+parsec_rbtree_node_t* parsec_rbtree_find(parsec_rbtree_t *tree, int data);
+
+parsec_rbtree_node_t* parsec_rbtree_find_or_larger(parsec_rbtree_t *tree, int data);
+
+int parsec_rbtree_update_node(parsec_rbtree_t *tree, parsec_rbtree_node_t *node, int newdata);
+
+void parsec_rbtree_foreach(parsec_rbtree_t *tree, parsec_rbtree_visitor_cb *fn, void *cbdata);
+
+#endif // PARSEC_RBTREE_H

--- a/parsec/class/parsec_rbtree.h
+++ b/parsec/class/parsec_rbtree.h
@@ -15,6 +15,7 @@ typedef struct parsec_rbtree_node_t {
 PARSEC_DECLSPEC PARSEC_OBJ_CLASS_DECLARATION(parsec_rbtree_node_t);
 
 typedef struct parsec_rbtree_t {
+    parsec_rbtree_node_t nil_element;
     parsec_rbtree_node_t *root;
     parsec_rbtree_node_t *nil;
     size_t comp_offset;
@@ -23,6 +24,8 @@ typedef struct parsec_rbtree_t {
 typedef void (parsec_rbtree_visitor_cb)(parsec_rbtree_node_t*, void*);
 
 void parsec_rbtree_init(parsec_rbtree_t *tree, size_t compare_offset);
+
+void parsec_rbtree_fini(parsec_rbtree_t* tree);
 
 void parsec_rbtree_insert(parsec_rbtree_t *tree, parsec_rbtree_node_t *node);
 

--- a/parsec/class/parsec_rbtree.h
+++ b/parsec/class/parsec_rbtree.h
@@ -1,8 +1,16 @@
+/*
+ * Copyright (c) 2026      Stony Brook University.  All rights reserved.
+ */
+
+
 #ifndef PARSEC_RBTREE_H
 #define PARSEC_RBTREE_H
 
+
 #include "parsec/class/list_item.h"
 
+
+BEGIN_C_DECLS
 
 typedef enum parsec_rbtree_color_e { PARSEC_RBTREE_RED, PARSEC_RBTREE_BLACK } parsec_rbtree_color_e;
 
@@ -40,5 +48,7 @@ parsec_rbtree_node_t* parsec_rbtree_find_or_larger(parsec_rbtree_t *tree, int da
 int parsec_rbtree_update_node(parsec_rbtree_t *tree, parsec_rbtree_node_t *node, int newdata);
 
 void parsec_rbtree_foreach(parsec_rbtree_t *tree, parsec_rbtree_visitor_cb *fn, void *cbdata);
+
+END_C_DECLS
 
 #endif // PARSEC_RBTREE_H

--- a/parsec/utils/zone_malloc.c
+++ b/parsec/utils/zone_malloc.c
@@ -135,7 +135,7 @@ void *zone_malloc(zone_malloc_t *gdata, size_t size)
     current_segment = (segment_t *)parsec_list_nolock_pop_front(&fl->list);
     assert(current_segment->nb_units >= nb_units);
     current_segment->status = SEGMENT_FULL;
-    if (parsec_list_is_empty(&fl->list)) {
+    if (parsec_list_nolock_is_empty(&fl->list)) {
         /* empty chunk list, remove */
         parsec_rbtree_remove(&gdata->rbtree, &fl->super);
         PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
@@ -256,7 +256,7 @@ void zone_free(zone_malloc_t *gdata, void *add)
         parsec_rbtree_insert(&gdata->rbtree, &fl->super);
     }
     assert(fl != NULL);
-    parsec_list_push_front(&fl->list, &current_segment->super);
+    parsec_list_nolock_push_front(&fl->list, &current_segment->super);
     parsec_atomic_unlock(&gdata->lock);
 }
 

--- a/parsec/utils/zone_malloc.c
+++ b/parsec/utils/zone_malloc.c
@@ -102,6 +102,8 @@ void* zone_malloc_fini(zone_malloc_t** gdata)
     (*gdata)->max_segment = 0;
     (*gdata)->unit_size = 0;
     (*gdata)->base = NULL;
+
+    parsec_rbtree_fini(&(*gdata)->rbtree);
     free(*gdata);
     *gdata = NULL;
     return base_ptr;

--- a/parsec/utils/zone_malloc.c
+++ b/parsec/utils/zone_malloc.c
@@ -8,7 +8,40 @@
 #include "parsec/utils/zone_malloc.h"
 #include "parsec/utils/debug.h"
 
+#include "parsec/class/list.h"
+#include "parsec/class/parsec_rbtree.h"
+
 #include <stdio.h>
+
+typedef struct zone_malloc_chunk_list_t {
+    parsec_rbtree_node_t super;
+    parsec_list_t list; /* list of free segments of specific size */
+    int nb_units;       /* size of free segments */
+} zone_malloc_chunk_list_t;
+
+static inline void
+zone_malloc_chunk_list_construct( zone_malloc_chunk_list_t* item )
+{
+    item->nb_units = 0;
+    PARSEC_OBJ_CONSTRUCT(&item->list, parsec_list_t);
+}
+
+PARSEC_OBJ_CLASS_INSTANCE(zone_malloc_chunk_list_t, parsec_rbtree_node_t,
+                          zone_malloc_chunk_list_construct, NULL);
+
+static zone_malloc_chunk_list_t* allocate_chunk_list(zone_malloc_t *gdata, int nb_units) {
+    zone_malloc_chunk_list_t* fl;
+    /* add a new segment */
+    if (!parsec_lifo_is_empty(&gdata->rbtree_free_list)) {
+        fl = (zone_malloc_chunk_list_t*)parsec_lifo_pop(&gdata->rbtree_free_list);
+    } else {
+        /* allocate new */
+        fl = PARSEC_OBJ_NEW(zone_malloc_chunk_list_t);
+    }
+    PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
+    fl->nb_units = nb_units;
+    return fl;
+}
 
 static inline void zone_malloc_error(const char *msg)
 {
@@ -41,15 +74,21 @@ zone_malloc_t* zone_malloc_init(void* base_ptr, int _max_segment, size_t _unit_s
     gdata->next_tid     = 0;
     gdata->segments     = (segment_t *)malloc(sizeof(segment_t) * _max_segment);
     parsec_atomic_lock_init(&gdata->lock);
-#if defined(PARSEC_DEBUG)
+    parsec_rbtree_init(&gdata->rbtree, offsetof(zone_malloc_chunk_list_t, nb_units));
+    PARSEC_OBJ_CONSTRUCT(&gdata->rbtree_free_list, parsec_lifo_t);
     for(int i = 0; i < _max_segment; i++) {
         SEGMENT_AT_TID(gdata, i)->status = SEGMENT_UNDEFINED;
+        PARSEC_OBJ_CONSTRUCT(&SEGMENT_AT_TID(gdata, i)->super, parsec_list_item_t);
     }
-#endif /* defined(PARSEC_DEBUG) */
     head = SEGMENT_AT_TID(gdata, 0);
     head->status = SEGMENT_EMPTY;
     head->nb_units = _max_segment;
     head->nb_prev  = 1; /**< This is to force SEGMENT_OF_TID( 0 - prev ) to return NULL */
+
+    zone_malloc_chunk_list_t *fl = PARSEC_OBJ_NEW(zone_malloc_chunk_list_t);
+    fl->nb_units = head->nb_units;
+    parsec_list_push_back(&fl->list, &head->super);
+    parsec_rbtree_insert(&gdata->rbtree, &fl->super);
 
     return gdata;
 }
@@ -72,52 +111,81 @@ void *zone_malloc(zone_malloc_t *gdata, size_t size)
 {
     segment_t *current_segment, *next_segment, *new_segment;
     int next_tid, current_tid, new_tid;
-    int cycled_through = 0, nb_units;
+    int nb_units;
+    zone_malloc_chunk_list_t* fl;
 
-    parsec_atomic_lock(&gdata->lock);
-    /* Let's start with the last remembered free slot */
-    current_tid = gdata->next_tid;
     nb_units = (size + gdata->unit_size - 1) / gdata->unit_size;
 
-    do {
-        current_segment = SEGMENT_AT_TID(gdata, current_tid);
-        if( NULL == current_segment ) {
-            /* Maybe there is a free slot in the beginning. Let's cycle at least once before we bail out */
-            if( 0 != cycled_through ) break;
-            current_tid = 0;
-            cycled_through = 1;
-            current_segment = SEGMENT_AT_TID(gdata, current_tid);
+    if (nb_units == 0) {
+        return NULL;
+    }
+
+    parsec_atomic_lock(&gdata->lock);
+    /* try to find the smallest possible element, or one size larger */
+    fl = (zone_malloc_chunk_list_t*) parsec_rbtree_find_or_larger(&gdata->rbtree, nb_units);
+
+    if (NULL == fl) {
+        /* no segment found */
+        parsec_atomic_unlock(&gdata->lock);
+        return NULL;
+    }
+
+    current_segment = (segment_t *)parsec_list_nolock_pop_front(&fl->list);
+    assert(current_segment->nb_units >= nb_units);
+    current_segment->status = SEGMENT_FULL;
+    if (parsec_list_is_empty(&fl->list)) {
+        /* empty chunk list, remove */
+        parsec_rbtree_remove(&gdata->rbtree, &fl->super);
+        PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
+        /* put into free list */
+        parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
+    }
+    current_tid = (current_segment - gdata->segments);
+    if (current_segment->nb_units > nb_units) {
+        /* segment must be split */
+        next_tid = current_tid + current_segment->nb_units;
+
+        /* get the following segment and put it into the rbtree */
+        next_segment = SEGMENT_AT_TID(gdata, next_tid);
+        if( NULL != next_segment ) {
+            next_segment->nb_prev -= nb_units;
         }
 
-        if( current_segment->status == SEGMENT_EMPTY && current_segment->nb_units >= nb_units ) {
-            current_segment->status = SEGMENT_FULL;
-            if( current_segment->nb_units > nb_units ) {
-                next_tid = current_tid + current_segment->nb_units;
+        new_tid = current_tid + nb_units;
+        new_segment = SEGMENT_AT_TID(gdata, new_tid);
+        new_segment->status = SEGMENT_EMPTY;
+        new_segment->nb_prev  = nb_units;
+        new_segment->nb_units = current_segment->nb_units - nb_units;
 
-                next_segment = SEGMENT_AT_TID(gdata, next_tid);
-                if( NULL != next_segment )
-                    next_segment->nb_prev -= nb_units;
-
-                new_tid = current_tid + nb_units;
-                new_segment = SEGMENT_AT_TID(gdata, new_tid);
-                new_segment->status = SEGMENT_EMPTY;
-                new_segment->nb_prev  = nb_units;
-                new_segment->nb_units = current_segment->nb_units - nb_units;
-
-                /* new_tid is a free slot, remember for next malloc */
-                gdata->next_tid = new_tid;
-
-                current_segment->nb_units = nb_units;
-            }
-            parsec_atomic_unlock(&gdata->lock);
-            return (void*)(gdata->base + (current_tid * gdata->unit_size));
+        fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, new_segment->nb_units);
+        if (fl == NULL) {
+            /* create new chunk list and insert into rbtree */
+            fl = allocate_chunk_list(gdata, new_segment->nb_units);
+            parsec_rbtree_insert(&gdata->rbtree, &fl->super);
         }
+        parsec_list_nolock_push_front(&fl->list, &new_segment->super);
 
-        current_tid += current_segment->nb_units;
-    } while( current_tid != gdata->next_tid );
-
+        /* reduce size of current segment */
+        current_segment->nb_units = nb_units;
+    }
+    /* found segment of right size, done */
     parsec_atomic_unlock(&gdata->lock);
-    return NULL;
+    return (void*)(gdata->base + (current_tid * gdata->unit_size));
+}
+
+static void remove_segment_from_rbtree(zone_malloc_t *gdata, segment_t *current_segment) {
+    zone_malloc_chunk_list_t *fl;
+    /* find chunk list */
+    fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, current_segment->nb_units);
+    assert(fl != NULL);
+    /* remove from list */
+    parsec_list_nolock_remove(&fl->list, &current_segment->super);
+    if (parsec_list_nolock_is_empty(&fl->list)) {
+        /* empty chunk list, remove */
+        parsec_rbtree_remove(&gdata->rbtree, &fl->super);
+        /* put into free list */
+        parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
+    }
 }
 
 void zone_free(zone_malloc_t *gdata, void *add)
@@ -125,6 +193,7 @@ void zone_free(zone_malloc_t *gdata, void *add)
     segment_t *current_segment, *next_segment, *prev_segment;
     int current_tid, next_tid, prev_tid;
     off_t offset;
+    zone_malloc_chunk_list_t *fl;
 
     parsec_atomic_lock(&gdata->lock);
     offset = (char*)add -gdata->base;
@@ -144,6 +213,7 @@ void zone_free(zone_malloc_t *gdata, void *add)
         return;
     }
 
+    /* check if we can merge segments */
     current_segment->status = SEGMENT_EMPTY;
 
     prev_tid = current_tid - current_segment->nb_prev;
@@ -152,7 +222,8 @@ void zone_free(zone_malloc_t *gdata, void *add)
     next_tid = current_tid + current_segment->nb_units;
     next_segment = SEGMENT_AT_TID(gdata, next_tid);
 
-    if( NULL != prev_segment && prev_segment->status == SEGMENT_EMPTY ) {
+    if (NULL != prev_segment && prev_segment->status == SEGMENT_EMPTY) {
+        remove_segment_from_rbtree(gdata, prev_segment);
         /* We can merge prev and current */
         if( NULL != next_segment ) {
             next_segment->nb_prev += prev_segment->nb_units;
@@ -164,10 +235,8 @@ void zone_free(zone_malloc_t *gdata, void *add)
         current_tid     = prev_tid;
     }
 
-    /* current_tid is a free slot, remember for next malloc */
-    gdata->next_tid = current_tid;
-
-    if( NULL != next_segment && next_segment->status == SEGMENT_EMPTY ) {
+    if (NULL != next_segment && next_segment->status == SEGMENT_EMPTY) {
+        remove_segment_from_rbtree(gdata, next_segment);
         /* We can merge current and next */
         next_tid += next_segment->nb_units;
         current_segment->nb_units += next_segment->nb_units;
@@ -176,6 +245,16 @@ void zone_free(zone_malloc_t *gdata, void *add)
             next_segment->nb_prev = current_segment->nb_units;
         }
     }
+
+    /* add the chunk into the RB tree */
+    fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, current_segment->nb_units);
+    if (fl == NULL) {
+        /* no chunk list, create a new entry */
+        fl = allocate_chunk_list(gdata, current_segment->nb_units);
+        parsec_rbtree_insert(&gdata->rbtree, &fl->super);
+    }
+    assert(fl != NULL);
+    parsec_list_push_front(&fl->list, &current_segment->super);
     parsec_atomic_unlock(&gdata->lock);
 }
 
@@ -185,6 +264,7 @@ size_t zone_in_use(zone_malloc_t *gdata)
     segment_t *current_segment;
     int current_tid;
     parsec_atomic_lock(&gdata->lock);
+    /* check segments */
     for(current_tid = 0;
         (current_segment = SEGMENT_AT_TID(gdata, current_tid)) != NULL;
         current_tid += current_segment->nb_units) {
@@ -196,6 +276,19 @@ size_t zone_in_use(zone_malloc_t *gdata)
     return ret;
 }
 
+typedef struct zone_malloc_rbtree_debug_t {
+    int level, output_id;
+    const char* prefix;
+} zone_malloc_rbtree_debug_t;
+
+static void zone_rbtree_cb(parsec_rbtree_node_t *node, void *data) {
+    zone_malloc_chunk_list_t *fl = (zone_malloc_chunk_list_t*)node;
+    zone_malloc_rbtree_debug_t* info = (zone_malloc_rbtree_debug_t*)data;
+    int len = 0;
+    PARSEC_LIST_NOLOCK_ITERATOR(&fl->list, iter, (void)iter; ++len; );
+    parsec_debug_verbose(info->level, info->output_id, "%srbtree node: %d segments a %d units",
+                         info->prefix, len, fl->nb_units);
+}
 
 size_t zone_debug(zone_malloc_t *gdata, int level, int output_id, const char *prefix)
 {
@@ -224,6 +317,10 @@ size_t zone_debug(zone_malloc_t *gdata, int level, int output_id, const char *pr
                                      gdata->base + (current_tid+current_segment->nb_units) * gdata->unit_size - 1);
         }
     }
+    zone_malloc_rbtree_debug_t info = {level, output_id, prefix};
+    parsec_rbtree_foreach(&gdata->rbtree, zone_rbtree_cb, &info);
+
     parsec_atomic_unlock(&gdata->lock);
+
     return ret;
 }

--- a/parsec/utils/zone_malloc.c
+++ b/parsec/utils/zone_malloc.c
@@ -105,6 +105,22 @@ void* zone_malloc_fini(zone_malloc_t** gdata)
     (*gdata)->unit_size = 0;
     (*gdata)->base = NULL;
 
+    /* Release all chunk_list nodes still in the rbtree, including the
+     * whole-pool node created in zone_malloc_init. */
+    zone_malloc_chunk_list_t* fl;
+    while ((*gdata)->rbtree.root != (*gdata)->rbtree.nil) {
+        fl = (zone_malloc_chunk_list_t*)(*gdata)->rbtree.root;
+        parsec_rbtree_remove(&(*gdata)->rbtree, (*gdata)->rbtree.root);
+        PARSEC_OBJ_RELEASE(fl);
+    }
+
+    /* Release chunk_list nodes retired to the free list.  These are already
+     * out of the rbtree, so no tree operation is needed. */
+    while (!parsec_lifo_nolock_is_empty(&(*gdata)->rbtree_free_list)) {
+        fl = (zone_malloc_chunk_list_t*)parsec_lifo_nolock_pop(&(*gdata)->rbtree_free_list);
+        PARSEC_OBJ_RELEASE(fl);
+    }
+
     parsec_rbtree_fini(&(*gdata)->rbtree);
     free(*gdata);
     *gdata = NULL;

--- a/parsec/utils/zone_malloc.c
+++ b/parsec/utils/zone_malloc.c
@@ -2,11 +2,13 @@
  * Copyright (c) 2012-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      Stony Brook University.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
 #include "parsec/utils/zone_malloc.h"
 #include "parsec/utils/debug.h"
+#include "parsec/constants.h"
 
 #include "parsec/class/list.h"
 #include "parsec/class/parsec_rbtree.h"
@@ -135,19 +137,13 @@ void *zone_malloc(zone_malloc_t *gdata, size_t size)
     current_segment = (segment_t *)parsec_list_nolock_pop_front(&fl->list);
     assert(current_segment->nb_units >= nb_units);
     current_segment->status = SEGMENT_FULL;
-    if (parsec_list_nolock_is_empty(&fl->list)) {
-        /* empty chunk list, remove */
-        parsec_rbtree_remove(&gdata->rbtree, &fl->super);
-        PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
-        /* put into free list */
-        parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
-    }
+    int fl_emptied = parsec_list_nolock_is_empty(&fl->list);
     current_tid = (current_segment - gdata->segments);
     if (current_segment->nb_units > nb_units) {
         /* segment must be split */
         next_tid = current_tid + current_segment->nb_units;
 
-        /* get the following segment and put it into the rbtree */
+        /* get the following segment and update its back-pointer */
         next_segment = SEGMENT_AT_TID(gdata, next_tid);
         if( NULL != next_segment ) {
             next_segment->nb_prev -= nb_units;
@@ -159,35 +155,45 @@ void *zone_malloc(zone_malloc_t *gdata, size_t size)
         new_segment->nb_prev  = nb_units;
         new_segment->nb_units = current_segment->nb_units - nb_units;
 
-        fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, new_segment->nb_units);
-        if (fl == NULL) {
-            /* create new chunk list and insert into rbtree */
-            fl = allocate_chunk_list(gdata, new_segment->nb_units);
-            parsec_rbtree_insert(&gdata->rbtree, &fl->super);
+        if (fl_emptied) {
+            /* The chunk-list for the old size is now empty.  Try to reuse it
+             * for the remainder by updating its key in place; this avoids a
+             * remove+insert pair when the new size fits in the same BST
+             * position (e.g., sequential allocation into a single large chunk). */
+            if (parsec_rbtree_update_node(&gdata->rbtree, &fl->super,
+                                          new_segment->nb_units) == PARSEC_SUCCESS) {
+                fl->nb_units = new_segment->nb_units;
+                parsec_list_nolock_push_front(&fl->list, &new_segment->super);
+            } else {
+                /* A node for the remainder size already exists; retire fl. */
+                parsec_rbtree_remove(&gdata->rbtree, &fl->super);
+                PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
+                parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
+                fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree,
+                                                                    new_segment->nb_units);
+                assert(fl != NULL);
+                parsec_list_nolock_push_front(&fl->list, &new_segment->super);
+            }
+        } else {
+            fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, new_segment->nb_units);
+            if (fl == NULL) {
+                fl = allocate_chunk_list(gdata, new_segment->nb_units);
+                parsec_rbtree_insert(&gdata->rbtree, &fl->super);
+            }
+            parsec_list_nolock_push_front(&fl->list, &new_segment->super);
         }
-        parsec_list_nolock_push_front(&fl->list, &new_segment->super);
 
         /* reduce size of current segment */
         current_segment->nb_units = nb_units;
+    } else if (fl_emptied) {
+        /* No split and the chunk-list is now empty: remove it. */
+        parsec_rbtree_remove(&gdata->rbtree, &fl->super);
+        PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
+        parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
     }
     /* found segment of right size, done */
     parsec_atomic_unlock(&gdata->lock);
     return (void*)(gdata->base + (current_tid * gdata->unit_size));
-}
-
-static void remove_segment_from_rbtree(zone_malloc_t *gdata, segment_t *current_segment) {
-    zone_malloc_chunk_list_t *fl;
-    /* find chunk list */
-    fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, current_segment->nb_units);
-    assert(fl != NULL);
-    /* remove from list */
-    parsec_list_nolock_remove(&fl->list, &current_segment->super);
-    if (parsec_list_nolock_is_empty(&fl->list)) {
-        /* empty chunk list, remove */
-        parsec_rbtree_remove(&gdata->rbtree, &fl->super);
-        /* put into free list */
-        parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
-    }
 }
 
 void zone_free(zone_malloc_t *gdata, void *add)
@@ -195,7 +201,7 @@ void zone_free(zone_malloc_t *gdata, void *add)
     segment_t *current_segment, *next_segment, *prev_segment;
     int current_tid, next_tid, prev_tid;
     off_t offset;
-    zone_malloc_chunk_list_t *fl;
+    zone_malloc_chunk_list_t *fl, *reuse_fl = NULL;
 
     parsec_atomic_lock(&gdata->lock);
     offset = (char*)add -gdata->base;
@@ -224,8 +230,31 @@ void zone_free(zone_malloc_t *gdata, void *add)
     next_tid = current_tid + current_segment->nb_units;
     next_segment = SEGMENT_AT_TID(gdata, next_tid);
 
+    /* Pre-compute the fully merged size so we can update an empty fl in place,
+     * avoiding a remove+insert pair in the common sequential-free pattern. */
+    int merged_nb_units = current_segment->nb_units;
+    if (NULL != prev_segment && prev_segment->status == SEGMENT_EMPTY)
+        merged_nb_units += prev_segment->nb_units;
+    if (NULL != next_segment && next_segment->status == SEGMENT_EMPTY)
+        merged_nb_units += next_segment->nb_units;
+
     if (NULL != prev_segment && prev_segment->status == SEGMENT_EMPTY) {
-        remove_segment_from_rbtree(gdata, prev_segment);
+        fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, prev_segment->nb_units);
+        assert(fl != NULL);
+        parsec_list_nolock_remove(&fl->list, &prev_segment->super);
+        if (parsec_list_nolock_is_empty(&fl->list)) {
+            /* fl is empty and still in the tree; update its key to merged_nb_units
+             * so we can reuse it without a remove+insert. */
+            if (parsec_rbtree_update_node(&gdata->rbtree, &fl->super, merged_nb_units) == PARSEC_SUCCESS) {
+                fl->nb_units = merged_nb_units;
+                reuse_fl = fl;
+            } else {
+                /* A node for merged_nb_units already exists; retire fl. */
+                parsec_rbtree_remove(&gdata->rbtree, &fl->super);
+                PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
+                parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
+            }
+        }
         /* We can merge prev and current */
         if( NULL != next_segment ) {
             next_segment->nb_prev += prev_segment->nb_units;
@@ -238,7 +267,27 @@ void zone_free(zone_malloc_t *gdata, void *add)
     }
 
     if (NULL != next_segment && next_segment->status == SEGMENT_EMPTY) {
-        remove_segment_from_rbtree(gdata, next_segment);
+        fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, next_segment->nb_units);
+        assert(fl != NULL);
+        parsec_list_nolock_remove(&fl->list, &next_segment->super);
+        if (parsec_list_nolock_is_empty(&fl->list)) {
+            if (reuse_fl == NULL) {
+                /* No prev merge reuse yet; try to reuse this fl. */
+                if (parsec_rbtree_update_node(&gdata->rbtree, &fl->super, merged_nb_units) == PARSEC_SUCCESS) {
+                    fl->nb_units = merged_nb_units;
+                    reuse_fl = fl;
+                } else {
+                    parsec_rbtree_remove(&gdata->rbtree, &fl->super);
+                    PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
+                    parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
+                }
+            } else {
+                /* Already have reuse_fl; retire this one. */
+                parsec_rbtree_remove(&gdata->rbtree, &fl->super);
+                PARSEC_LIST_ITEM_SINGLETON(&fl->super.super);
+                parsec_lifo_nolock_push(&gdata->rbtree_free_list, &fl->super.super);
+            }
+        }
         /* We can merge current and next */
         next_tid += next_segment->nb_units;
         current_segment->nb_units += next_segment->nb_units;
@@ -248,15 +297,20 @@ void zone_free(zone_malloc_t *gdata, void *add)
         }
     }
 
-    /* add the chunk into the RB tree */
-    fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, current_segment->nb_units);
-    if (fl == NULL) {
-        /* no chunk list, create a new entry */
-        fl = allocate_chunk_list(gdata, current_segment->nb_units);
-        parsec_rbtree_insert(&gdata->rbtree, &fl->super);
+    /* add the merged chunk into the RB tree */
+    if (reuse_fl != NULL) {
+        /* reuse_fl is already in the tree with key = merged_nb_units */
+        parsec_list_nolock_push_front(&reuse_fl->list, &current_segment->super);
+    } else {
+        fl = (zone_malloc_chunk_list_t*)parsec_rbtree_find(&gdata->rbtree, current_segment->nb_units);
+        if (fl == NULL) {
+            /* no chunk list, create a new entry */
+            fl = allocate_chunk_list(gdata, current_segment->nb_units);
+            parsec_rbtree_insert(&gdata->rbtree, &fl->super);
+        }
+        assert(fl != NULL);
+        parsec_list_nolock_push_front(&fl->list, &current_segment->super);
     }
-    assert(fl != NULL);
-    parsec_list_nolock_push_front(&fl->list, &current_segment->super);
     parsec_atomic_unlock(&gdata->lock);
 }
 

--- a/parsec/utils/zone_malloc.h
+++ b/parsec/utils/zone_malloc.h
@@ -10,6 +10,9 @@
 #include "parsec/parsec_config.h"
 #include "parsec/sys/atomic.h"
 
+#include "parsec/class/parsec_rbtree.h"
+#include "parsec/class/lifo.h"
+
 #include <stdlib.h>
 #include <assert.h>
 
@@ -20,18 +23,21 @@ BEGIN_C_DECLS
 #define SEGMENT_UNDEFINED  3
 
 typedef struct segment {
+    parsec_list_item_t super;
     int status;     /* True if this segment is full, false if it is free */
-    int32_t nb_units;   /* Number of units on this segment */
-    int32_t nb_prev;    /* Number of units on the segment before */
+    int nb_units;   /* Number of units on this segment */
+    int nb_prev;    /* Number of units on the segment before */
 } segment_t;
 
 typedef struct zone_malloc_s {
     char      *base;                 /* Base pointer              */
-    segment_t *segments;             /* Array of available segments */
+    segment_t *segments;             /* Array of segments */
     size_t     unit_size;            /* Basic Unit                */
     int        max_segment;          /* Maximum number of segment */
     int        next_tid;             /* Next TID to look at for a malloc */
     parsec_atomic_lock_t lock;
+    parsec_rbtree_t rbtree;          /* RB tree tracking chunks of free segments */
+    parsec_lifo_t rbtree_free_list;
 } zone_malloc_t;
 
 

--- a/parsec/utils/zone_malloc.h
+++ b/parsec/utils/zone_malloc.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      Stony Brook University.  All rights reserved.
  */
 
 #ifndef _ZONE_MALLOC_H_

--- a/tests/runtime/cuda/CMakeLists.txt
+++ b/tests/runtime/cuda/CMakeLists.txt
@@ -26,3 +26,6 @@ if(PARSEC_HAVE_CUDA)
   target_include_directories(testing_get_best_device PRIVATE $<$<NOT:${PARSEC_BUILD_INPLACE}>:${CMAKE_CURRENT_SOURCE_DIR}>)
   target_ptg_sources(testing_get_best_device PRIVATE "get_best_device_check.jdf")
 endif(PARSEC_HAVE_CUDA)
+
+parsec_addtest_executable(C zonemalloc SOURCES zonemalloc.c)
+

--- a/tests/runtime/cuda/zonemalloc.c
+++ b/tests/runtime/cuda/zonemalloc.c
@@ -1,0 +1,88 @@
+#include "parsec.h"
+#include "parsec/utils/zone_malloc.h"
+
+#define NUM_SEGMENTS 128
+
+
+int main(int argc, char **argv) {
+    parsec_context_t *parsec = NULL;
+
+#if defined(DISTRIBUTED)
+    {
+        int provided;
+        MPI_Init_thread(NULL, NULL, MPI_THREAD_SERIALIZED, &provided);
+    }
+#endif /* DISTRIBUTED */
+
+    /* Initialize PaRSEC */
+    parsec = parsec_init(1, &argc, &argv);
+    if( NULL == parsec ) {
+        /* Failed to correctly initialize. In a correct scenario report*/
+         /* upstream, but in this particular case bail out.*/
+        exit(-1);
+    }
+
+    char** segments = calloc(NUM_SEGMENTS, sizeof(char*));
+
+    char *base = malloc(NUM_SEGMENTS*512);
+    zone_malloc_t *gdata;
+    gdata = zone_malloc_init(base, NUM_SEGMENTS, 512);
+    assert(gdata != NULL);
+
+    /* allocate and free all segments same size */
+    for (int i = 0; i < NUM_SEGMENTS; ++i) {
+        segments[i] = zone_malloc(gdata, 512);
+        assert(segments[i] != NULL);
+    }
+    zone_debug(gdata, 0, 0, "sequential alloc: ");
+
+    /* free all segments sequentially */
+    for (int i = 0; i < NUM_SEGMENTS; ++i) {
+        zone_free(gdata, segments[i]);
+        segments[i] = NULL;
+    }
+    zone_debug(gdata, 0, 0, "sequential free: ");
+
+    /* allocate all segments same size */
+    for (int i = 0; i < NUM_SEGMENTS; ++i) {
+        segments[i] = zone_malloc(gdata, 512);
+        assert(segments[i] != NULL);
+    }
+    zone_debug(gdata, 0, 0, "stride alloc: ");
+
+    /* free segments with stride */
+    for (int i = 0; i < NUM_SEGMENTS; i += 2) {
+        zone_free(gdata, segments[i]);
+        segments[i] = NULL;
+    }
+    zone_debug(gdata, 0, 0, "stried free1: ");
+    for (int i = 1; i < NUM_SEGMENTS; i += 2) {
+        zone_free(gdata, segments[i]);
+        segments[i] = NULL;
+    }
+    zone_debug(gdata, 0, 0, "stried free2: ");
+
+    /* allocate segments with 2 different sizes (256, 512) */
+    for (int i = 0; i < NUM_SEGMENTS; ++i) {
+        segments[i] = zone_malloc(gdata, 512/((i%2)+1));
+        assert(segments[i] != NULL);
+    }
+
+    /* free them in reverse order */
+    for (int i = NUM_SEGMENTS-1; i > 0; i--) {
+        zone_free(gdata, segments[i]);
+        segments[i] = NULL;
+    }
+
+
+
+    zone_malloc_fini(&gdata);
+    free(base);
+    free(segments);
+
+
+    parsec_fini(&parsec);
+#if defined(DISTRIBUTED)
+    MPI_Finalize();
+#endif /* DISTRIBUTED */
+}

--- a/tests/runtime/cuda/zonemalloc_benchmark.c
+++ b/tests/runtime/cuda/zonemalloc_benchmark.c
@@ -138,7 +138,7 @@ static int pow2_L(int num_segments)
     return L;
 }
 
-static double bench_pow2(int num_segments, int iterations)
+static double bench_pow2(int num_segments, int iterations, long *actual_ops_out)
 {
     int L = pow2_L(num_segments);
     unsigned *sizes = (unsigned *)malloc((size_t)L * sizeof(unsigned));
@@ -148,20 +148,21 @@ static double bench_pow2(int num_segments, int iterations)
     zone_malloc_t *z = make_zone(&base, num_segments);
     void **ptrs = (void **)malloc((size_t)L * sizeof(void *));
 
+    long total_ops = 0;
     double t0 = wall_time();
     for (int it = 0; it < iterations; it++) {
+        int n_alloc = 0;
         for (int i = 0; i < L; i++) {
             ptrs[i] = zone_malloc(z, (size_t)sizes[i] * UNIT_SIZE);
-			if (!ptrs[i]) {
-				fprintf(stderr, "Failed to allocate pow2 segment %d\n", i);
-				return 0.0;
-			}
+            if (ptrs[i]) n_alloc++;
         }
         /* largest first: coalescing unwinds back to one big free chunk */
         for (int i = L - 1; i >= 0; i--)
-            zone_free(z, ptrs[i]);
+            if (ptrs[i]) zone_free(z, ptrs[i]);
+        total_ops += 2L * n_alloc;
     }
     double elapsed = wall_time() - t0;
+    *actual_ops_out = total_ops;
 
     free(sizes); free(ptrs);
     destroy_zone(z, base);
@@ -188,7 +189,7 @@ static int distinct_K(int num_segments)
     return K;
 }
 
-static double bench_many_distinct(int num_segments, int iterations)
+static double bench_many_distinct(int num_segments, int iterations, long *actual_ops_out)
 {
     int K = distinct_K(num_segments);
 
@@ -209,21 +210,22 @@ static double bench_many_distinct(int num_segments, int iterations)
         zone_free(z, chunks[i]);
     /* rbtree now has K distinct nodes: sizes 1, 2, 3, ..., K */
 
+    long total_ops = 0;
     double t0 = wall_time();
     for (int it = 0; it < iterations; it++) {
         /* each alloc calls find(size) — exact match exists at depth O(log K) */
+        int n_alloc = 0;
         for (int i = 0; i < K; i++) {
             allocs[i] = zone_malloc(z, (size_t)(i + 1) * UNIT_SIZE);
-			if (!allocs[i]) {
-				fprintf(stderr, "Failed to allocate pow2 segment %d\n", i);
-				return 0.0;
-			}
+            if (allocs[i]) n_alloc++;
         }
         /* reverse free: restores the K distinct nodes for next iteration */
         for (int i = K - 1; i >= 0; i--)
-            zone_free(z, allocs[i]);
+            if (allocs[i]) zone_free(z, allocs[i]);
+        total_ops += 2L * n_alloc;
     }
     double elapsed = wall_time() - t0;
+    *actual_ops_out = total_ops;
 
     for (int i = 0; i < K; i++)
         zone_free(z, spacers[i]);
@@ -256,7 +258,7 @@ static int gaps_K(int num_segments)
     return K;
 }
 
-static double bench_find_or_larger(int num_segments, int iterations)
+static double bench_find_or_larger(int num_segments, int iterations, long *actual_ops_out)
 {
     int K = gaps_K(num_segments);
 
@@ -277,22 +279,23 @@ static double bench_find_or_larger(int num_segments, int iterations)
         zone_free(z, chunks[i]);
     /* rbtree has K nodes: sizes 2, 4, 6, ..., 2K */
 
+    long total_ops = 0;
     double t0 = wall_time();
     for (int it = 0; it < iterations; it++) {
         /* request odd sizes → find_or_larger must skip to the next even node */
+        int n_alloc = 0;
         for (int i = 0; i < K; i++) {
             allocs[i] = zone_malloc(z, (size_t)(2 * i + 1) * UNIT_SIZE);
-			if (!allocs[i]) {
-				fprintf(stderr, "Failed to allocate find-or-larger segment %d\n", i);
-				return 0.0;
-			}
+            if (allocs[i]) n_alloc++;
         }
         /* reverse free: leftover 1-unit fragments coalesce with the freed
          * block to restore the original even-sized free chunks */
         for (int i = K - 1; i >= 0; i--)
-            zone_free(z, allocs[i]);
+            if (allocs[i]) zone_free(z, allocs[i]);
+        total_ops += 2L * n_alloc;
     }
     double elapsed = wall_time() - t0;
+    *actual_ops_out = total_ops;
 
     for (int i = 0; i < K; i++)
         zone_free(z, spacers[i]);
@@ -466,8 +469,8 @@ static double bench_fragmentation(int num_segments, int iterations)
 static void print_row(const char *name, double elapsed, long ops, int k)
 {
     const char *k_str = (k >= 0) ? "" : "varies";
-    if (elapsed < 1e-9) {
-        /* Timer resolution too coarse — cannot compute meaningful rates. */
+    if (elapsed < 1e-9 || ops == 0) {
+        /* Timer resolution too coarse or no successful operations. */
         if (k >= 0)
             printf("  %-34s  %8.3f s  %8s ns/op  %11s ops/s   k=%-4d\n",
                    name, elapsed, "<res", "<res", k);
@@ -578,20 +581,23 @@ int main(int argc, char **argv)
 
     {
         int L = pow2_L(num_segments);
-        t = bench_pow2(num_segments, iterations);
-        print_row("power-of-2 sizes", t, 2L * iterations * L, L);
+        long actual_ops;
+        t = bench_pow2(num_segments, iterations, &actual_ops);
+        print_row("power-of-2 sizes", t, actual_ops, L);
     }
 
     {
         int K = distinct_K(num_segments);
-        t = bench_many_distinct(num_segments, iterations);
-        print_row("many distinct sizes (exact)", t, 2L * iterations * K, K);
+        long actual_ops;
+        t = bench_many_distinct(num_segments, iterations, &actual_ops);
+        print_row("many distinct sizes (exact)", t, actual_ops, K);
     }
 
     {
         int K = gaps_K(num_segments);
-        t = bench_find_or_larger(num_segments, iterations);
-        print_row("find_or_larger with gaps", t, 2L * iterations * K, K);
+        long actual_ops;
+        t = bench_find_or_larger(num_segments, iterations, &actual_ops);
+        print_row("find_or_larger with gaps", t, actual_ops, K);
     }
 
     {

--- a/tests/runtime/cuda/zonemalloc_benchmark.c
+++ b/tests/runtime/cuda/zonemalloc_benchmark.c
@@ -1,0 +1,626 @@
+/*
+ * Copyright (c) 2026      Stony Brook University.  All rights reserved.
+ *
+ * Benchmark for the zone_malloc allocator with rbtree free-list management.
+ *
+ * The rbtree organises free chunks by size so that find_or_larger() runs in
+ * O(log k) time, where k is the number of distinct free-chunk sizes present.
+ * Each scenario deliberately varies k:
+ *
+ *   sequential        k=1 always              — baseline, minimal tree work
+ *   stride-2          k=1 (after coalescing)  — exercises the coalesce path
+ *   power-of-2        k=log2(N) ≈ 12          — realistic GPU buffer pool
+ *   many distinct     k≈sqrt(2N) ≈ 88         — stress find() / insert / remove
+ *   find_or_larger    k≈sqrt(N) ≈ 63          — every alloc must walk to a
+ *                                                larger node in the tree
+ *   random mixed      k varies, steady state  — workload simulation
+ *
+ * Output columns:
+ *   total time   — wall time for all iterations of the scenario
+ *   throughput   — (alloc+free) operations per second
+ *   k            — number of distinct free-chunk sizes in the rbtree
+ *                  during the timed section (-1 = varies)
+ *
+ * Usage: zonemalloc_benchmark [-n num_segments] [-N iterations] [-- parsec-opts]
+ */
+
+#include "parsec.h"
+#include "parsec/utils/zone_malloc.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define UNIT_SIZE  512u   /* bytes per unit (typical GPU page bucket) */
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                              */
+/* ------------------------------------------------------------------ */
+
+static double wall_time(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+static zone_malloc_t *make_zone(char **base_out, int num_segments)
+{
+    char *b = (char *)malloc((size_t)num_segments * UNIT_SIZE);
+    assert(b);
+    *base_out = b;
+    zone_malloc_t *z = zone_malloc_init(b, num_segments, UNIT_SIZE);
+    assert(z);
+    return z;
+}
+
+static void destroy_zone(zone_malloc_t *z, char *base)
+{
+    zone_malloc_fini(&z);
+    free(base);
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 1 – sequential same-size                                   */
+/* k = 1 throughout; baseline overhead of the rbtree.                  */
+/* ------------------------------------------------------------------ */
+
+static double bench_sequential(int num_segments, int iterations)
+{
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **ptrs = (void **)malloc((size_t)num_segments * sizeof(void *));
+
+    double t0 = wall_time();
+    for (int it = 0; it < iterations; it++) {
+        for (int i = 0; i < num_segments; i++) {
+            ptrs[i] = zone_malloc(z, UNIT_SIZE);
+			if (!ptrs[i]) {
+				fprintf(stderr, "Failed to allocate sequential segment %d\n", i);
+				return 0.0;
+			}
+        }
+        for (int i = 0; i < num_segments; i++)
+            zone_free(z, ptrs[i]);
+    }
+    double elapsed = wall_time() - t0;
+
+    free(ptrs);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 2 – stride-2 fragmentation then coalescing                 */
+/* Alloc all, free even slots (k=1 isolated holes), then free odd      */
+/* slots (each free merges left+right, k collapses back to 1).         */
+/* ------------------------------------------------------------------ */
+
+static double bench_stride2(int num_segments, int iterations)
+{
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **ptrs = (void **)malloc((size_t)num_segments * sizeof(void *));
+
+    double t0 = wall_time();
+    for (int it = 0; it < iterations; it++) {
+        for (int i = 0; i < num_segments; i++)
+            ptrs[i] = zone_malloc(z, UNIT_SIZE);
+        /* free even: creates N/2 isolated 1-unit holes → k=1 */
+        for (int i = 0; i < num_segments; i += 2)
+            zone_free(z, ptrs[i]);
+        /* free odd: each triggers two-way coalesce → k=1 */
+        for (int i = 1; i < num_segments; i += 2)
+            zone_free(z, ptrs[i]);
+    }
+    double elapsed = wall_time() - t0;
+
+    free(ptrs);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 3 – power-of-2 sizes                                       */
+/* Sizes 1, 2, 4, 8, ... units → k = floor(log2(num_segments)).       */
+/* Typical GPU scratch-buffer pool allocation pattern.                  */
+/* ------------------------------------------------------------------ */
+
+static int pow2_L(int num_segments)
+{
+    int L = 0;
+    unsigned s = 1, total = 0;
+    while (total + s <= (unsigned)num_segments) { total += s; s <<= 1; L++; }
+    return L;
+}
+
+static double bench_pow2(int num_segments, int iterations)
+{
+    int L = pow2_L(num_segments);
+    unsigned *sizes = (unsigned *)malloc((size_t)L * sizeof(unsigned));
+    { unsigned s = 1; for (int i = 0; i < L; i++) { sizes[i] = s; s <<= 1; } }
+
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **ptrs = (void **)malloc((size_t)L * sizeof(void *));
+
+    double t0 = wall_time();
+    for (int it = 0; it < iterations; it++) {
+        for (int i = 0; i < L; i++) {
+            ptrs[i] = zone_malloc(z, (size_t)sizes[i] * UNIT_SIZE);
+			if (!ptrs[i]) {
+				fprintf(stderr, "Failed to allocate pow2 segment %d\n", i);
+				return 0.0;
+			}
+        }
+        /* largest first: coalescing unwinds back to one big free chunk */
+        for (int i = L - 1; i >= 0; i--)
+            zone_free(z, ptrs[i]);
+    }
+    double elapsed = wall_time() - t0;
+
+    free(sizes); free(ptrs);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 4 – many distinct free-chunk sizes (exact matches)         */
+/*                                                                      */
+/* Setup: interleave 1-unit spacers with i-unit data blocks (i=1..K).  */
+/* Free all data blocks → rbtree holds K distinct sizes simultaneously, */
+/* none can coalesce (spacers keep them apart).                         */
+/* Each alloc in the timed loop calls find() for an exact size → k=K.  */
+/*                                                                      */
+/* Slot layout: [spacer:1][chunk:i] for i=1..K                         */
+/* Units needed: sum_{i=1}^{K} (1+i) = K + K(K+1)/2 = K(K+3)/2       */
+/* ------------------------------------------------------------------ */
+
+static int distinct_K(int num_segments)
+{
+    int K = 0, total = 0;
+    while (total + 1 + (K + 1) <= num_segments)
+        { K++; total += 1 + K; }
+    return K;
+}
+
+static double bench_many_distinct(int num_segments, int iterations)
+{
+    int K = distinct_K(num_segments);
+
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **spacers = (void **)malloc((size_t)K * sizeof(void *));
+    void **chunks  = (void **)malloc((size_t)K * sizeof(void *));
+    void **allocs  = (void **)malloc((size_t)K * sizeof(void *));
+
+    /* build fragmented heap: spacer prevents coalescing between chunks */
+    for (int i = 0; i < K; i++) {
+        spacers[i] = zone_malloc(z, UNIT_SIZE);
+        assert(spacers[i]);
+        chunks[i]  = zone_malloc(z, (size_t)(i + 1) * UNIT_SIZE);
+        assert(chunks[i]);
+    }
+    for (int i = 0; i < K; i++)
+        zone_free(z, chunks[i]);
+    /* rbtree now has K distinct nodes: sizes 1, 2, 3, ..., K */
+
+    double t0 = wall_time();
+    for (int it = 0; it < iterations; it++) {
+        /* each alloc calls find(size) — exact match exists at depth O(log K) */
+        for (int i = 0; i < K; i++) {
+            allocs[i] = zone_malloc(z, (size_t)(i + 1) * UNIT_SIZE);
+			if (!allocs[i]) {
+				fprintf(stderr, "Failed to allocate pow2 segment %d\n", i);
+				return 0.0;
+			}
+        }
+        /* reverse free: restores the K distinct nodes for next iteration */
+        for (int i = K - 1; i >= 0; i--)
+            zone_free(z, allocs[i]);
+    }
+    double elapsed = wall_time() - t0;
+
+    for (int i = 0; i < K; i++)
+        zone_free(z, spacers[i]);
+    free(spacers); free(chunks); free(allocs);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 5 – find_or_larger with deliberate gaps                    */
+/*                                                                      */
+/* Free chunks exist only for even sizes: 2, 4, 6, ..., 2K.           */
+/* Every allocation requests an odd size (1, 3, 5, ..., 2K-1) so      */
+/* find_or_larger() always has to advance to the next larger node.     */
+/* This exercises the "or larger" branch on every single allocation.   */
+/*                                                                      */
+/* Slot layout: [spacer:1][chunk:2i] for i=1..K                        */
+/* Units needed: sum_{i=1}^{K} (1+2i) = K + K(K+1) = K(K+2)          */
+/*                                                                      */
+/* Allocation of 2i-1 units from a 2i-unit chunk leaves a 1-unit      */
+/* leftover; freeing in reverse order coalesces it back, restoring     */
+/* the original even-sized chunks for the next iteration.              */
+/* ------------------------------------------------------------------ */
+
+static int gaps_K(int num_segments)
+{
+    int K = 0;
+    while ((K + 1) * (K + 3) <= num_segments)
+        K++;
+    return K;
+}
+
+static double bench_find_or_larger(int num_segments, int iterations)
+{
+    int K = gaps_K(num_segments);
+
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **spacers = (void **)malloc((size_t)K * sizeof(void *));
+    void **chunks  = (void **)malloc((size_t)K * sizeof(void *));
+    void **allocs  = (void **)malloc((size_t)K * sizeof(void *));
+
+    /* build heap: even-sized free chunks, isolated by spacers */
+    for (int i = 0; i < K; i++) {
+        spacers[i] = zone_malloc(z, UNIT_SIZE);
+        assert(spacers[i]);
+        chunks[i]  = zone_malloc(z, (size_t)(2 * (i + 1)) * UNIT_SIZE);
+        assert(chunks[i]);
+    }
+    for (int i = 0; i < K; i++)
+        zone_free(z, chunks[i]);
+    /* rbtree has K nodes: sizes 2, 4, 6, ..., 2K */
+
+    double t0 = wall_time();
+    for (int it = 0; it < iterations; it++) {
+        /* request odd sizes → find_or_larger must skip to the next even node */
+        for (int i = 0; i < K; i++) {
+            allocs[i] = zone_malloc(z, (size_t)(2 * i + 1) * UNIT_SIZE);
+			if (!allocs[i]) {
+				fprintf(stderr, "Failed to allocate find-or-larger segment %d\n", i);
+				return 0.0;
+			}
+        }
+        /* reverse free: leftover 1-unit fragments coalesce with the freed
+         * block to restore the original even-sized free chunks */
+        for (int i = K - 1; i >= 0; i--)
+            zone_free(z, allocs[i]);
+    }
+    double elapsed = wall_time() - t0;
+
+    for (int i = 0; i < K; i++)
+        zone_free(z, spacers[i]);
+    free(spacers); free(chunks); free(allocs);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 6 – random mixed alloc/free (steady-state churn)           */
+/* Maintains ~pool_size live allocations; randomly replaces entries.   */
+/* Simulates a real workload; k fluctuates in a realistic range.       */
+/* ------------------------------------------------------------------ */
+
+static double bench_random_mixed(int num_segments, int iterations)
+{
+    int pool_size = num_segments / 8;
+    if (pool_size < 1) pool_size = 1;
+
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **pool = (void **)calloc((size_t)pool_size, sizeof(void *));
+
+    /* deterministic LCG — no stdlib rand() state interference */
+    uint64_t rng = 0xdeadbeef12345678ULL;
+#define LCG_STEP() (rng = rng * 6364136223846793005ULL + 1442695040888963407ULL)
+#define LCG_BITS(n) ((int)((LCG_STEP() >> 33) & (((uint64_t)1 << (n)) - 1)))
+
+    for (int i = 0; i < pool_size; i++) {
+        int sz = LCG_BITS(2) + 1;
+        pool[i] = zone_malloc(z, (size_t)sz * UNIT_SIZE);
+        if (!pool[i]) pool[i] = zone_malloc(z, UNIT_SIZE);
+    }
+
+    double t0 = wall_time();
+    long n_ops = (long)pool_size * iterations;
+    for (long op = 0; op < n_ops; op++) {
+        int slot = (int)((LCG_STEP() >> 1) % (uint64_t)pool_size);
+        if (pool[slot]) { zone_free(z, pool[slot]); pool[slot] = NULL; }
+        int sz = LCG_BITS(2) + 1;
+        pool[slot] = zone_malloc(z, (size_t)sz * UNIT_SIZE);
+    }
+    double elapsed = wall_time() - t0;
+
+    for (int i = 0; i < pool_size; i++)
+        if (pool[i]) zone_free(z, pool[i]);
+
+#undef LCG_STEP
+#undef LCG_BITS
+
+    free(pool);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 7 – full pool then OOM attempt                             */
+/* Allocates every last segment, verifies that a further allocation    */
+/* returns NULL (rbtree is empty; find_or_larger returns NULL in O(1)),*/
+/* then frees all segments. k = 0 while the pool is full.             */
+/* ------------------------------------------------------------------ */
+
+static double bench_full_oom(int num_segments, int iterations)
+{
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **ptrs = (void **)malloc((size_t)num_segments * sizeof(void *));
+        for (int i = 0; i < num_segments; i++) {
+            ptrs[i] = zone_malloc(z, UNIT_SIZE);
+            assert(ptrs[i]);
+        }
+
+    double t0 = wall_time();
+    for (int it = 0; it < iterations; it++) {
+        /* No free chunks remain in the rbtree; must return NULL. */
+        assert(zone_malloc(z, UNIT_SIZE) == NULL);
+    }
+    double elapsed = wall_time() - t0;
+        for (int i = 0; i < num_segments; i++)
+            zone_free(z, ptrs[i]);
+
+    free(ptrs);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scenario 8 – fragmentation impact on memory availability            */
+/*                                                                      */
+/* Creates a stride-2 fragmented heap: fills with 1-unit blocks, then */
+/* frees every other one.  50 % of memory is nominally free but spread */
+/* across isolated 1-unit holes — only size-1 requests can succeed.   */
+/*                                                                      */
+/* Timed section: repeatedly probe all power-of-2 request sizes from   */
+/* 1 up to num_segments/2 units.  For each size the benchmark greedily */
+/* allocates until OOM, then frees to restore the fragmented state.    */
+/* For sizes > 1 this is a fast-fail path: find_or_larger finds the    */
+/* single rbtree node (key=1) is smaller than the request and returns  */
+/* NULL without scanning the N/2 individual free chunks.               */
+/*                                                                      */
+/* After timing, a per-size table is printed showing how much of the   */
+/* nominally-free memory can actually be satisfied.                    */
+/* ------------------------------------------------------------------ */
+
+static double bench_fragmentation(int num_segments, int iterations)
+{
+    char *base;
+    zone_malloc_t *z = make_zone(&base, num_segments);
+    void **held   = (void **)malloc((size_t)num_segments * sizeof(void *));
+    void **allocs = (void **)malloc((size_t)num_segments * sizeof(void *));
+
+    /* ---- build fragmented state once (outside timed section) ---- */
+    for (int i = 0; i < num_segments; i++) {
+        held[i] = zone_malloc(z, UNIT_SIZE);
+        assert(held[i]);
+    }
+    for (int i = 0; i < num_segments; i += 2) {
+        zone_free(z, held[i]);
+        held[i] = NULL;
+    }
+    /* rbtree: single node, key=1, list holds num_segments/2 free chunks */
+
+    /* ---- timed probe loop ---- */
+    double t0 = wall_time();
+    for (int it = 0; it < iterations; it++) {
+        for (int s = 1; s <= num_segments / 2; s <<= 1) {
+            int n = 0;
+            void *p;
+            while ((p = zone_malloc(z, (size_t)s * UNIT_SIZE)) != NULL)
+                allocs[n++] = p;
+            for (int j = 0; j < n; j++)
+                zone_free(z, allocs[j]);
+        }
+    }
+    double elapsed = wall_time() - t0;
+
+    /* ---- fragmentation report (one pass, outside timing) ---- */
+    size_t pool_bytes = (size_t)num_segments * UNIT_SIZE;
+    size_t free_bytes = pool_bytes - zone_in_use(z);
+    printf("\n  fragmentation detail (stride-2, %.0f%% of pool nominally free):\n",
+           100.0 * (double)free_bytes / (double)pool_bytes);
+    printf("  %-14s  %10s  %14s  %8s\n",
+           "request size", "succeeded", "bytes usable", "usable%");
+    printf("  %-14s  %10s  %14s  %8s\n",
+           "------------", "---------", "------------", "-------");
+    for (int s = 1; s <= num_segments / 2; s <<= 1) {
+        int n = 0;
+        void *p;
+        while ((p = zone_malloc(z, (size_t)s * UNIT_SIZE)) != NULL)
+            allocs[n++] = p;
+        size_t usable = (size_t)n * (size_t)s * UNIT_SIZE;
+        printf("  %3d unit(s)%4s  %10d  %14zu  %7.0f%%\n",
+               s, "", n, usable,
+               free_bytes > 0 ? 100.0 * (double)usable / (double)free_bytes : 0.0);
+        for (int j = 0; j < n; j++)
+            zone_free(z, allocs[j]);
+    }
+
+    /* ---- teardown ---- */
+    for (int i = 1; i < num_segments; i += 2)
+        zone_free(z, held[i]);
+    free(held); free(allocs);
+    destroy_zone(z, base);
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Reporting                                                            */
+/* ------------------------------------------------------------------ */
+
+static void print_row(const char *name, double elapsed, long ops, int k)
+{
+    const char *k_str = (k >= 0) ? "" : "varies";
+    if (elapsed < 1e-9) {
+        /* Timer resolution too coarse — cannot compute meaningful rates. */
+        if (k >= 0)
+            printf("  %-34s  %8.3f s  %8s ns/op  %11s ops/s   k=%-4d\n",
+                   name, elapsed, "<res", "<res", k);
+        else
+            printf("  %-34s  %8.3f s  %8s ns/op  %11s ops/s   k=%s\n",
+                   name, elapsed, "<res", "<res", k_str);
+        return;
+    }
+    double ns_per_op = elapsed * 1e9 / (double)ops;
+    if (k >= 0)
+        printf("  %-34s  %8.3f s  %8.1f ns/op  %11.0f ops/s   k=%-4d\n",
+               name, elapsed, ns_per_op, (double)ops / elapsed, k);
+    else
+        printf("  %-34s  %8.3f s  %8.1f ns/op  %11.0f ops/s   k=varies\n",
+               name, elapsed, ns_per_op, (double)ops / elapsed);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                 */
+/* ------------------------------------------------------------------ */
+
+static void usage(const char *prog)
+{
+    fprintf(stderr,
+            "Usage: %s [-n num_segments] [-N iterations] [-- parsec-opts]\n"
+            "  -n : total units in the managed pool (default: 4096)\n"
+            "  -N : outer repetitions per scenario  (default: 200)\n"
+            "  -h : print this message\n",
+            prog);
+}
+
+int main(int argc, char **argv)
+{
+    int num_segments = 4096;
+    int iterations   = 200;
+    int ch;
+    char *endptr;
+
+    while ((ch = getopt(argc, argv, "n:N:h")) != -1) {
+        switch (ch) {
+        case 'n':
+            num_segments = (int)strtol(optarg, &endptr, 10);
+            if (endptr == optarg || *endptr != '\0' || num_segments <= 0) {
+                fprintf(stderr, "invalid -n value '%s'\n", optarg);
+                return 1;
+            }
+            break;
+        case 'N':
+            iterations = (int)strtol(optarg, &endptr, 10);
+            if (endptr == optarg || *endptr != '\0' || iterations <= 0) {
+                fprintf(stderr, "invalid -N value '%s'\n", optarg);
+                return 1;
+            }
+            break;
+        case 'h':
+            usage(argv[0]);
+            return 0;
+        default:
+            usage(argv[0]);
+            return 1;
+        }
+    }
+
+#if defined(DISTRIBUTED)
+    {
+        int provided;
+        MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
+    }
+#endif
+
+    /* Pass only the portion after '--' to parsec_init so it does not
+     * choke on our own options. */
+    int pargc = 0;
+    char **pargv = NULL;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--") == 0) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
+    }
+
+    parsec_context_t *parsec = parsec_init(1, &pargc, &pargv);
+    if (!parsec) {
+        fprintf(stderr, "parsec_init failed\n");
+        return 1;
+    }
+
+    printf("zone_malloc rbtree benchmark\n");
+    printf("  pool: %d segments x %u bytes = %u KiB\n",
+           num_segments, UNIT_SIZE, (unsigned)num_segments * UNIT_SIZE / 1024);
+    printf("  %d iterations per scenario\n\n", iterations);
+    printf("  %-34s  %10s  %14s  %13s   %s\n",
+           "scenario", "total time", "ns/op", "throughput", "k (rbtree nodes)");
+    printf("  %s\n",
+           "------------------------------------------------------------------------------------"
+           "----------");
+
+    double t;
+
+    t = bench_sequential(num_segments, iterations);
+    print_row("sequential same-size", t,
+              2L * iterations * (long)num_segments, 1);
+
+    t = bench_stride2(num_segments, iterations);
+    print_row("stride-2 coalescing", t,
+              3L * iterations * (long)num_segments, 1);
+
+    {
+        int L = pow2_L(num_segments);
+        t = bench_pow2(num_segments, iterations);
+        print_row("power-of-2 sizes", t, 2L * iterations * L, L);
+    }
+
+    {
+        int K = distinct_K(num_segments);
+        t = bench_many_distinct(num_segments, iterations);
+        print_row("many distinct sizes (exact)", t, 2L * iterations * K, K);
+    }
+
+    {
+        int K = gaps_K(num_segments);
+        t = bench_find_or_larger(num_segments, iterations);
+        print_row("find_or_larger with gaps", t, 2L * iterations * K, K);
+    }
+
+    {
+        int pool_size = num_segments / 8;
+        if (pool_size < 1) pool_size = 1;
+        t = bench_random_mixed(num_segments, iterations);
+        print_row("random mixed alloc/free", t,
+                  2L * iterations * (long)pool_size, -1);
+    }
+
+    t = bench_full_oom(num_segments, iterations);
+    /* ops: num_segments allocs + 1 failed alloc + num_segments frees per iter */
+    print_row("full pool + OOM attempt", t,
+              (long)iterations * (2L * num_segments + 1), 0);
+
+    {
+        /* count the probe sizes: 1, 2, 4, ..., num_segments/2 */
+        int n_probes = 0;
+        for (int s = 1; s <= num_segments / 2; s <<= 1) n_probes++;
+        /* bench_fragmentation prints the detail table before returning */
+        t = bench_fragmentation(num_segments, iterations);
+        /* ops per iter: num_segments alloc+free (size-1 succeeds) + (n_probes-1) failed finds */
+        print_row("fragmentation probes", t,
+                  (long)iterations * ((long)num_segments + n_probes - 1), 1);
+    }
+
+    parsec_fini(&parsec);
+#if defined(DISTRIBUTED)
+    MPI_Finalize();
+#endif
+    return 0;
+}


### PR DESCRIPTION
Currently, zone_malloc iterates linearly over its blocks, leading to O(N) complexity and significant overhead if all blocks are taken. We now use a red-black-tree to order lists of free blocks in a binary search tree. Lookup, insert, and delete are log(N). If all blocks are taken lookup is constant.

When allocating memory, we look for blocks or the requested size or the next larger size. In the latter case, the block is split and put back into the tree, potentially allocating a new node.
When releasing a block, it is either inserted directly or merged with its predecessor/successor blocks, which are then removed and reinserted as a larger block.

In the previous scheme, freeing was of O(1) complexity, which is now O(log(N)). However, the better worst-case complexity will amortize this. Plus, using a binary search tree will help reuse of same-size fragments and avoids splitting larger segements when possible.

RB trees have lower average complexity than AVL trees and are widely used (C++ std::map, Linux kernel allocator).