### PR TITLE
Minor fixes to installed files for missing header and ROCM search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,14 +736,14 @@ int main(int argc, char *argv[]) {
   endif( PARSEC_GPU_WITH_CUDA )
 
   if( PARSEC_GPU_WITH_HIP )
-    # This is kinda ugly but the PATH and HINTS don't get transmitted to sub-dependents
-    set(CMAKE_SYSTEM_PREFIX_PATH_save ${CMAKE_SYSTEM_PREFIX_PATH})
-    list(APPEND CMAKE_SYSTEM_PREFIX_PATH /opt/rocm)
+    if( NOT DEFINED ROCM_ROOT_DIR AND IS_DIRECTORY /opt/rocm )
+      set(ROCM_ROOT_DIR /opt/rocm)
+    endif()
+    list(APPEND CMAKE_PREFIX_PATH ${ROCM_ROOT_DIR}/hip ${ROCM_ROOT_DIR})
     find_package(HIP QUIET) #quiet because hip-config.cmake is not part of core-cmake and will spam a loud warning when hip/rocm is not installed
     if(HIP_FOUND AND HIP_VERSION VERSION_LESS 5) # find_package(HIP 5...6) does not work for some reason
         message(FATAL_ERROR "Found HIP version ${HIP_VERSION} in ${HIP_LIB_INSTALL_DIR} is too old, use HIP_ROOT to select another version")
     endif()
-    set(CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH_save})
     if(HIP_FOUND AND PARSEC_HAVE_CUDA)
       # the underlying reason is that the generated ptg code cannot include at the same time
       # cuda_runtime.h and hip_runtime.h, so we need to modify the dev_cuda.h to not expose any

--- a/cmake_modules/PaRSECConfig.cmake.in
+++ b/cmake_modules/PaRSECConfig.cmake.in
@@ -69,6 +69,7 @@ endif(@PARSEC_HAVE_CUDA@)
 
 if(@PARSEC_HAVE_HIP@)
   enable_language(CXX)
+  list (APPEND CMAKE_PREFIX_PATH @ROCM_ROOT_DIR@/hip @ROCM_ROOT_DIR@)
   find_package(HIP REQUIRED)
   set(PARSEC_HAVE_HIP TRUE)
 endif(@PARSEC_HAVE_HIP@)

--- a/parsec/data_dist/matrix/CMakeLists.txt
+++ b/parsec/data_dist/matrix/CMakeLists.txt
@@ -31,8 +31,9 @@ if( TARGET parsec-ptgpp )
 
   target_ptg_sources(parsec PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/reduce_col.jdf;${CMAKE_CURRENT_SOURCE_DIR}/reduce_row.jdf;${CMAKE_CURRENT_SOURCE_DIR}/reduce.jdf;${CMAKE_CURRENT_SOURCE_DIR}/diag_band_to_rect.jdf;${CMAKE_CURRENT_SOURCE_DIR}/apply.jdf")
   set_property(TARGET parsec
-               APPEND PROPERTY
-                      PRIVATE_HEADER_H data_dist/matrix/diag_band_to_rect.h)
+               APPEND PROPERTY PRIVATE_HEADER_H
+               data_dist/matrix/diag_band_to_rect.h
+               data_dist/matrix/apply.h)
 endif( TARGET parsec-ptgpp )
 
 target_sources(parsec PRIVATE ${sources})


### PR DESCRIPTION
This adds a missing header file to the installation that is required for building against the parsec install. 

It also add the ~~default~~ rocm search path ~~/opt/rocm~~ so that an application building against this installation can find the HIP installation when parsec is built with HIP support.