### PR TITLE
Fix no-MPI Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright (c) 2010-2024 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 #
 cmake_minimum_required (VERSION 3.21)
 project (PARSEC C)
@@ -413,6 +414,14 @@ endif(NOT PARSEC_HAVE_SCHED_SETAFFINITY)
 
 # timeval, timespec, realtime clocks, etc
 include(CheckStructHasMember)
+check_c_source_compiles("
+#include <sys/time.h>
+int main(int argc, char *argv[]) {
+  struct timeval start, end, diff;
+  (void)argc; (void)argv;
+  timersub(&end, &start, &diff);
+  return 0;
+}" PARSEC_HAVE_TIMERSUB)
 check_struct_has_member("struct timespec" tv_nsec time.h PARSEC_HAVE_TIMESPEC_TV_NSEC)
 if( NOT PARSEC_HAVE_TIMESPEC_TV_NSEC )
   cmake_push_check_state()
@@ -434,6 +443,20 @@ if( NOT PARSEC_HAVE_CLOCK_GETTIME )
     list(APPEND EXTRA_LIBS rt)
   endif(PARSEC_HAVE_CLOCK_GETTIMERT)
 endif( NOT PARSEC_HAVE_CLOCK_GETTIME )
+if( PARSEC_HAVE_CLOCK_GETTIME )
+  cmake_push_check_state()
+  if( PARSEC_HAVE_CLOCK_GETTIMERT )
+    list(APPEND CMAKE_REQUIRED_LIBRARIES rt)
+  endif()
+  check_c_source_compiles("
+#include <time.h>
+int main(int argc, char *argv[]) {
+  struct timespec ts;
+  (void)argc; (void)argv;
+  return clock_gettime(CLOCK_MONOTONIC, &ts);
+}" PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+  cmake_pop_check_state()
+endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows" OR
    CMAKE_SYSTEM_NAME MATCHES "MSYS" OR
@@ -507,8 +530,20 @@ check_include_files(dlfcn.h PARSEC_HAVE_DLFCN_H)
 check_function_exists(asprintf PARSEC_HAVE_ASPRINTF)
 check_function_exists(vasprintf PARSEC_HAVE_VASPRINTF)
 check_function_exists(getopt_long PARSEC_HAVE_GETOPT_LONG)
-check_function_exists(rand_r PARSEC_HAVE_RAND_R)
+check_symbol_exists(rand_r "stdlib.h" PARSEC_HAVE_RAND_R_WITHOUT_POSIX_C_SOURCE)
+set(PARSEC_HAVE_RAND_R ${PARSEC_HAVE_RAND_R_WITHOUT_POSIX_C_SOURCE})
+if( NOT PARSEC_HAVE_RAND_R )
+  cmake_push_check_state()
+  list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_POSIX_C_SOURCE=199506L")
+  check_symbol_exists(rand_r "stdlib.h" PARSEC_HAVE_RAND_R_WITH_POSIX_C_SOURCE)
+  cmake_pop_check_state()
+  if( PARSEC_HAVE_RAND_R_WITH_POSIX_C_SOURCE )
+    set(PARSEC_HAVE_RAND_R 1)
+    set(PARSEC_NEED_POSIX_C_SOURCE_FOR_RAND_R 1)
+  endif()
+endif()
 check_function_exists(getline PARSEC_HAVE_GETLINE)
+check_function_exists(readlink PARSEC_HAVE_READLINK)
 check_function_exists(setenv PARSEC_HAVE_SETENV)
 check_function_exists(sysconf PARSEC_HAVE_SYSCONF)
 

--- a/parsec/CMakeLists.txt
+++ b/parsec/CMakeLists.txt
@@ -116,8 +116,6 @@ set(SOURCES
   private_mempool.c
   remote_dep.c
   parsec_comm_engine.c
-  parsec_mpi_funnelled.c
-  remote_dep_mpi.c
   scheduling.c
   compound.c
   vpmap.c
@@ -128,6 +126,11 @@ set(SOURCES
 if( PARSEC_PROF_TRACE )
   list(APPEND SOURCES dictionary.c)
 endif( PARSEC_PROF_TRACE )
+if( PARSEC_HAVE_MPI )
+  list(APPEND SOURCES
+    parsec_mpi_funnelled.c
+    remote_dep_mpi.c)
+endif( PARSEC_HAVE_MPI )
 if( NOT MPI_C_FOUND )
   list(APPEND SOURCES datatype/datatype.c)
 else( NOT MPI_C_FOUND )
@@ -378,5 +381,4 @@ endif(PARSEC_WITH_DEVEL_HEADERS)
 
 
 endif( BUILD_PARSEC )
-
 

--- a/parsec/data_dist/matrix/two_dim_tabular.c
+++ b/parsec/data_dist/matrix/two_dim_tabular.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/parsec_config.h"
@@ -13,11 +14,11 @@
 #include "parsec/vpmap.h"
 #include "parsec/runtime.h"
 #include "parsec/data.h"
-#include <string.h>
 #if defined(__WINDOWS__)
 #define _CRT_RAND_S
-#include <stdlib.h>
 #endif
+#include <stdlib.h>
+#include <string.h>
 
 static uint32_t      twoDTD_rank_of(    parsec_data_collection_t* dc, ... );
 static uint32_t      twoDTD_rank_of_key(parsec_data_collection_t* dc, parsec_data_key_t key);

--- a/parsec/include/parsec/parsec_options.h.in
+++ b/parsec/include/parsec/parsec_options.h.in
@@ -1,5 +1,16 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ */
+
 #ifndef PARSEC_CONFIG_H_HAS_BEEN_INCLUDED
 #define PARSEC_CONFIG_H_HAS_BEEN_INCLUDED
+
+#cmakedefine PARSEC_NEED_POSIX_C_SOURCE_FOR_RAND_R
+#if defined(PARSEC_NEED_POSIX_C_SOURCE_FOR_RAND_R) && \
+    (!defined(_POSIX_C_SOURCE) || (_POSIX_C_SOURCE < 199506L))
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 199506L
+#endif
 
 /* This file contains the OS dependent capabilities, and should be generic for
  * all compilers on a particular architecture. It is used during the PaRSEC build to
@@ -27,7 +38,9 @@
 /* OS dependent capabilities */
 #cmakedefine PARSEC_HAVE_PTHREAD
 #cmakedefine PARSEC_HAVE_SCHED_SETAFFINITY
+#cmakedefine PARSEC_HAVE_TIMERSUB
 #cmakedefine PARSEC_HAVE_CLOCK_GETTIME
+#cmakedefine PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC
 #cmakedefine PARSEC_HAVE_ASPRINTF
 #cmakedefine PARSEC_HAVE_VASPRINTF
 #cmakedefine PARSEC_HAVE_RAND_R
@@ -36,6 +49,7 @@
 #cmakedefine PARSEC_HAVE_NRAND48
 #cmakedefine PARSEC_HAVE_LRAND48
 #cmakedefine PARSEC_HAVE_GETLINE
+#cmakedefine PARSEC_HAVE_READLINK
 #cmakedefine PARSEC_HAVE_SETENV
 #cmakedefine PARSEC_HAVE_STDARG_H
 #cmakedefine PARSEC_HAVE_UNISTD_H
@@ -155,4 +169,3 @@
 #include "parsec/parsec_config_bottom.h"
 
 #endif  /* PARSEC_CONFIG_H_HAS_BEEN_INCLUDED */
-

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2023-2024 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2023-2026 NVIDIA Corporation.  All rights reserved.
  */
 
 /* **************************************************************************** */
@@ -29,10 +29,11 @@
  * scheduling of kernel routines.
  */
 
+#include "parsec/parsec_config.h"
+
 #include <stdlib.h>
 #include <sys/time.h>
 
-#include "parsec/parsec_config.h"
 #include "parsec/parsec_internal.h"
 #include "parsec/scheduling.h"
 #include "parsec/remote_dep.h"

--- a/parsec/mca/termdet/fourcounter/termdet_fourcounter_module.c
+++ b/parsec/mca/termdet/fourcounter/termdet_fourcounter_module.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,6 +12,9 @@
  */
 
 #include "parsec/parsec_config.h"
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+#include <time.h>
+#endif
 #include "parsec/parsec_internal.h"
 #include "parsec/include/parsec/execution_stream.h"
 #include "parsec/utils/debug.h"
@@ -99,9 +103,11 @@ typedef struct parsec_termdet_fourcounter_monitor_s {
     uint32_t stats_nb_recv_msg;                 /**< Statistics: number of messages received */
     uint32_t stats_nb_sent_bytes;               /**< Statistics: number of bytes sent */
     uint32_t stats_nb_recv_bytes;               /**< Statistics: number of bytes received */
-    struct timeval stats_time_start;
-    struct timeval stats_time_last_idle;
-    struct timeval stats_time_end;
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+    struct timespec stats_time_start;
+    struct timespec stats_time_last_idle;
+    struct timespec stats_time_end;
+#endif
 } parsec_termdet_fourcounter_monitor_t;
 
 
@@ -109,6 +115,23 @@ static void parsec_termdet_fourcounter_msg_down(parsec_termdet_fourcounter_msg_d
 static void parsec_termdet_fourcounter_msg_up(parsec_termdet_fourcounter_msg_up_t *msg, int src, parsec_taskpool_t *tp);
 
 parsec_list_t parsec_termdet_fourcounter_delayed_messages;
+
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+static inline unsigned long long
+parsec_termdet_fourcounter_timespec_sub(const struct timespec *end,
+                                        const struct timespec *start)
+{
+    time_t sec = end->tv_sec - start->tv_sec;
+    long nsec = end->tv_nsec - start->tv_nsec;
+
+    if( nsec < 0 ) {
+        sec--;
+        nsec += 1000000000L;
+    }
+
+    return ((unsigned long long)sec * 1000000ULL) + (unsigned long long)(nsec / 1000L);
+}
+#endif
 
 static int parsec_termdet_fourcounter_msg_dispatch_taskpool(parsec_taskpool_t *tp, parsec_comm_engine_t *ce,
                                                             long unsigned int tag,  void *msg,
@@ -253,7 +276,10 @@ static void parsec_termdet_fourcounter_monitor_taskpool(parsec_taskpool_t *tp,
     tp->nb_pending_actions = 0;
 
     parsec_atomic_rwlock_init(&tpm->rw_lock);
-    gettimeofday(&tpm->stats_time_start, NULL);
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+    clock_gettime(CLOCK_MONOTONIC, &tpm->stats_time_start);
+    tpm->stats_time_last_idle = tpm->stats_time_start;
+#endif
 }
 
 static void parsec_termdet_fourcounter_unmonitor_taskpool(parsec_taskpool_t *tp)
@@ -370,7 +396,9 @@ static void parsec_termdet_fourcounter_send_up_messages(parsec_termdet_fourcount
         tpm->last_acc_received_at_root = tpm->acc_received;
         if( msg_down.result ) {
             PARSEC_DEBUG_VERBOSE(10, parsec_debug_output, "TERMDET-4C:\tTermination detected on root decision");
-            gettimeofday(&tpm->stats_time_end, NULL);
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+            clock_gettime(CLOCK_MONOTONIC, &tpm->stats_time_end);
+#endif
             tpm->state = PARSEC_TERMDET_FOURCOUNTER_TERMINATED;
             tp->tdm.callback(tp);
         } else {
@@ -408,7 +436,9 @@ static void parsec_termdet_fourcounter_check_state_workload_changed(parsec_termd
 {
     if(tp->nb_tasks == 0 && tp->nb_pending_actions == 0) {
         /* We are now IDLE */
-        gettimeofday(&tpm->stats_time_last_idle, NULL);
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+        clock_gettime(CLOCK_MONOTONIC, &tpm->stats_time_last_idle);
+#endif
         if( tpm->state == PARSEC_TERMDET_FOURCOUNTER_BUSY_WAITING_FOR_PARENT) {
             PARSEC_DEBUG_VERBOSE(10, parsec_debug_output, "TERMDET-4C:\tProcess changed state for IDLE_WAITING_FOR_PARENT");
             tpm->state = PARSEC_TERMDET_FOURCOUNTER_IDLE_WAITING_FOR_PARENT;
@@ -635,7 +665,9 @@ static void parsec_termdet_fourcounter_msg_down(parsec_termdet_fourcounter_msg_d
 
     if(msg->result) {
         assert(tpm->state == PARSEC_TERMDET_FOURCOUNTER_IDLE_WAITING_FOR_PARENT);
-        gettimeofday(&tpm->stats_time_end, NULL);
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+        clock_gettime(CLOCK_MONOTONIC, &tpm->stats_time_end);
+#endif
         tpm->state = PARSEC_TERMDET_FOURCOUNTER_TERMINATED;
         PARSEC_DEBUG_VERBOSE(10, parsec_debug_output, "TERMDET-4C:\tTermination detected on DOWN(true) message");
         parsec_atomic_rwlock_wrunlock(&tpm->rw_lock);
@@ -683,15 +715,17 @@ static void parsec_termdet_fourcounter_msg_up(parsec_termdet_fourcounter_msg_up_
 static int parsec_termdet_fourcounter_write_stats(parsec_taskpool_t *tp, FILE *fp)
 {
     parsec_termdet_fourcounter_monitor_t *tpm;
-    struct timeval t1, t2;
+    unsigned long long idle_us = 0ULL, wall_us = 0ULL;
     assert(NULL != tp->tdm.module);
     assert(&parsec_termdet_fourcounter_module.module == tp->tdm.module);
     tpm = (parsec_termdet_fourcounter_monitor_t *)tp->tdm.monitor;
 
-    timersub(&tpm->stats_time_end, &tpm->stats_time_last_idle, &t1);
-    timersub(&tpm->stats_time_end, &tpm->stats_time_start, &t2);
+#if defined(PARSEC_HAVE_CLOCK_GETTIME_MONOTONIC)
+    idle_us = parsec_termdet_fourcounter_timespec_sub(&tpm->stats_time_end, &tpm->stats_time_last_idle);
+    wall_us = parsec_termdet_fourcounter_timespec_sub(&tpm->stats_time_end, &tpm->stats_time_start);
+#endif
 
-    fprintf(fp, "NP: %d M: 4C Rank: %d Taskpool#: %d #Transitions_Busy_to_Idle: %u #Transitions_Idle_to_Busy: %u #Times_Credit_was_Borrowed: 0 #Times_Credit_was_Flushed: 0 #Times_a_message_was_Delayed: 0 #Times_credit_was_merged: 0 #SentCtlMsg: %u #RecvCtlMsg: %u SentCtlBytes: %u RecvCtlBytes: %u WallTime: %u.%06u Idle2End: %u.%06u\n",
+    fprintf(fp, "NP: %d M: 4C Rank: %d Taskpool#: %d #Transitions_Busy_to_Idle: %u #Transitions_Idle_to_Busy: %u #Times_Credit_was_Borrowed: 0 #Times_Credit_was_Flushed: 0 #Times_a_message_was_Delayed: 0 #Times_credit_was_merged: 0 #SentCtlMsg: %u #RecvCtlMsg: %u SentCtlBytes: %u RecvCtlBytes: %u WallTime: %llu.%06llu Idle2End: %llu.%06llu\n",
             tp->context->nb_nodes,
             tp->context->my_rank,
             tp->taskpool_id,
@@ -701,8 +735,8 @@ static int parsec_termdet_fourcounter_write_stats(parsec_taskpool_t *tp, FILE *f
             tpm->stats_nb_recv_msg,
             tpm->stats_nb_sent_bytes,
             tpm->stats_nb_recv_bytes,
-            (unsigned int)t2.tv_sec, (unsigned int)t2.tv_usec,
-            (unsigned int)t1.tv_sec, (unsigned int)t1.tv_usec);
+            wall_us / 1000000ULL, wall_us % 1000000ULL,
+            idle_us / 1000000ULL, idle_us % 1000000ULL);
 
     return PARSEC_SUCCESS;
 }

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -2141,7 +2141,11 @@ void parsec_taskpool_sync_ids_context( intptr_t comm )
  * id at all ranks. */
 void parsec_taskpool_sync_ids( void )
 {
+#if defined(DISTRIBUTED) && defined(PARSEC_HAVE_MPI)
   parsec_taskpool_sync_ids_context( (intptr_t)MPI_COMM_WORLD );
+#else
+  parsec_taskpool_sync_ids_context( (intptr_t)0 );
+#endif
 }
 
 /* Unregister the taskpool with the engine. This make the taskpool_id available for
@@ -2830,4 +2834,3 @@ int parsec_context_query(parsec_context_t *context, parsec_context_query_cmd_t c
     }
     return PARSEC_ERR_NOT_SUPPORTED;  /* unknown command */
 }
-

--- a/parsec/parsec_comm_engine.c
+++ b/parsec/parsec_comm_engine.c
@@ -5,10 +5,13 @@
  */
 
 #include <assert.h>
+#include "parsec/parsec_config.h"
 #include "parsec/parsec_mpi_funnelled.h"
 #include "parsec/remote_dep.h"
 
 parsec_comm_engine_t parsec_ce;
+
+#if defined(PARSEC_HAVE_MPI)
 
 /* This function will be called by the runtime */
 parsec_comm_engine_t *
@@ -32,3 +35,24 @@ parsec_comm_engine_fini(parsec_comm_engine_t *comm_engine)
     parsec_ce.fini(&parsec_ce);
     return PARSEC_SUCCESS;
 }
+
+#else
+
+parsec_comm_engine_t *
+parsec_comm_engine_init(parsec_context_t *parsec_context)
+{
+    parsec_ce.parsec_context = parsec_context;
+    parsec_ce.capabilites.sided = 0;
+    parsec_ce.capabilites.supports_noncontiguous_datatype = 0;
+    parsec_ce.capabilites.multithreaded = 0;
+    return &parsec_ce;
+}
+
+int
+parsec_comm_engine_fini(parsec_comm_engine_t *comm_engine)
+{
+    (void)comm_engine;
+    return PARSEC_SUCCESS;
+}
+
+#endif  /* defined(PARSEC_HAVE_MPI) */

--- a/parsec/parsec_reshape.c
+++ b/parsec/parsec_reshape.c
@@ -20,6 +20,13 @@
 #define PARSEC_UNFULFILLED_RESHAPE_PROMISE 0
 #define PARSEC_FULFILLED_RESHAPE_PROMISE   1
 
+#if !defined(PARSEC_HAVE_MPI)
+void parsec_local_reshape_cb(parsec_base_future_t *future, ... )
+{
+    (void)future;
+    parsec_fatal("Data reshaping requires MPI datatype support");
+}
+#endif  /* !defined(PARSEC_HAVE_MPI) */
 
 /**
  *
@@ -451,7 +458,14 @@ parsec_set_up_reshape_promise(parsec_execution_stream_t *es,
             }
             data->local = aux_data.remote;
             data->local.src_datatype = PARSEC_DATATYPE_PACKED;
+#if defined(PARSEC_HAVE_MPI)
             MPI_Pack_size(aux_data.remote.dst_count, aux_data.remote.dst_datatype , MPI_COMM_WORLD, &dsize);
+#else
+            if( PARSEC_SUCCESS != parsec_type_size(aux_data.remote.dst_datatype, &dsize) ) {
+                dsize = 0;
+            }
+            dsize *= aux_data.remote.dst_count;
+#endif
             data->local.src_count = dsize;
 
             /* Check if the previous future set up on iterate successor is tracking the same

--- a/parsec/remote_dep.h
+++ b/parsec/remote_dep.h
@@ -426,18 +426,29 @@ extern int parsec_comm_puts;
 static inline void
 remote_dep_rank_to_bit(int rank, uint32_t *bank, uint32_t *bit, int root)
 {
+#if defined(DISTRIBUTED)
     uint32_t nb_nodes = parsec_remote_dep_context.max_nodes_number;
     uint32_t _rank = (rank + nb_nodes - root) % nb_nodes;
     *bank = _rank / (8 * sizeof(uint32_t));
     *bit =  _rank % (8 * sizeof(uint32_t));
+#else
+    (void)rank; (void)root;
+    *bank = 0;
+    *bit = 0;
+#endif
 }
 
 static inline void
 remote_dep_bit_to_rank(int *rank, uint32_t bank, uint32_t bit, int root)
 {
+#if defined(DISTRIBUTED)
     int nb_nodes = parsec_remote_dep_context.max_nodes_number;
     uint32_t _rank = bank * (8 * sizeof(uint32_t)) + bit;
     *rank = (_rank + root) % nb_nodes;
+#else
+    (void)bank; (void)bit; (void)root;
+    *rank = 0;
+#endif
 }
 
 #endif /* __USE_PARSEC_REMOTE_DEP_H__ */

--- a/parsec/utils/backoff.h
+++ b/parsec/utils/backoff.h
@@ -2,16 +2,36 @@
  * Copyright (c) 2022      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
 
+#include "parsec/parsec_config.h"
+
+#if defined(PARSEC_HAVE_RAND_R)
+#include <stdlib.h>
+#define PARSEC_BACKOFF_RAND_MAX RAND_MAX
+#else
+#define PARSEC_BACKOFF_RAND_MAX 32767U
+#endif
 
 #define TIME_STEP 5410
+
+static inline unsigned int parsec_backoff_rand(parsec_execution_stream_t *es)
+{
+#if defined(PARSEC_HAVE_RAND_R)
+    return (unsigned int)rand_r(&es->rand_seed);
+#else
+    es->rand_seed = 1103515245U * es->rand_seed + 12345U;
+    return (es->rand_seed / 65536U) & PARSEC_BACKOFF_RAND_MAX;
+#endif
+}
 
 static inline unsigned long parsec_exponential_backoff(parsec_execution_stream_t *es, uint64_t k)
 {
     unsigned int n = (64 < k ? 64 : k);
-    unsigned int r = (unsigned int) ((double)n * ((double)rand_r(&es->rand_seed)/(double)RAND_MAX));
+    unsigned int r = (unsigned int)((double)n * ((double)parsec_backoff_rand(es) / (double)PARSEC_BACKOFF_RAND_MAX));
 
     return r * TIME_STEP;
 }
 
+#undef PARSEC_BACKOFF_RAND_MAX

--- a/parsec/utils/process_name.c
+++ b/parsec/utils/process_name.c
@@ -2,9 +2,12 @@
  * Copyright (c) 2014-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
 #include "parsec/parsec_config.h"
+#if defined(PARSEC_HAVE_UNISTD_H)
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <limits.h>
 #include <stdio.h>
@@ -25,6 +28,7 @@ char *parsec_process_name(void) {
         return strdup(name);
     }
 #else
+#if defined(PARSEC_HAVE_READLINK)
     size_t len = PATH_MAX;
     ret = readlink("/proc/self/exe", name, len);
     if(-1 == ret) {
@@ -32,9 +36,12 @@ char *parsec_process_name(void) {
         return strdup(name);
     }
     name[ret] = '\0';
+#else
+    ret = snprintf(name, PATH_MAX, "parsec-app");
+    (void)ret;
+#endif
 #endif
     sname = strrchr(name, PARSEC_PATH_SEP[0]);
     if(NULL == sname) return strdup(name);
     else return strdup(sname+1);
 }
-

--- a/tests/api/init_fini.c
+++ b/tests/api/init_fini.c
@@ -3,15 +3,21 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */
+#if defined(PARSEC_HAVE_MPI)
 #include <mpi.h>
+#endif
 #include "parsec.h"
 
 int main(int argc, char *argv[])
 {
+#if defined(PARSEC_HAVE_MPI)
     int mpith = MPI_THREAD_SINGLE;
     MPI_Init_thread(NULL, NULL, MPI_THREAD_SERIALIZED, &mpith);
     assert(mpith >= MPI_THREAD_SERIALIZED); // parsec will do the complaining in NDEBUG
+#endif
     parsec_context_t *parsec = parsec_init(-1, &argc, &argv);
     parsec_fini(&parsec);
+#if defined(PARSEC_HAVE_MPI)
     MPI_Finalize();
+#endif
 }

--- a/tests/api/taskpool_wait/main.c
+++ b/tests/api/taskpool_wait/main.c
@@ -11,7 +11,7 @@
 static int TILE_FULL;
 
 int main(int argc, char *argv[]) {
-    int provided, err, world_size, my_rank;
+    int err, world_size = 1, my_rank = 0;
     parsec_taskpool_t *ptg_tp1, *ptg_tp2;
     parsec_taskpool_t *dtd_tp1;
     parsec_arena_datatype_t *adt;
@@ -24,9 +24,12 @@ int main(int argc, char *argv[]) {
     err = 0;
 
     parsec_context_t *parsec;
+#if defined(PARSEC_HAVE_MPI)
+    int provided;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+#endif
 
     parsec = parsec_init(-1, NULL, NULL);
     parsec_matrix_block_cyclic_init(&A, PARSEC_MATRIX_INTEGER,
@@ -106,6 +109,8 @@ int main(int argc, char *argv[]) {
     parsec_dtd_data_collection_fini(&A.super.super);
 
     parsec_fini(&parsec);
+#if defined(PARSEC_HAVE_MPI)
     MPI_Finalize();
+#endif
     return err;
 }

--- a/tests/class/hash.c
+++ b/tests/class/hash.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2017-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -22,6 +22,17 @@
 #include "parsec/utils/debug.h"
 
 #include "parsec/class/parsec_hash_table.h"
+
+#if !defined(timersub)
+#define timersub(a, b, result) do {                \
+        (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;       \
+        (result)->tv_usec = (a)->tv_usec - (b)->tv_usec;    \
+        if( (result)->tv_usec < 0 ) {                       \
+            --(result)->tv_sec;                             \
+            (result)->tv_usec += 1000000;                   \
+        }                                                   \
+    } while(0)
+#endif
 
 #define START_BASE 4
 #define START_MASK (0xFFFFFFFF >> (32-START_BASE))

--- a/tests/collections/CMakeLists.txt
+++ b/tests/collections/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(kcyclic PRIVATE m)
 
 add_subdirectory(two_dim_band)
 
-add_subdirectory(redistribute)
+if(PARSEC_HAVE_MPI)
+  add_subdirectory(redistribute)
+endif(PARSEC_HAVE_MPI)
 add_subdirectory(reshape)
-

--- a/tests/collections/Testings.cmake
+++ b/tests/collections/Testings.cmake
@@ -1,13 +1,10 @@
 
 parsec_addtest_cmd(collections/reduce ${SHM_TEST_CMD_LIST} collections/reduce)
 
-if( MPI_C_FOUND )
+if( PARSEC_HAVE_MPI )
     parsec_addtest_cmd(collections/redistribute:mp ${MPI_TEST_CMD_LIST} 8 collections/redistribute/testing_redistribute -M 2400 -N 2400 -a 2400 -A 2400 -t 300 -T 300 -b 200 -B 200 -m 2000 -n 2000 -I 30 -J 40 -i 100 -j 121 -v -z -x -P 2 -Q 4 -p 4 -q 2)
     parsec_addtest_cmd(collections/redistribute_random:mp ${MPI_TEST_CMD_LIST} 8 collections/redistribute/testing_redistribute_random -M 2400 -N 2400 -a 2400 -A 2400 -t 300 -T 300 -b 200 -B 200 -m 2000 -n 2000 -I 30 -J 40 -i 100 -j 121 -v -z -x -P 2 -Q 4 -p 4 -q 2)
-else( MPI_C_FOUND )
-    parsec_addtest_cmd(collections/redistribute ${MPI_TEST_CMD_LIST} collections/redistribute/testing_redistribute -M 2400 -N 2400 -a 2400 -A 2400 -t 300 -T 300 -b 200 -B 200 -m 2000 -n 2000 -I 30 -J 40 -i 100 -j 121 -v -z -x)
-    parsec_addtest_cmd(collections/redistribute_random ${MPI_TEST_CMD_LIST} collections/redistribute/testing_redistribute_random -M 2400 -N 2400 -a 2400 -A 2400 -t 300 -T 300 -b 200 -B 200 -m 2000 -n 2000 -I 30 -J 40 -i 100 -j 121 -v -z -x)
-endif( MPI_C_FOUND )
+endif( PARSEC_HAVE_MPI )
 
 parsec_addtest_cmd(collections/reshape ${SHM_TEST_CMD_LIST} collections/reshape/reshape -N 120 -t 9 -c 10)
 parsec_addtest_cmd(collections/reshape:mt ${SHM_TEST_CMD_LIST} collections/reshape/reshape -N 120 -t 9 -c 10 -m 1)

--- a/tests/dsl/dtd/CMakeLists.txt
+++ b/tests/dsl/dtd/CMakeLists.txt
@@ -22,7 +22,9 @@ parsec_addtest_executable(C dtd_test_global_id_for_dc_assumed SOURCES dtd_test_g
 parsec_addtest_executable(C dtd_test_explicit_task_creation SOURCES dtd_test_explicit_task_creation.c)
 parsec_addtest_executable(C dtd_test_tp_enqueue_dequeue SOURCES dtd_test_tp_enqueue_dequeue.c)
 parsec_addtest_executable(C dtd_test_interleave_actions SOURCES dtd_test_interleave_actions.c)
-parsec_addtest_executable(C dtd_test_ce SOURCES dtd_test_ce.c)
+if( PARSEC_HAVE_MPI )
+  parsec_addtest_executable(C dtd_test_ce SOURCES dtd_test_ce.c)
+endif( PARSEC_HAVE_MPI )
 
 parsec_addtest_executable(C dtd_test_new_tile SOURCES dtd_test_new_tile.c)
 if( PARSEC_HAVE_CUDA )

--- a/tests/dsl/dtd/dtd_test_empty.c
+++ b/tests/dsl/dtd/dtd_test_empty.c
@@ -4,7 +4,9 @@
  *                         reserved.
  */
 #include "parsec.h"
+#if defined(PARSEC_HAVE_MPI)
 #include <mpi.h>
+#endif
 
 int main(int argc, char **argv)
 {

--- a/tests/dsl/dtd/dtd_test_explicit_task_creation.c
+++ b/tests/dsl/dtd/dtd_test_explicit_task_creation.c
@@ -96,7 +96,7 @@ int main(int argc, char ** argv)
     adt = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
     parsec_arena_datatype_construct( adt,
                                      nb*sizeof(int), PARSEC_ARENA_ALIGNMENT_SSE,
-                                     MPI_INT );
+                                     parsec_datatype_int_t );
 
     dcA = create_and_distribute_data(rank, world, nb, nt);
     parsec_data_collection_set_key((parsec_data_collection_t *)dcA, "A");

--- a/tests/dsl/dtd/dtd_test_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_test_simple_gemm.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2021-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec.h"
@@ -13,6 +14,19 @@
 // The file is not compiled if CUDA is not present or CUBLAS is not found
 #include "parsec/mca/device/cuda/device_cuda.h"
 #include "cublas_v2.h"
+
+#include <sys/time.h>
+
+#if !defined(timersub)
+#define timersub(a, b, result) do {                \
+        (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;       \
+        (result)->tv_usec = (a)->tv_usec - (b)->tv_usec;    \
+        if( (result)->tv_usec < 0 ) {                       \
+            --(result)->tv_sec;                             \
+            (result)->tv_usec += 1000000;                   \
+        }                                                   \
+    } while(0)
+#endif
 
 #if defined(HAVE_BLAS)
 // If our CMake finds a BLAS library, it defines HAVE_BLAS

--- a/tests/dsl/ptg/multisize_bcast/check_multisize_bcast.jdf
+++ b/tests/dsl/ptg/multisize_bcast/check_multisize_bcast.jdf
@@ -32,8 +32,8 @@ k = 0 .. NT-1
 // Parameters
 RW T <- (k == 0) ? descA(k, k) : A potrf_diag(k, k-1)
      -> T potrf_diag(k+1..NT-1, k)
-     -> T potrf_col(k+1..NT-1..2, k) [layout = MPI_DOUBLE count = 2]
-     -> T potrf_col(k+2..NT-1..2, k) [layout = MPI_DOUBLE count = 3]
+     -> T potrf_col(k+1..NT-1..2, k) [layout = parsec_datatype_double_t count = 2]
+     -> T potrf_col(k+2..NT-1..2, k) [layout = parsec_datatype_double_t count = 3]
      -> descA(k, k)
 
 BODY
@@ -89,4 +89,3 @@ BODY
     printf("diag %d, iteration %d\n", k, i);
 }
 END
-

--- a/tests/dsl/ptg/ptgpp/write_check.jdf
+++ b/tests/dsl/ptg/ptgpp/write_check.jdf
@@ -158,8 +158,8 @@ int main(int argc, char* argv[])
 
     free(descA.mat);
 
-#ifdef PARSEC_HAVE_MPI
     int maxloc[2] = {error_found, rank};
+#ifdef PARSEC_HAVE_MPI
     MPI_Reduce(0 == rank? MPI_IN_PLACE: &maxloc, &maxloc, 1, MPI_2INT, MPI_MAXLOC, 0, MPI_COMM_WORLD);
     MPI_Finalize();
 #endif
@@ -178,4 +178,3 @@ int main(int argc, char* argv[])
 }
 
 %}
-

--- a/tests/profiling-standalone/sp-perf.c
+++ b/tests/profiling-standalone/sp-perf.c
@@ -2,7 +2,10 @@
  * Copyright (c) 2017-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
+#include "parsec/parsec_config.h"
+
 #include <stdlib.h>
 #include <pthread.h>
 #ifdef PARSEC_HAVE_PTHREAD_BARRIER_H
@@ -16,6 +19,17 @@
 #include <string.h>
 #include <stdio.h>
 #include "parsec/profiling.h"
+
+#if !defined(timersub)
+#define timersub(a, b, result) do {                \
+        (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;       \
+        (result)->tv_usec = (a)->tv_usec - (b)->tv_usec;    \
+        if( (result)->tv_usec < 0 ) {                       \
+            --(result)->tv_sec;                             \
+            (result)->tv_usec += 1000000;                   \
+        }                                                   \
+    } while(0)
+#endif
 
 #include <mpi.h>
 

--- a/tests/runtime/scheduling/schedmicro_data.c
+++ b/tests/runtime/scheduling/schedmicro_data.c
@@ -67,7 +67,7 @@ static parsec_data_t* data_of(parsec_data_collection_t *desc, ...)
     assert( k < dat->size && k >= 0 );
     (void)k;
     if(NULL == dat->data) {
-        dat->data = parsec_data_copy_new(NULL, 0, MPI_BYTE, PARSEC_DATA_FLAG_PARSEC_MANAGED);
+        dat->data = parsec_data_copy_new(NULL, 0, parsec_datatype_int8_t, PARSEC_DATA_FLAG_PARSEC_MANAGED);
         dat->data->device_private = dat->ptr;
     }
     return (void*)(dat->data);


### PR DESCRIPTION
Keep MPI-only runtime sources out of non-MPI builds and provide the minimal no-MPI communication-engine path needed by the common runtime.

Also clean up tests and generated PTG inputs that still assumed MPI was available by guarding MPI setup/teardown, using PaRSEC datatype constants instead of MPI datatypes, and skipping the MPI-only DTD communication engine test when MPI support is disabled.