### PR TITLE
BODY without a type will be considered as CPU.

### DIFF
--- a/tests/dsl/ptg/recursive.jdf
+++ b/tests/dsl/ptg/recursive.jdf
@@ -81,7 +81,7 @@ END
 
 BODY  [type=CPU]
 {
-    fprintf(stderr, "do_something(level=%d, i=%d): prio=%d\n", level, i, prio );
+    fprintf(stderr, "do_something[TYPE=CPU](level=%d, i=%d): prio=%d\n", level, i, prio );
 }
 END
 


### PR DESCRIPTION
This was already the case in most of the code but some corner cases where skipped such as:
  - don't allow for two bodies with the same tyoe (including the case where one of the bodies is untyped)
  - protect all the inlined functions with the BODY type.

Provides a more complete alternative approach to #740.

Fixes #458.