### PR TITLE
Disable msys2 CI

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,5 +1,5 @@
 name: MSYS2
-on: [push, pull_request]
+on: workflow_dispatch  # disable for now msys2 is lacking support [push, pull_request]
 
 jobs:
   msys2-ucrt64:


### PR DESCRIPTION
msys2 is lacking too much functionality to be able to properly support parsec, and I don't have more time to waste to make it work.

It was my mistake to merge the PR allowing msys2 builds earlier today.