### PR TITLE
Rework the parsec_object_t system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright (c) 2010-2024 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
+# Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
 #
 cmake_minimum_required (VERSION 3.21)
 project (PARSEC C)
@@ -536,6 +537,7 @@ if( NOT PARSEC_HAVE_RUSAGE_THREAD )
 endif( NOT PARSEC_HAVE_RUSAGE_THREAD)
 check_include_files(limits.h PARSEC_HAVE_LIMITS_H)
 check_include_files(string.h PARSEC_HAVE_STRING_H)
+check_include_files(strings.h PARSEC_HAVE_STRINGS_H)
 check_include_files(libgen.h PARSEC_HAVE_GEN_H)
 check_include_files(complex.h PARSEC_HAVE_COMPLEX_H)
 check_include_files(sys/param.h PARSEC_HAVE_SYS_PARAM_H)

--- a/parsec/arena.c
+++ b/parsec/arena.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -96,7 +97,7 @@ int parsec_arena_construct(parsec_arena_t* arena,
                                     parsec_arena_max_cached_memory);
 }
 
-static void parsec_arena_destructor(parsec_arena_t* arena)
+static int parsec_arena_destructor(parsec_arena_t* arena)
 {
     parsec_list_item_t* item;
 
@@ -116,6 +117,7 @@ static void parsec_arena_destructor(parsec_arena_t* arena)
         }
         PARSEC_OBJ_DESTRUCT(&arena->area_lifo);
     }
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_arena_t, parsec_object_t, NULL, parsec_arena_destructor);
@@ -223,7 +225,7 @@ int  parsec_arena_allocate_device_private(parsec_data_copy_t *copy,
     assert(0 == (((ptrdiff_t)chunk->data) % arena->alignment));
     assert((arena->elem_size + (ptrdiff_t)chunk->data)  <= (size + (ptrdiff_t)chunk));
 
-    data->nb_elts = count * arena->elem_size;
+    data->span = count * arena->elem_size;
 
     copy->flags = PARSEC_DATA_FLAG_ARENA |
                   PARSEC_DATA_FLAG_PARSEC_OWNED |

--- a/parsec/class/info.c
+++ b/parsec/class/info.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2020-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2025 NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -21,7 +21,7 @@ static void parsec_info_constructor(parsec_object_t *obj)
     PARSEC_OBJ_CONSTRUCT(&nfo->ioa_list, parsec_list_t);
 }
 
-static void parsec_info_destructor(parsec_object_t *obj)
+static int parsec_info_destructor(parsec_object_t *obj)
 {
     parsec_info_t *nfo = (parsec_info_t*)obj;
     parsec_list_item_t *item, *next;
@@ -34,6 +34,7 @@ static void parsec_info_destructor(parsec_object_t *obj)
     }
     PARSEC_OBJ_DESTRUCT(&nfo->ioa_list);
     /* nfo->info_list is the parent and will be destructed at exit */
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_info_t, parsec_list_t, parsec_info_constructor, parsec_info_destructor);
@@ -223,7 +224,7 @@ void parsec_info_object_array_init(parsec_info_object_array_t *oa, parsec_info_t
     oa->cons_obj = cons_obj;
 }
 
-static void parsec_info_object_array_destructor(parsec_object_t *obj)
+static int parsec_info_object_array_destructor(parsec_object_t *obj)
 {
     parsec_list_item_t *next, *item;
     parsec_info_object_array_t *oa = (parsec_info_object_array_t*)obj;
@@ -246,6 +247,7 @@ static void parsec_info_object_array_destructor(parsec_object_t *obj)
     oa->info_objects = NULL;
     oa->infos = NULL;
     oa->known_infos = -1;
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_info_object_array_t, parsec_list_item_t,

--- a/parsec/class/parsec_datacopy_future.c
+++ b/parsec/class/parsec_datacopy_future.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023-2025 NVIDIA CORPORATION. All rights reserved.
  */
 #include "parsec/parsec_config.h"
 #include "parsec/class/parsec_future.h"
@@ -12,7 +12,7 @@
 static void parsec_datacopy_future_construct(parsec_base_future_t* future);
 
 static void parsec_datacopy_future_cleanup_nested(parsec_base_future_t* future);
-static void parsec_datacopy_future_destruct(parsec_base_future_t* future);
+static int parsec_datacopy_future_destruct(parsec_base_future_t* future);
 
 static void  parsec_datacopy_future_init(parsec_base_future_t* future,
                                         parsec_future_cb_fulfill cb, ...);
@@ -295,7 +295,7 @@ static void parsec_datacopy_future_cleanup_nested(parsec_base_future_t* future)
  *
  * @param[in] future to be destructed.
  */
-static void parsec_datacopy_future_destruct(parsec_base_future_t* future)
+static int parsec_datacopy_future_destruct(parsec_base_future_t* future)
 {
     parsec_datacopy_future_t* d_fut = (parsec_datacopy_future_t*)future;
 
@@ -313,6 +313,7 @@ static void parsec_datacopy_future_destruct(parsec_base_future_t* future)
     if(d_fut->cb_cleanup != NULL){
         d_fut->cb_cleanup(future);
     }
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_datacopy_future_t, parsec_base_future_t,

--- a/parsec/class/parsec_hash_table.c
+++ b/parsec/class/parsec_hash_table.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include <assert.h>
@@ -261,7 +262,7 @@ void parsec_hash_table_unlock_bucket_handle_impl(parsec_hash_table_t *ht,
 }
 
 
-void parsec_hash_table_fini(parsec_hash_table_t *ht)
+int parsec_hash_table_fini(parsec_hash_table_t *ht)
 {
     parsec_hash_table_head_t *head, *next;
     head = ht->rw_hash;
@@ -279,6 +280,7 @@ void parsec_hash_table_fini(parsec_hash_table_t *ht)
         head = next;
     }
     ht->rw_hash = NULL;
+    return 0;
 }
 
 void parsec_hash_table_nolock_insert(parsec_hash_table_t *ht, parsec_hash_table_item_t *item)

--- a/parsec/class/parsec_hash_table.h
+++ b/parsec/class/parsec_hash_table.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #ifndef _parsec_hash_table_h
@@ -210,8 +211,11 @@ void parsec_hash_table_unlock_bucket_handle_impl(parsec_hash_table_t *ht,
  *   Releases the resources allocated by the hash table.
  *   In debug mode, will assert if the hash table is not empty
  * @arg[inout] ht the hash table to release
+ * @return As all destructors, it shall return 0 to continue the chain of destructors and
+ *         1 to stop the chain and save the object from oblivion. The user will then be in
+ *         charge of freeing the object.
  */
-void parsec_hash_table_fini(parsec_hash_table_t *ht);
+int parsec_hash_table_fini(parsec_hash_table_t *ht);
 
 /**
  * @brief Insert element in a hash table without

--- a/parsec/class/parsec_list.c
+++ b/parsec/class/parsec_list.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -39,10 +40,11 @@ parsec_list_construct( parsec_list_t* list )
     parsec_atomic_lock_init(&list->atomic_lock);
 }
 
-static inline void
+static inline int
 parsec_list_destruct( parsec_list_t* list )
 {
     assert(parsec_list_is_empty(list)); (void)list;
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_list_t, parsec_object_t,

--- a/parsec/class/parsec_object.c
+++ b/parsec/class/parsec_object.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,15 +36,15 @@
  * and no constructor or destructor.
  */
 parsec_class_t parsec_object_t_class = {
-    "parsec_object_t",    /* name */
-    NULL,                 /* parent class */
-    NULL,                 /* constructor */
-    NULL,                 /* destructor */
-    1,                    /* initialized  -- this class is preinitialized */
-    0,                    /* class hierarchy depth */
-    NULL,                 /* array of constructors */
-    NULL,                 /* array of destructors */
-    sizeof(parsec_object_t) /* size of the opal object */
+    "parsec_object_t",        /* name */
+    NULL,                     /* parent class */
+    NULL,                     /* constructor */
+    NULL,                     /* destructor */
+    1,                        /* initialized  -- this class is preinitialized */
+    0,                        /* class hierarchy depth */
+    NULL,                     /* array of constructors */
+    NULL,                     /* array of destructors */
+    sizeof(parsec_object_t)   /* size of the opal object */
 };
 
 /*
@@ -135,7 +136,7 @@ void parsec_class_initialize(parsec_class_t *cls)
         exit(-1);
     }
     cls->cls_destruct_array =
-        cls->cls_construct_array + cls_construct_array_count + 1;
+        (parsec_destruct_t*)(cls->cls_construct_array + cls_construct_array_count + 1);
 
     /*
      * The constructor array is reversed, so start at the end

--- a/parsec/class/parsec_value_array.c
+++ b/parsec/class/parsec_value_array.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -28,10 +29,11 @@ static void parsec_value_array_construct(parsec_value_array_t* array)
     array->array_alloc_size = 0;
 }
 
-static void parsec_value_array_destruct(parsec_value_array_t* array)
+static int parsec_value_array_destruct(parsec_value_array_t* array)
 {
     if (NULL != array->array_items)
         free(array->array_items);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(

--- a/parsec/compound.c
+++ b/parsec/compound.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2019-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -65,7 +66,7 @@ parsec_compound_taskpool_startup( parsec_context_t *context,
     (void)startup_list;
 }
 
-static void
+static int
 __parsec_compound_taskpool_destructor( parsec_compound_taskpool_t* compound )
 {
     assert(PARSEC_TASKPOOL_TYPE_COMPOUND == compound->super.taskpool_type);
@@ -76,6 +77,7 @@ __parsec_compound_taskpool_destructor( parsec_compound_taskpool_t* compound )
         free(compound->super.taskpool_name);
         compound->super.taskpool_name = NULL;
     }
+    return 0;
 }
 
 static void

--- a/parsec/data.c
+++ b/parsec/data.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -36,7 +37,7 @@ static void parsec_data_copy_construct(parsec_data_copy_t* obj)
     PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Allocate data copy %p", obj);
 }
 
-static void parsec_data_copy_destruct(parsec_data_copy_t* obj)
+static int parsec_data_copy_destruct(parsec_data_copy_t* obj)
 {
     PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Destruct data copy %p (attached to %p)", obj, obj->original);
 
@@ -52,6 +53,7 @@ static void parsec_data_copy_destruct(parsec_data_copy_t* obj)
          * obj is already detached from obj->original, but this frees the arena chunk */
         parsec_arena_release(obj);
     }
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_data_copy_t, parsec_list_item_t,
@@ -63,7 +65,7 @@ static void parsec_data_construct(parsec_data_t* obj )
     obj->owner_device     = -1;
     obj->preferred_device = -1;
     obj->key              = 0;
-    obj->nb_elts          = 0;
+    obj->span          = 0;
     for( uint32_t i = 0; i < parsec_nb_devices;
          obj->device_copies[i] = NULL, i++ );
     obj->dc               = NULL;
@@ -71,7 +73,7 @@ static void parsec_data_construct(parsec_data_t* obj )
     PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Allocate data %p", obj);
 }
 
-static void parsec_data_destruct(parsec_data_t* obj )
+static int parsec_data_destruct(parsec_data_t* obj )
 {
     PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Destruct data %p", obj);
     for( uint32_t i = 0; i < parsec_nb_devices; i++ ) {
@@ -103,6 +105,7 @@ static void parsec_data_destruct(parsec_data_t* obj )
         }
         assert(NULL == obj->device_copies[i]);
     }
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_data_t, parsec_object_t,
@@ -503,7 +506,7 @@ parsec_data_create( parsec_data_t **holder,
         data->owner_device = 0;
         data->key = key;
         data->dc = desc;
-        data->nb_elts = size;
+        data->span = size;
         parsec_data_copy_attach(data, data_copy, 0);
 
         if( !parsec_atomic_cas_ptr(holder, NULL, data) ) {
@@ -540,7 +543,7 @@ parsec_data_create_with_type( parsec_data_collection_t *desc,
     clone->owner_device = 0;
     clone->key = key;
     clone->dc = desc;
-    clone->nb_elts = size;
+    clone->span = size;
     parsec_data_copy_attach(clone, data_copy, 0);
 
     return clone;

--- a/parsec/data_dist/matrix/broadcast.jdf
+++ b/parsec/data_dist/matrix/broadcast.jdf
@@ -4,6 +4,7 @@ extern "C" %{
  * Copyright (c) 2011-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/data_internal.h"
@@ -59,7 +60,7 @@ static parsec_data_t* data_of(parsec_data_collection_t *desc, ...)
             data->owner_device = 0;
             data->key = k;
             data->dc = (parsec_data_collection_t*)desc;
-            data->nb_elts = 1;
+            data->span = 1;
             parsec_data_copy_t* data_copy = (parsec_data_copy_t*)PARSEC_OBJ_NEW(parsec_data_copy_t);
             parsec_data_copy_attach(data, data_copy, 0);
             data_copy->device_private = NULL;

--- a/parsec/data_dist/matrix/map_operator.c
+++ b/parsec/data_dist/matrix/map_operator.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2011-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2025 NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -513,13 +513,14 @@ __parsec_map_operator_constructor(parsec_map_operator_taskpool_t* tp )
 #endif /* defined(PARSEC_PROF_TRACE) */
 }
 
-static void
+static int
 __parsec_map_operator_destructor(parsec_map_operator_taskpool_t* tp)
 {
     if( NULL != tp->super.taskpool_name ) {
         free(tp->super.taskpool_name);
         tp->super.taskpool_name = NULL;
     }
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_map_operator_taskpool_t, parsec_taskpool_t,

--- a/parsec/data_dist/matrix/redistribute/redistribute_wrapper.c
+++ b/parsec/data_dist/matrix/redistribute/redistribute_wrapper.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2017-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 #include "redistribute_internal.h"
 #include "redistribute.h"
@@ -143,7 +144,7 @@ parsec_redistribute_New(parsec_tiled_matrix_t *dcY,
 /**
  * @param [inout] the parsec object to destroy
  */
-static void
+static int
 __parsec_redistribute_destructor(parsec_redistribute_taskpool_t *redistribute_taskpool)
 {
     /* Optimized version: tile sizes of source and target ar the same,
@@ -163,6 +164,7 @@ __parsec_redistribute_destructor(parsec_redistribute_taskpool_t *redistribute_ta
         // parsec_del2arena(&redistribute_taskpool->arenas_datatypes[PARSEC_redistribute_SOURCE_ADT_IDX]);
         parsec_del2arena(&redistribute_taskpool->arenas_datatypes[PARSEC_redistribute_INNER_ADT_IDX]);
     }
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_redistribute_taskpool_t, parsec_taskpool_t,

--- a/parsec/data_dist/matrix/reduce_wrapper.c
+++ b/parsec/data_dist/matrix/reduce_wrapper.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -12,10 +13,11 @@
 #include "reduce_col.h"
 #include "reduce_row.h"
 
-static void
+static int
 __parsec_reduce_col_destructor(parsec_reduce_col_taskpool_t* tp)
 {
     parsec_type_free(&tp->arenas_datatypes[PARSEC_reduce_col_DEFAULT_ADT_IDX].opaque_dtt);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_reduce_col_taskpool_t, parsec_taskpool_t,
@@ -49,10 +51,11 @@ parsec_reduce_col_New( const parsec_tiled_matrix_t* src,
 
 
 
-static void
+static int
 __parsec_reduce_row_destructor(parsec_reduce_row_taskpool_t* tp)
 {
     parsec_type_free(&tp->arenas_datatypes[PARSEC_reduce_row_DEFAULT_ADT_IDX].opaque_dtt);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_reduce_row_taskpool_t, parsec_taskpool_t,

--- a/parsec/data_internal.h
+++ b/parsec/data_internal.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #if !defined(PARSEC_CONFIG_H_HAS_BEEN_INCLUDED)
@@ -36,7 +37,7 @@ struct parsec_data_s {
                                                   * which device this data should be modified RW when there
                                                   * are multiple choices. -1 means no preference. */
     struct parsec_data_collection_s*     dc;
-    size_t                     nb_elts;          /* size in bytes of the memory layout */
+    size_t                     span;          /* size in bytes of the memory layout */
     struct parsec_data_copy_s *device_copies[];  /* this array allocated according to the number of devices
                                                   * (parsec_nb_devices). It points to the most recent
                                                   * version of the data.

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2023-2024 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2023-2025 NVIDIA Corporation.  All rights reserved.
  */
 
 /* **************************************************************************** */
@@ -352,7 +352,7 @@ void parsec_dtd_taskpool_constructor(parsec_dtd_taskpool_t *tp)
  * @ingroup         DTD_INTERFACE_INTERNAL
  *
  ******************************************************************************/
-void
+int
 parsec_dtd_taskpool_destructor(parsec_dtd_taskpool_t *tp)
 {
     uint32_t i;
@@ -424,6 +424,8 @@ parsec_dtd_taskpool_destructor(parsec_dtd_taskpool_t *tp)
 
     parsec_hash_table_fini(tp->function_h_table);
     PARSEC_OBJ_RELEASE(tp->function_h_table);
+
+    return 0;
 }
 
 /* To create object of class parsec_dtd_taskpool_t that inherits parsec_taskpool_t
@@ -2293,7 +2295,7 @@ static parsec_hook_return_t parsec_dtd_gpu_task_submit(parsec_execution_stream_t
         if(flow->op_type & PARSEC_PUSHOUT)
             gpu_task->pushout |= 1<<i;
         gpu_task->flow[i] = dtd_tc->super.in[i];
-        gpu_task->flow_nb_elts[i] = this_task->data[i].data_in->original->nb_elts;
+        gpu_task->flow_span[i] = this_task->data[i].data_in->original->span;
     }
 
     parsec_device_module_t *device = this_task->selected_device;

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2021-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2025 NVIDIA Corporation.  All rights reserved.
  */
 
 #ifndef PARSEC_DEVICE_GPU_H
@@ -105,7 +105,7 @@ struct parsec_gpu_task_s {
             const parsec_flow_t           *flow[MAX_PARAM_COUNT];  /* There is no consistent way to access the flows from the task_class,
                                                                     * so the DSL need to provide these flows here.
                                                                     */
-            size_t                         flow_nb_elts[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
+            size_t                         flow_span[MAX_PARAM_COUNT]; /* for each flow, size of the data to be allocated
                                                                            * on the GPU.
                                                                            */
             parsec_data_collection_t      *flow_dc[MAX_PARAM_COUNT];     /* for each flow, data collection from which the data

--- a/parsec/mca/device/transfer_gpu.c
+++ b/parsec/mca/device/transfer_gpu.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2025 NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -309,7 +309,7 @@ int parsec_gpu_complete_w2r_task(parsec_device_gpu_module_t *gpu_device,
         parsec_atomic_lock(&gpu_copy->original->lock);
         gpu_copy->readers--;
         gpu_copy->data_transfer_status = PARSEC_DATA_STATUS_COMPLETE_TRANSFER;
-        gpu_device->super.data_out_to_host += gpu_copy->original->nb_elts; /* TODO: not hardcoded, use datatype size */
+        gpu_device->super.data_out_to_host += gpu_copy->original->span; /* TODO: not hardcoded, use datatype size */
         assert(gpu_copy->readers >= 0);
 
         original = gpu_copy->original;

--- a/parsec/mca/sched/spq/sched_spq_module.c
+++ b/parsec/mca/sched/spq/sched_spq_module.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2017-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +41,7 @@ typedef struct parsec_spq_priority_list_s {
 PARSEC_DECLSPEC PARSEC_OBJ_CLASS_DECLARATION(parsec_spq_priority_list_t);
 
 static inline void parsec_spq_priority_list_construct( parsec_spq_priority_list_t*plist );
-static inline void parsec_spq_priority_list_destruct( parsec_spq_priority_list_t *plist );
+static inline int parsec_spq_priority_list_destruct( parsec_spq_priority_list_t *plist );
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_spq_priority_list_t, parsec_list_item_t,
                    parsec_spq_priority_list_construct, parsec_spq_priority_list_destruct);
@@ -51,9 +52,10 @@ static inline void parsec_spq_priority_list_construct( parsec_spq_priority_list_
     plist->prio = -1;
 }
 
-static inline void parsec_spq_priority_list_destruct( parsec_spq_priority_list_t*plist )
+static inline int parsec_spq_priority_list_destruct( parsec_spq_priority_list_t*plist )
 {
     PARSEC_OBJ_DESTRUCT(&plist->tasks);
+    return 0;
 }
 
 /* Since we're locking the list for all operations anyway,

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2023      NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023-2025 NVIDIA CORPORATION. All rights reserved.
  */
 #ifndef __USE_PARSEC_REMOTE_DEP_H__
 #define __USE_PARSEC_REMOTE_DEP_H__
@@ -426,18 +426,30 @@ extern int parsec_comm_puts;
 static inline void
 remote_dep_rank_to_bit(int rank, uint32_t *bank, uint32_t *bit, int root)
 {
+#ifdef DISTRIBUTED
     uint32_t nb_nodes = parsec_remote_dep_context.max_nodes_number;
     uint32_t _rank = (rank + nb_nodes - root) % nb_nodes;
     *bank = _rank / (8 * sizeof(uint32_t));
     *bit =  _rank % (8 * sizeof(uint32_t));
+#else
+    /* it's a lonely world ! */
+    *bank = *bit = 0;
+    (void)rank; (void)root;
+#endif  /* DISTRIBUTED */
 }
 
 static inline void
 remote_dep_bit_to_rank(int *rank, uint32_t bank, uint32_t bit, int root)
 {
+#ifdef DISTRIBUTED
     int nb_nodes = parsec_remote_dep_context.max_nodes_number;
     uint32_t _rank = bank * (8 * sizeof(uint32_t)) + bit;
     *rank = (_rank + root) % nb_nodes;
+#else
+    /* it's a lonely world ! */
+    *rank = 0;
+    (void)bank; (void)bit; (void)root;
+#endif  /* DISTRIBUTED */
 }
 
 #endif /* __USE_PARSEC_REMOTE_DEP_H__ */

--- a/parsec/runtime.h
+++ b/parsec/runtime.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #ifndef PARSEC_RUNTIME_H_HAS_BEEN_INCLUDED
@@ -560,17 +561,6 @@ void parsec_taskpool_unregister(parsec_taskpool_t* tp);
  *  taskpools not registered over all ranks.
 */
 void parsec_taskpool_sync_ids_context( intptr_t comm );
-
-/**
- * @brief Globally synchronize taskpool IDs.
- *
- * @details
- *  Globally synchronize taskpool IDs so that next register generates the same
- *  id at all ranks. This is a collective over the communication object
- *  associated with PaRSEC, and can be used to resolve discrepancies introduced by
- *  taskpools not registered over all ranks.
-*/
-void parsec_taskpool_sync_ids(void);
 
 /**
  * @brief Returns the execution stream that corresponds to the calling thread

--- a/parsec/utils/cmd_line.c
+++ b/parsec/utils/cmd_line.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,7 +70,7 @@ struct cmd_line_option_t {
 };
 typedef struct cmd_line_option_t cmd_line_option_t;
 static void option_constructor(cmd_line_option_t *cmd);
-static void option_destructor(cmd_line_option_t *cmd);
+static int option_destructor(cmd_line_option_t *cmd);
 
 PARSEC_OBJ_CLASS_INSTANCE(cmd_line_option_t,
                    parsec_list_item_t,
@@ -101,7 +102,7 @@ struct cmd_line_param_t {
 };
 typedef struct cmd_line_param_t cmd_line_param_t;
 static void param_constructor(cmd_line_param_t *cmd);
-static void param_destructor(cmd_line_param_t *cmd);
+static int param_destructor(cmd_line_param_t *cmd);
 PARSEC_OBJ_CLASS_INSTANCE(cmd_line_param_t,
                    parsec_list_item_t,
                    param_constructor, param_destructor);
@@ -110,7 +111,7 @@ PARSEC_OBJ_CLASS_INSTANCE(cmd_line_param_t,
  * Instantiate the parsec_cmd_line_t class
  */
 static void cmd_line_constructor(parsec_cmd_line_t *cmd);
-static void cmd_line_destructor(parsec_cmd_line_t *cmd);
+static int cmd_line_destructor(parsec_cmd_line_t *cmd);
 PARSEC_OBJ_CLASS_INSTANCE(parsec_cmd_line_t,
                    parsec_object_t,
                    cmd_line_constructor,
@@ -870,7 +871,7 @@ static void option_constructor(cmd_line_option_t *o)
 }
 
 
-static void option_destructor(cmd_line_option_t *o)
+static int option_destructor(cmd_line_option_t *o)
 {
     if (NULL != o->clo_single_dash_name) {
         free(o->clo_single_dash_name);
@@ -884,6 +885,7 @@ static void option_destructor(cmd_line_option_t *o)
     if (NULL != o->clo_mca_param_env_var) {
         free(o->clo_mca_param_env_var);
     }
+    return 0;
 }
 
 
@@ -896,11 +898,12 @@ static void param_constructor(cmd_line_param_t *p)
 }
 
 
-static void param_destructor(cmd_line_param_t *p)
+static int param_destructor(cmd_line_param_t *p)
 {
     if (NULL != p->clp_argv) {
         parsec_argv_free(p->clp_argv);
     }
+    return 0;
 }
 
 
@@ -926,7 +929,7 @@ static void cmd_line_constructor(parsec_cmd_line_t *cmd)
 }
 
 
-static void cmd_line_destructor(parsec_cmd_line_t *cmd)
+static int cmd_line_destructor(parsec_cmd_line_t *cmd)
 {
     parsec_list_item_t *item;
 
@@ -947,6 +950,7 @@ static void cmd_line_destructor(parsec_cmd_line_t *cmd)
 
     PARSEC_OBJ_DESTRUCT(&cmd->lcl_options);
     PARSEC_OBJ_DESTRUCT(&cmd->lcl_params);
+    return 0;
 }
 
 

--- a/parsec/utils/mca_param.c
+++ b/parsec/utils/mca_param.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,13 +136,13 @@ static bool lookup_default(parsec_mca_param_t *param,
 static bool set(parsec_mca_param_type_t type,
                 parsec_mca_param_storage_t *dest, parsec_mca_param_storage_t *src);
 static void param_constructor(parsec_mca_param_t *p);
-static void param_destructor(parsec_mca_param_t *p);
+static int param_destructor(parsec_mca_param_t *p);
 static void fv_constructor(parsec_mca_param_file_value_t *p);
-static void fv_destructor(parsec_mca_param_file_value_t *p);
+static int fv_destructor(parsec_mca_param_file_value_t *p);
 static void info_constructor(parsec_mca_param_info_t *p);
-static void info_destructor(parsec_mca_param_info_t *p);
+static int info_destructor(parsec_mca_param_info_t *p);
 static void syn_info_constructor(parsec_syn_info_t *si);
-static void syn_info_destructor(parsec_syn_info_t *si);
+static int syn_info_destructor(parsec_syn_info_t *si);
 static parsec_mca_param_type_t param_type_from_index (size_t index);
 
 /*
@@ -1835,7 +1836,7 @@ static void param_constructor(parsec_mca_param_t *p)
 /*
  * Free all the contents of a param container
  */
-static void param_destructor(parsec_mca_param_t *p)
+static int param_destructor(parsec_mca_param_t *p)
 {
     parsec_list_item_t *item;
 
@@ -1891,6 +1892,7 @@ static void param_destructor(parsec_mca_param_t *p)
     /* Cheap trick to reset everything to NULL */
     param_constructor(p);
 #endif
+    return 0;
 }
 
 
@@ -1902,7 +1904,7 @@ static void fv_constructor(parsec_mca_param_file_value_t *f)
 }
 
 
-static void fv_destructor(parsec_mca_param_file_value_t *f)
+static int fv_destructor(parsec_mca_param_file_value_t *f)
 {
     if (NULL != f->mbpfv_param) {
         free(f->mbpfv_param);
@@ -1914,6 +1916,7 @@ static void fv_destructor(parsec_mca_param_file_value_t *f)
         free(f->mbpfv_file);
     }
     fv_constructor(f);
+    return 0;
 }
 
 static void info_constructor(parsec_mca_param_info_t *p)
@@ -1936,7 +1939,7 @@ static void info_constructor(parsec_mca_param_info_t *p)
     p->mbpp_help_msg = NULL;
 }
 
-static void info_destructor(parsec_mca_param_info_t *p)
+static int info_destructor(parsec_mca_param_info_t *p)
 {
     if (NULL != p->mbpp_synonyms) {
         free(p->mbpp_synonyms);
@@ -1945,6 +1948,7 @@ static void info_destructor(parsec_mca_param_info_t *p)
        by value from their corresponding parameter registration */
 
     info_constructor(p);
+    return 0;
 }
 
 static void syn_info_constructor(parsec_syn_info_t *si)
@@ -1954,7 +1958,7 @@ static void syn_info_constructor(parsec_syn_info_t *si)
     si->si_deprecated = si->si_deprecated_warning_shown = false;
 }
 
-static void syn_info_destructor(parsec_syn_info_t *si)
+static int syn_info_destructor(parsec_syn_info_t *si)
 {
     if (NULL != si->si_type_name) {
         free(si->si_type_name);
@@ -1973,6 +1977,7 @@ static void syn_info_destructor(parsec_syn_info_t *si)
     }
 
     syn_info_constructor(si);
+    return 0;
 }
 
 int parsec_mca_param_find_int_name(const char *type,

--- a/parsec/utils/process_name.c
+++ b/parsec/utils/process_name.c
@@ -2,10 +2,14 @@
  * Copyright (c) 2014-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 #include "parsec/parsec_config.h"
 #include <unistd.h>
 #include <string.h>
+#if defined(PARSEC_HAVE_STRINGS_H)
+#include <strings.h>
+#endif  /* defined(PARSEC_HAVE_STRINGS_H) */
 #include <limits.h>
 #include <stdio.h>
 

--- a/tests/apps/generalized_reduction/BT_reduction_wrapper.c
+++ b/tests/apps/generalized_reduction/BT_reduction_wrapper.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -19,10 +20,11 @@ static parsec_datatype_t block;
 #include "BT_reduction_wrapper.h"
 #include "parsec/data_dist/matrix/two_dim_rectangle_cyclic.h"
 
-static void
+static int
 __parsec_taskpool_BT_reduction_destruct(parsec_BT_reduction_taskpool_t *tp)
 {
     parsec_type_free( &(tp->arenas_datatypes[PARSEC_BT_reduction_DEFAULT_ADT_IDX].opaque_dtt) );
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_BT_reduction_taskpool_t, parsec_taskpool_t,

--- a/tests/apps/pingpong/rtt_wrapper.c
+++ b/tests/apps/pingpong/rtt_wrapper.c
@@ -1,8 +1,8 @@
-
 /*
  * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -17,13 +17,14 @@
 #include "rtt.h"
 #include "rtt_wrapper.h"
 
-static void
+static int
 __parsec_rtt_taskpool_destructor(parsec_rtt_taskpool_t *rtt_tp)
 {
     /* We have created our own datatype, instead of using a predefined one
      * so we need to clean up.
      */
     parsec_type_free( &(rtt_tp->arenas_datatypes[PARSEC_rtt_DEFAULT_ADT_IDX].opaque_dtt) );
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_rtt_taskpool_t, parsec_taskpool_t,

--- a/tests/collections/redistribute/redistribute_check.jdf
+++ b/tests/collections/redistribute/redistribute_check.jdf
@@ -3,6 +3,7 @@ extern "C" %{
  * Copyright (c) 2017-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 #include "redistribute_test.h"
 
@@ -207,11 +208,12 @@ parsec_redistribute_check_New(parsec_tiled_matrix_t *Y,
     return redistribute_check_taskpool;
 }
 
-static void
+static int
 __parsec_taskpool_redistribute_check_destructor(parsec_redistribute_check_taskpool_t *redistribute_check_taskpool)
 {
     parsec_del2arena(&redistribute_check_taskpool->arenas_datatypes[PARSEC_redistribute_check_ORIGIN_ADT_IDX]);
     parsec_del2arena(&redistribute_check_taskpool->arenas_datatypes[PARSEC_redistribute_check_TARGET_ADT_IDX]);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_redistribute_check_taskpool_t, parsec_taskpool_t,

--- a/tests/collections/redistribute/redistribute_check2.jdf
+++ b/tests/collections/redistribute/redistribute_check2.jdf
@@ -3,7 +3,7 @@ extern "C" %{
  * Copyright (c) 2017-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2025 NVIDIA Corporation.  All rights reserved.
  */
 #include "redistribute_test.h"
 
@@ -114,10 +114,11 @@ parsec_redistribute_check2_New(parsec_tiled_matrix_t *dcY,
     return redistribute_check2_taskpool;
 }
 
-static void
+static int
 __parsec_taskpool_redistribute_check2_destructor(parsec_redistribute_check2_taskpool_t *redistribute_check2_taskpool)
 {
     parsec_del2arena(&redistribute_check2_taskpool->arenas_datatypes[PARSEC_redistribute_check2_DEFAULT_ADT_IDX]);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_redistribute_check2_taskpool_t, parsec_taskpool_t,

--- a/tests/collections/redistribute/redistribute_no_optimization.jdf
+++ b/tests/collections/redistribute/redistribute_no_optimization.jdf
@@ -3,6 +3,7 @@ extern "C" %{
  * Copyright (c) 2017-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  *
  */
 #include "redistribute_test.h"
@@ -444,11 +445,12 @@ parsec_redistribute_no_optimization_New(parsec_tiled_matrix_t *dcY,
 /**
  * @param [inout] the parsec object to destroy
  */
-static void
+static int
 __parsec_taskpool_redistribute_no_optimization_destructor(parsec_redistribute_no_optimization_taskpool_t *redistribute_no_optimization_taskpool)
 {
     parsec_del2arena(&redistribute_no_optimization_taskpool->arenas_datatypes[PARSEC_redistribute_no_optimization_TARGET_ADT_IDX]);
     parsec_del2arena(&redistribute_no_optimization_taskpool->arenas_datatypes[PARSEC_redistribute_no_optimization_SOURCE_ADT_IDX]);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_redistribute_no_optimization_taskpool_t, parsec_taskpool_t,

--- a/tests/dsl/ptg/branching/branching_wrapper.c
+++ b/tests/dsl/ptg/branching/branching_wrapper.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -16,14 +17,8 @@
 #include "branching.h"
 #include "branching_wrapper.h"
 
-static void
-__parsec_taskpool_branching_destructor(parsec_branching_taskpool_t* tp)
-{
-    (void)tp;
-}
-
 PARSEC_OBJ_CLASS_INSTANCE(parsec_branching_taskpool_t, parsec_taskpool_t,
-                          NULL, __parsec_taskpool_branching_destructor);
+                          NULL, NULL);
 
 /**
  * @param [IN] A    the data, already distributed and allocated

--- a/tests/dsl/ptg/choice/choice_data.c
+++ b/tests/dsl/ptg/choice/choice_data.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -50,7 +51,7 @@ get_or_create_data(my_datatype_t* dat, uint32_t pos)
 
         data->owner_device = 0;
         data->key = pos;
-        data->nb_elts = 1;
+        data->span = 1;
         data->device_copies[0] = data_copy;
 
         if( !parsec_atomic_cas_ptr(&dat->data_map[pos], NULL, data) ) {

--- a/tests/dsl/ptg/choice/choice_wrapper.c
+++ b/tests/dsl/ptg/choice/choice_wrapper.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -16,13 +17,14 @@
 #include "choice.h"
 #include "choice_wrapper.h"
 
-static void
+static int
 __parsec_taskpool_choice_destructor(parsec_choice_taskpool_t *tp)
 {
     /* We have created our own datatype, instead of using a predefined one
      * so we need to clean up.
      */
     parsec_type_free(&(tp->arenas_datatypes[PARSEC_choice_DEFAULT_ADT_IDX].opaque_dtt));
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_choice_taskpool_t, parsec_taskpool_t,

--- a/tests/dsl/ptg/controlgather/ctlgat_wrapper.c
+++ b/tests/dsl/ptg/controlgather/ctlgat_wrapper.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -18,13 +19,14 @@
 
 static parsec_datatype_t block;
 
-static void
+static int
 __parsec_taskpool_ctlgat_destructor(parsec_ctlgat_taskpool_t *tp)
 {
     /* We have created our own datatype, instead of using a predefined one
      * so we need to clean up.
      */
     parsec_type_free(&(tp->arenas_datatypes[PARSEC_ctlgat_DEFAULT_ADT_IDX].opaque_dtt));
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_ctlgat_taskpool_t, parsec_taskpool_t,

--- a/tests/runtime/cuda/get_best_device_check.jdf
+++ b/tests/runtime/cuda/get_best_device_check.jdf
@@ -3,6 +3,7 @@ extern "C" %{
  * Copyright (c) 2021-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 #include "cuda_test_internal.h"
 
@@ -180,7 +181,7 @@ parsec_get_best_device_check_New(parsec_tiled_matrix_t *dcA, int *info)
 /**
  * @param [inout] the parsec object to destroy
  */
-static void
+static int
 __parsec_taskpool_get_best_device_check_destructor(parsec_get_best_device_check_taskpool_t *get_best_device_check_taskpool)
 {
     parsec_del2arena(&get_best_device_check_taskpool->arenas_datatypes[PARSEC_get_best_device_check_DEFAULT_ADT_IDX]);
@@ -188,6 +189,7 @@ __parsec_taskpool_get_best_device_check_destructor(parsec_get_best_device_check_
     if( NULL != get_best_device_check_taskpool->_g_cuda_device_index )
         free(get_best_device_check_taskpool->_g_cuda_device_index);
 #endif
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_get_best_device_check_taskpool_t, parsec_taskpool_t,

--- a/tests/runtime/cuda/nvlink_wrapper.c
+++ b/tests/runtime/cuda/nvlink_wrapper.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2019-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2025 NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec.h"
@@ -57,7 +57,7 @@ static void destroy_cublas_handle(void *_h, void *_n)
     (void)_h;
 }
 
-static void
+static int
 __parsec_nvlink_destructor( parsec_nvlink_taskpool_t* nvlink_taskpool)
 {
     int g, dev;
@@ -89,6 +89,7 @@ __parsec_nvlink_destructor( parsec_nvlink_taskpool_t* nvlink_taskpool)
 
     free(dcA);
     free(userM);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_nvlink_taskpool_t, parsec_taskpool_t,
@@ -189,7 +190,7 @@ parsec_taskpool_t* testing_nvlink_New( parsec_context_t *ctx, int depth, int mb 
             /* And copy the tile from CPU to GPU */
             status = (cudaError_t)cudaMemcpy( gpu_copy->device_private,
                                               cpu_copy->device_private,
-                                              dta->nb_elts,
+                                              dta->span,
                                               cudaMemcpyHostToDevice );
             PARSEC_CUDA_CHECK_ERROR( "(nvlink_wrapper) cudaMemcpy", status, {return NULL;} );
             g++;

--- a/tests/runtime/cuda/stage_custom.jdf
+++ b/tests/runtime/cuda/stage_custom.jdf
@@ -3,7 +3,7 @@ extern "C" %{
  * Copyright (c) 2019-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2025 NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -62,7 +62,7 @@ stage_stride_in(parsec_gpu_task_t *gtask,
             }else{
                 ret = (cudaError_t)cudaMemcpyAsync( copy_out->device_private,
                                                     copy_in->device_private,
-                                                    copy_in->original->nb_elts,
+                                                    copy_in->original->span,
                                                     cudaMemcpyDeviceToDevice,
                                                     cuda_stream->cuda_stream );
                 PARSEC_CUDA_CHECK_ERROR( "cudaMemcpyAsync", ret, { return PARSEC_ERROR; } );
@@ -312,7 +312,7 @@ parsec_taskpool_t* testing_stage_custom_New( parsec_context_t *ctx, int M, int N
     return &testing_handle->super;
 }
 
-static void
+static int
 __parsec_taskpool_stage_custom_destructor(parsec_stage_custom_taskpool_t *stage_custom_taskpool)
 {
     parsec_matrix_block_cyclic_t *descA = (parsec_matrix_block_cyclic_t*)stage_custom_taskpool->_g_descA;
@@ -324,6 +324,7 @@ __parsec_taskpool_stage_custom_destructor(parsec_stage_custom_taskpool_t *stage_
     parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)stage_custom_taskpool->_g_descB );
     free(descA);
     free(descB);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_stage_custom_taskpool_t, parsec_taskpool_t,

--- a/tests/runtime/cuda/stress_wrapper.c
+++ b/tests/runtime/cuda/stress_wrapper.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2019-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
  */
 #include "parsec.h"
 #include "parsec/execution_stream.h"
@@ -11,7 +12,7 @@
 
 #include "stress.h"
 
-static void __parsec_stress_destructor( parsec_taskpool_t *tp )
+static int __parsec_stress_destructor( parsec_taskpool_t *tp )
 {
     parsec_stress_taskpool_t *stress_taskpool = (parsec_stress_taskpool_t *)tp;
     parsec_matrix_block_cyclic_t *dcA;
@@ -21,6 +22,7 @@ static void __parsec_stress_destructor( parsec_taskpool_t *tp )
     parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)stress_taskpool->_g_descA );
     free(dcA);
     free(stress_taskpool->_g_cuda_device_index);
+    return 0;
 }
 
 PARSEC_OBJ_CLASS_INSTANCE(parsec_stress_taskpool_t, parsec_taskpool_t,


### PR DESCRIPTION
The new destructor need to return a continuation value, 0 if the chain of destructors will continue to be called, 1 if no other destructors shall be called on this object. As a result, we can now recycle parsec_objects for as long as they are correctly initialized twice. The first time, when the object is stored in some internal cache (in order to be able to properly chain it) and the second time before returning a newly allocated object back to the user.

Fixes #724.

Per @devreal  suggestion here is a use case:

```
struct derived_t { lifo_elem_t super; ... }; 
ALLOC(obj)
  -> [
       -> CONSTRUCT(obj, derived_t)
       -> USE(obj)
       -> RELEASE(obj)
         // inside the destructor of derived_t
         -> no CONSTRUCT(obj, lifo_elem_t) is necessary as the object is already derived from lifo_elem_t, and the destructor of the lifo_elem_t has not yet been called (they are called in reverse class order).
         -> PUSH(lifo, obj) // stash away
         // destructor of derived_t returns 1
       -> POP(lifo, obj)  // get it back
     ]* // rinse and repeat
-> FREE(obj) // finally release the memory
```
