### PR TITLE
Introduce managed objects

### DIFF
--- a/parsec/class/list_item.h
+++ b/parsec/class/list_item.h
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2025      Stony Brook University.  All rights reserved.
  */
 
 #ifndef PARSEC_LIST_ITEM_H_HAS_BEEN_INCLUDED
@@ -25,7 +26,7 @@
  *    parsec_internal_classes_list, @ref parsec_internal_classes_lifo,
  *    @ref parsec_internal_classes_fifo, for examples of data structures
  *    that use list items.
- * 
+ *
  *    Functions and macros in this group are used to manipulate the
  *    list items.
  */
@@ -36,7 +37,7 @@ BEGIN_C_DECLS
  * @brief List Item structure
  */
 typedef struct parsec_list_item_s {
-    parsec_object_t  super;                         /**< A list item is a @ref parsec_internal_classes_object */
+    parsec_managed_object_t  super;                 /**< A list item is a @ref parsec_internal_classes_object */
     volatile struct parsec_list_item_s* list_next;  /**< Pointer to the next item */
     volatile struct parsec_list_item_s* list_prev;  /**< Pointer to the previous item */
     int32_t aba_key;                                /**< This field is __very__ special and should be handled with extreme
@@ -62,7 +63,7 @@ PARSEC_DECLSPEC PARSEC_OBJ_CLASS_DECLARATION(parsec_list_item_t);
  */
 #define PARSEC_LIST_ITEM_PREV(item) ((__typeof__(item))(((parsec_list_item_t*)(item))->list_prev))
 
-/** 
+/**
  * @brief
  *  Make a well formed singleton ring with a list item.
  *
@@ -93,7 +94,7 @@ parsec_list_item_singleton( parsec_list_item_t* item )
  * @details
  *  Starting with first, ending with last, returns first.
  *    if first->last is not a valid chain of items, result is undetermined
- *    in PARSEC_DEBUG_PARANOID mode, attached items are detached, must be reattached if needed 
+ *    in PARSEC_DEBUG_PARANOID mode, attached items are detached, must be reattached if needed
  * @param[inout] first the first item of the chain
  * @param[inout] last the last item of the chain
  * @return first after it has been chained to last to make a ring

--- a/parsec/class/parsec_list.c
+++ b/parsec/class/parsec_list.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2025      Stony Brook University.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -22,7 +23,7 @@ parsec_list_item_construct( parsec_list_item_t* item )
 #endif
 }
 
-PARSEC_OBJ_CLASS_INSTANCE(parsec_list_item_t, parsec_object_t,
+PARSEC_OBJ_CLASS_INSTANCE(parsec_list_item_t, parsec_managed_object_t,
                    parsec_list_item_construct, NULL);
 
 /**

--- a/parsec/class/parsec_object.c
+++ b/parsec/class/parsec_object.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2025      Stony Brook University.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,6 +61,18 @@ static const int increment = 10;
  */
 static void save_class(parsec_class_t *cls);
 static void expand_array(void);
+
+static inline void
+parsec_managed_object_construct( parsec_managed_object_t* obj )
+{
+    /* mark the object as managed so PARSEC_OBJ_RELEASE calls the release callback */
+    obj->super.obj_flags = PARSEC_OBJ_FLAG_MANAGED;
+    obj->obj_release = (parsec_release_t)&free; // fallback, may be overwritten by application
+}
+
+PARSEC_OBJ_CLASS_INSTANCE(parsec_managed_object_t, parsec_object_t,
+                          parsec_managed_object_construct, NULL);
+
 
 /*
  * When we build PaRSEC itself, we will use the inline version of the function from

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -410,7 +410,7 @@ parsec_dtd_taskpool_destructor(parsec_dtd_taskpool_t *tp)
 #if defined(PARSEC_PROF_TRACE)
         free((void *)tp->super.profiling_array);
 #endif /* defined(PARSEC_PROF_TRACE) */
- 
+
     if( NULL != tp->super.taskpool_name) {
         free(tp->super.taskpool_name);
         tp->super.taskpool_name = NULL;
@@ -1197,8 +1197,8 @@ parsec_dtd_tile_find(parsec_data_collection_t *dc, uint64_t key)
 void
 parsec_dtd_tile_release(parsec_dtd_tile_t *tile)
 {
-    assert(tile->super.super.obj_reference_count > 1);
-    if( 2 == parsec_atomic_fetch_dec_int32(&tile->super.super.obj_reference_count)) {
+    assert(tile->super.super.super.obj_reference_count > 1);
+    if( 2 == parsec_atomic_fetch_dec_int32(&tile->super.super.super.obj_reference_count)) {
         assert(tile->flushed == FLUSHED);
         if(tile->dc->data_of_key == parsec_dtd_tile_new_dc_data_of_key) {
             // This is a tile_new, we need to collect everything that it points to
@@ -1282,7 +1282,7 @@ parsec_dtd_tile_of(parsec_data_collection_t *dc, parsec_data_key_t key)
     }
     assert(tile->flushed == NOT_FLUSHED);
 #if defined(PARSEC_DEBUG_PARANOID)
-    assert(tile->super.super.obj_reference_count > 0);
+    assert(tile->super.super.super.obj_reference_count > 0);
 #endif
     return tile;
 }
@@ -1328,7 +1328,7 @@ parsec_dtd_tile_t *parsec_dtd_tile_new(parsec_taskpool_t *tp, int rank)
     SET_LAST_ACCESSOR(tile);
 
 #if defined(PARSEC_DEBUG_PARANOID)
-    assert(tile->super.super.obj_reference_count > 0);
+    assert(tile->super.super.super.obj_reference_count > 0);
 #endif
     return tile;
 }
@@ -1852,7 +1852,7 @@ parsec_hook_return_t
 parsec_dtd_release_local_task(parsec_dtd_task_t *this_task)
 {
     parsec_object_t *object = (parsec_object_t *)this_task;
-    assert(this_task->super.super.super.obj_reference_count > 1);
+    assert(this_task->super.super.super.super.obj_reference_count > 1);
     if( 2 == parsec_atomic_fetch_dec_int32(&object->obj_reference_count)) {
         int current_flow;
         for( current_flow = 0; current_flow < this_task->super.task_class->nb_flows; current_flow++ ) {
@@ -1870,7 +1870,7 @@ parsec_dtd_release_local_task(parsec_dtd_task_t *this_task)
                 parsec_dtd_tile_release(tile);
             }
         }
-        assert(this_task->super.super.super.obj_reference_count == 1);
+        assert(this_task->super.super.super.super.obj_reference_count == 1);
         parsec_thread_mempool_free(this_task->mempool_owner, this_task);
     }
     return PARSEC_HOOK_RETURN_DONE;
@@ -1916,7 +1916,7 @@ parsec_dtd_remote_task_release(parsec_dtd_task_t *this_task)
                 parsec_dtd_tile_release(tile);
             }
         }
-        assert(this_task->super.super.super.obj_reference_count == 1);
+        assert(this_task->super.super.super.super.obj_reference_count == 1);
         parsec_taskpool_t *tp = this_task->super.taskpool;
         parsec_thread_mempool_free(this_task->mempool_owner, this_task);
         parsec_taskpool_update_runtime_nbtask(tp, -1);


### PR DESCRIPTION
Managed objects derive from `parsec_object_t` and provide a custom release function that can be set by the application. PaRSEC will fall back to calling `free` if no explicit callback is set. Managed objects are tied into the type system because `PARSEC_OBJ_RELEASE` must be able to distinguish them from regular objects. The most common managed object would be `parsec_list_item_t` as that is the basis for all container elements in PaRSEC and so we can register a release callback that stashes an object into a container from where it can be retrieved and reused later.

This is an alternative to #726 . It's less intrusive but like #726  not ABI backwards compatible but does not change the API.