### PR TITLE
Store release callback in parsec_object_t

### DIFF
--- a/parsec/class/parsec_object.c
+++ b/parsec/class/parsec_object.c
@@ -188,6 +188,21 @@ void parsec_class_finalize(void)
     }
 }
 
+void parsec_obj_release(parsec_object_t *object)
+{
+    PARSEC_OBJ_SET_MAGIC_ID((object), 0);
+    object->obj_release(object);
+}
+
+void parsec_obj_destruct(parsec_object_t * object) {
+    PARSEC_OBJ_SET_MAGIC_ID((object), 0);
+    parsec_obj_run_destructors(object);
+}
+
+void parsec_obj_destruct_and_free(parsec_object_t * object) {
+    parsec_obj_destruct(object);
+    free(object);
+}
 
 static void save_class(parsec_class_t *cls)
 {


### PR DESCRIPTION
By default, objects created through `PARSEC_OBJ_NEW` will  be free'd in the callback, objects constructed through `PARSEC_OBJ_CONSTRUCT` will only be destructed. Users/applications can provide their own release callback through
`PARSEC_OBJ_RELEASE_CONSTRUCT`.

Mempools break the PaRSEC object model. To store the mempool origin, a list item and an offset stored in the mempool that points to the mempool from where the item was allocated. We should consider adding a type `parsec_mempool_item_t` that stores the origin mempool. Then the release callback invoked from `PARSEC_OBJ_RELEASE` can put the object back into the mempool.

Yes, this adds 8B to the `parsec_object_t` but in today's world that is negligible and is outweighed by the benefits of having a more flexible object model.

Alternative to #726 and #728.