### PR TITLE
profiling: add optional NVTX substrate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,8 @@ option(PARSEC_PROF_TRACE
   set(PARSEC_PROF_TRACE_SYSTEM "PaRSEC Binary Tracing Format" CACHE STRING "Select the profiling system, if PARSEC_PROF_TRACE is ON")
 #This enforces that only valid values are available in ccmake or cmake-gui
 set_property(CACHE PARSEC_PROF_TRACE_SYSTEM PROPERTY STRINGS "OTF2" "PaRSEC Binary Tracing Format")
+option(PARSEC_PROF_TRACE_NVTX
+  "Mirror PaRSEC profiling events as NVIDIA NVTX ranges for Nsight Systems" OFF)
 option(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT
   "Generate Profiling traces for the internal_init tasks in the PTG interface (expert mode only)" OFF)
 mark_as_advanced(PARSEC_PROF_TRACE_PTG_INTERNAL_INIT) #This is available in export mode only
@@ -931,6 +933,28 @@ if(PARSEC_PROF_TRACE AND PARSEC_DIST_WITH_MPI)
     endif(OTF2_FOUND AND MPI_C_FOUND)
   endif(PARSEC_PROF_TRACE_SYSTEM STREQUAL "OTF2" OR PARSEC_PROF_TRACE_SYSTEM STREQUAL "Auto")
 endif(PARSEC_PROF_TRACE AND PARSEC_DIST_WITH_MPI)
+
+if(PARSEC_PROF_TRACE_NVTX)
+  if(NOT PARSEC_PROF_TRACE)
+    message(FATAL_ERROR "PARSEC_PROF_TRACE_NVTX requires PARSEC_PROF_TRACE=ON")
+  endif()
+  find_path(PARSEC_NVTX_INCLUDE_DIR
+            NAMES nvtx3/nvToolsExt.h
+            HINTS ${PARSEC_NVTX_ROOT}
+                  ${NVTX_ROOT}
+                  ${CUDAToolkit_INCLUDE_DIRS}
+                  ${CUDAToolkit_ROOT}
+                  ${CUDA_TOOLKIT_ROOT_DIR}
+                  ENV NVTX_ROOT
+                  ENV CUDAToolkit_ROOT
+                  ENV CUDA_PATH
+            PATH_SUFFIXES include)
+  if(NOT PARSEC_NVTX_INCLUDE_DIR)
+    message(FATAL_ERROR "PARSEC_PROF_TRACE_NVTX was requested, but nvtx3/nvToolsExt.h was not found. Set NVTX_ROOT or PARSEC_NVTX_INCLUDE_DIR.")
+  endif()
+  message(STATUS "Profiling will emit NVTX annotations using ${PARSEC_NVTX_INCLUDE_DIR}")
+endif()
+mark_as_advanced(PARSEC_NVTX_INCLUDE_DIR)
 
 #
 # First go for the tools.

--- a/configure
+++ b/configure
@@ -70,6 +70,8 @@ cat <<EOF
 
 --enable-prof-trace
                 produce a trace of the execution that can be analyzed in a trace vizualizer
+--enable-prof-nvtx
+                emit profiling events as NVTX ranges for NVIDIA Nsight Systems
 --enable-prof-calltrace
                 print a message when each task body is executed
 --enable-prof-dryrun=yes|dep|body|no
@@ -89,6 +91,8 @@ cat <<EOF
                 use the PAPI performance counter package [installed in DIR] (default=autodetect)
 --with-ayudame[=DIR]
                 use the Ayudame package [installed in DIR] (optional)
+--with-nvtx[=DIR]
+                use NVTX headers [installed in DIR] for Nsight Systems annotations
 
 --with-hwloc[=DIR]
                 use the HWLoc package [installed in DIR] (default=autodetect)
@@ -209,6 +213,8 @@ while [ "x$1" != x ]; do
         --disable-debug) enable_debug=no; shift;;
         --enable-prof-trace) enable_prof_trace=yes; shift;;
         --disable-prof-trace) enable_prof_trace=no; shift;;
+        --enable-prof-nvtx|--enable-nvtx) enable_prof_nvtx=yes; shift;;
+        --disable-prof-nvtx|--disable-nvtx) enable_prof_nvtx=no; shift;;
         --enable-prof-calltrace) enable_prof_calltrace=yes; shift;;
         --disable-prof-calltrace) enable_prof_calltrace=no; shift;;
         --enable-prof-dryrun=*) enable_prof_dryrun="${1#*=}"; shift;;
@@ -231,6 +237,9 @@ while [ "x$1" != x ]; do
         --with-ayudame=*) with_ayudame="${1#*=}"; shift;;
         --with-ayudame) with_ayudame=yes; shift;;
         --without-ayudame) with_ayudame=no; shift;;
+        --with-nvtx=*) with_nvtx="${1#*=}"; shift;;
+        --with-nvtx) with_nvtx=yes; shift;;
+        --without-nvtx) with_nvtx=no; shift;;
 
 # MPI options
         --with-mpi=*) with_mpi="${1#*=}"; shift;;
@@ -472,6 +481,16 @@ else echo >&2 "Option $enable_debug is invalid (can be yes|paranoid|noisier|hist
 
 [ x$enable_prof_trace = xyes ] && CMAKE_DEFINES+=" -DPARSEC_PROF_TRACE=ON"
 [ x$enable_prof_trace = xno ] && CMAKE_DEFINES+=" -DPARSEC_PROF_TRACE=OFF"
+
+case x$with_nvtx in
+xno) enable_prof_nvtx=no;;
+xyes) enable_prof_nvtx=yes;;
+x) ;;
+*) enable_prof_nvtx=yes
+   CMAKE_DEFINES+=" -DPARSEC_NVTX_ROOT=$(printf %q "$with_nvtx")";;
+esac
+[ x$enable_prof_nvtx = xyes ] && CMAKE_DEFINES+=" -DPARSEC_PROF_TRACE=ON -DPARSEC_PROF_TRACE_NVTX=ON"
+[ x$enable_prof_nvtx = xno ] && CMAKE_DEFINES+=" -DPARSEC_PROF_TRACE_NVTX=OFF"
 [ x$enable_prof_calltrace = xyes ] && CMAKE_DEFINES+=" -DPARSEC_PROF_CALLTRACE=ON"
 [ x$enable_prof_calltrace = xno ] && CMAKE_DEFINES+=" -DPARSEC_PROF_CALLTRACE=OFF"
 [ x$enable_prof_grapher = xyes ] && CMAKE_DEFINES+=" -DPARSEC_PROF_GRAPHER=ON"
@@ -606,4 +625,3 @@ if [ x$nocreate != xyes ]; then
 #
 EOF
 fi
-

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -658,6 +658,7 @@ WARN_LOGFILE           =
 # with spaces.
 
 INPUT                  = @PROJECT_SOURCE_DIR@/docs/doxygen/mainpage.md
+INPUT                 += @PROJECT_SOURCE_DIR@/docs/doxygen/profiling.md
 INPUT                 += @PROJECT_SOURCE_DIR@/docs/doxygen/groups.dox
 INPUT                 += @PROJECT_SOURCE_DIR@/parsec
 INPUT                 += @PROJECT_BINARY_DIR@/parsec/include

--- a/docs/doxygen/mainpage.md
+++ b/docs/doxygen/mainpage.md
@@ -33,7 +33,9 @@ task runtime system, schedule DAGs of Tasks in it, and expose the user
 data to the task system
 - [A profiling system](@ref parsec_public_profiling) to build traces
 of the execution at runtime, providing performance information
-feedback to the application or to the user
+feedback to the application or to the user. See the
+[profiling how-to](@ref parsec_profiling_howto) for build and runtime
+collection examples for the PaRSEC binary trace format, OTF2, and NVTX.
 
 ## <a name="parsecdev">PaRSEC Developer and Advanced Usage Documentation</a> ###
 [(Return to Table of Contents](#toc)]
@@ -117,4 +119,3 @@ following components have specific documentation:
 
  - [schedulers](@ref parsec/mca/sched/sched.h) in `parsec/mca/sched`
  - [PaRSEC INStrumentation](@ref parsec/mca/pins/pins.h) in `parsec/mca/pins`
-

--- a/docs/doxygen/profiling.md
+++ b/docs/doxygen/profiling.md
@@ -1,0 +1,221 @@
+PaRSEC Profiling How-To {#parsec_profiling_howto}
+=======================
+
+PaRSEC can record execution information through the @ref
+parsec_public_profiling API and through the PaRSEC INStrumentation
+system (PINS). The profiling API provides the storage and event model;
+PINS decides which runtime events, such as task execution, are emitted.
+
+Profiling is a build-time feature. A build can provide one file-based
+profiling substrate, either the PaRSEC binary trace format or OTF2, and
+can also mirror emitted events to NVTX ranges for NVIDIA Nsight Systems.
+At runtime, file-based substrates require a profile filename. NVTX does
+not write a PaRSEC profile file and is enabled with its own MCA parameter.
+
+## Build-Time Support
+
+The common option for all profiling substrates is:
+
+```
+cmake -S <src> -B <build> -DPARSEC_PROF_TRACE=ON
+```
+
+The `configure` wrapper can also enable the common profiling support:
+
+```
+./configure --enable-prof-trace
+```
+
+By default, `PARSEC_PROF_TRACE=ON` selects the PaRSEC binary trace
+format. To select OTF2 instead, configure with:
+
+```
+cmake -S <src> -B <build> \
+  -DPARSEC_PROF_TRACE=ON \
+  -DPARSEC_PROF_TRACE_SYSTEM=OTF2 \
+  -DOTF2_DIR=<otf2-prefix>
+```
+
+OTF2 support requires a distributed MPI build and an OTF2 installation
+that provides `otf2-config`.
+
+To add NVTX support, enable both the common profiling layer and the NVTX
+mirror:
+
+```
+cmake -S <src> -B <build> \
+  -DPARSEC_PROF_TRACE=ON \
+  -DPARSEC_PROF_TRACE_NVTX=ON \
+  -DPARSEC_NVTX_ROOT=<cuda-or-nvtx-prefix>
+```
+
+or, through the `configure` wrapper:
+
+```
+./configure --enable-prof-nvtx --with-nvtx=<cuda-or-nvtx-prefix>
+```
+
+`PARSEC_NVTX_ROOT` and `--with-nvtx` are optional when the NVTX headers
+can be found from the CUDA Toolkit or the system include paths.
+
+## Runtime Instrumentation
+
+The profiling layer only records events that are emitted by the
+application or by selected runtime instrumentation modules. To collect
+task events from the PaRSEC runtime, enable the PINS task profiler:
+
+```
+--mca mca_pins task_profiler
+```
+
+The task profiler enables `release_deps` and `exec_begin` events by
+default. The selected task-profiler event families can be changed with:
+
+```
+--mca pins_task_profiler_event exec,release_deps,complete_exec
+```
+
+Accepted task-profiler event family names include `select`,
+`prepare_input`, `release_deps`, `activate_cb`, `data_flush`, `exec`,
+`complete_exec`, and `schedule`.
+
+If the application has its own command line parser, PaRSEC MCA arguments
+are commonly passed after the application's `--` separator:
+
+```
+./app <app-arguments> -- --mca mca_pins task_profiler
+```
+
+Some applications pass MCA arguments directly to PaRSEC and do not need
+the separator.
+
+## PaRSEC Binary Trace Format
+
+The PaRSEC binary trace format is the default file-based substrate when
+profiling is compiled in:
+
+```
+cmake -S <src> -B <build> -DPARSEC_PROF_TRACE=ON
+```
+
+Collect a trace by providing a base profile filename and enabling the
+task profiler:
+
+```
+./app <app-arguments> -- \
+  --mca profile_filename run \
+  --mca mca_pins task_profiler
+```
+
+The binary substrate creates one `.prof` file per process, using the
+profile filename as the base name, for example `run-0.prof`,
+`run-1.prof`, and so on.
+
+The binary files can be converted to the HDF5/PTT format with the
+profiling tools:
+
+```
+<build>/tools/profiling/python/profile2h5.py \
+  --output run.h5 \
+  run-*.prof
+```
+
+The resulting HDF5 file can be inspected with the PaRSEC profiling
+Python tools and viewers.
+
+## OTF2
+
+OTF2 is selected at configure time instead of the PaRSEC binary trace
+format:
+
+```
+cmake -S <src> -B <build> \
+  -DPARSEC_PROF_TRACE=ON \
+  -DPARSEC_PROF_TRACE_SYSTEM=OTF2 \
+  -DOTF2_DIR=<otf2-prefix>
+```
+
+Collect an OTF2 trace by providing a profile filename and enabling the
+task profiler:
+
+```
+./app <app-arguments> -- \
+  --mca profile_filename traces/run \
+  --mca mca_pins task_profiler
+```
+
+For OTF2, `profile_filename` names the archive path used by the OTF2
+writer. The parent directory must already exist and must be writable by
+the application. The generated archive can be opened with standard OTF2
+trace analysis tools.
+
+## NVTX and NVIDIA Nsight Systems
+
+NVTX support mirrors PaRSEC profiling events into an NVTX domain named
+`PaRSEC`. It is intended for use with NVIDIA Nsight Systems and can be
+used without creating a PaRSEC profile file.
+
+Build with NVTX support:
+
+```
+cmake -S <src> -B <build> \
+  -DPARSEC_PROF_TRACE=ON \
+  -DPARSEC_PROF_TRACE_NVTX=ON
+```
+
+or:
+
+```
+./configure --enable-prof-nvtx
+```
+
+Collect NVTX events with Nsight Systems by enabling the NVTX runtime
+mirror and the PINS task profiler:
+
+```
+nsys profile --trace=nvtx,cuda -o parsec_report \
+  ./app <app-arguments> -- \
+  --mca profile_nvtx 1 \
+  --mca mca_pins task_profiler
+```
+
+Environment variables are often convenient when the profiled command
+line is already complex:
+
+```
+PARSEC_MCA_profile_nvtx=1 \
+PARSEC_MCA_mca_pins=task_profiler \
+nsys profile --trace=nvtx,cuda -o parsec_report ./app <app-arguments>
+```
+
+No `profile_filename` is required for NVTX-only collection. To collect
+both NVTX ranges and the selected file-based substrate in the same run,
+enable `profile_nvtx` and also provide `profile_filename`:
+
+```
+nsys profile --trace=nvtx,cuda -o parsec_report \
+  ./app <app-arguments> -- \
+  --mca profile_nvtx 1 \
+  --mca profile_filename run \
+  --mca mca_pins task_profiler
+```
+
+## Troubleshooting Empty Traces
+
+If a profiling run completes but the trace is empty, check the following
+items:
+
+- The build was configured with `PARSEC_PROF_TRACE=ON`.
+- NVTX runs were also configured with `PARSEC_PROF_TRACE_NVTX=ON`.
+- File-based runs provided `--mca profile_filename <name>`.
+- Task event collection enabled the PINS task profiler with
+  `--mca mca_pins task_profiler`.
+- The selected application path actually executed PaRSEC tasks.
+- The output directory for binary or OTF2 traces already exists and is
+  writable.
+- Nsight Systems was instructed to collect NVTX events with
+  `--trace=nvtx` or a trace list that includes `nvtx`.
+
+When using Nsight Systems, `nsys status --environment` can also confirm
+whether the current system supports the requested CUDA and tracing
+features.

--- a/parsec/CMakeLists.txt
+++ b/parsec/CMakeLists.txt
@@ -101,6 +101,9 @@ else(NOT PARSEC_HAVE_OTF2)
   list(APPEND EXTRA_LIBS "otf2")
   message(STATUS "Profiling uses OTF2")
 endif(NOT PARSEC_HAVE_OTF2)
+if(PARSEC_PROF_TRACE_NVTX)
+  list(APPEND EXTRA_SOURCES "profiling_nvtx.c")
+endif()
 
 set(SOURCES
   arena.c
@@ -230,6 +233,9 @@ if( BUILD_PARSEC )
       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/parsec/include>>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/parsec/include>)
+  if(PARSEC_PROF_TRACE_NVTX)
+    target_include_directories(parsec PRIVATE ${PARSEC_NVTX_INCLUDE_DIR})
+  endif()
   target_link_libraries(parsec
     PRIVATE
     Threads::Threads
@@ -381,4 +387,3 @@ endif(PARSEC_WITH_DEVEL_HEADERS)
 
 
 endif( BUILD_PARSEC )
-

--- a/parsec/include/parsec/parsec_options.h.in
+++ b/parsec/include/parsec/parsec_options.h.in
@@ -107,6 +107,7 @@
 
 /* profiling */
 #cmakedefine PARSEC_PROF_TRACE
+#cmakedefine PARSEC_PROF_TRACE_NVTX
 #cmakedefine PARSEC_PROF_TRACE_PTG_INTERNAL_INIT
 #cmakedefine PARSEC_PROF_RUSAGE_EU
 #cmakedefine PARSEC_PROF_TRACE_SCHEDULING_EVENTS

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -56,6 +56,9 @@
 #ifdef PARSEC_PROF_TRACE
 #include "parsec/profiling.h"
 #endif
+#if defined(PARSEC_PROF_TRACE_NVTX)
+#include "parsec/profiling_nvtx.h"
+#endif
 
 #include "parsec/parsec_hwloc.h"
 #ifdef PARSEC_HAVE_HWLOC
@@ -389,9 +392,13 @@ parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[] )
     char *parsec_enable_profiling = NULL;  /* profiling file prefix when PARSEC_PROF_TRACE is on */
     int slow_option_used = 0;
 #if defined(PARSEC_PROF_TRACE)
+    int profiling_file_requested = 0;
     int profiling_id = 0;
-#endif
     int profiling_enabled = 0;
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    int profiling_nvtx_enabled = 0;
+#endif
+#endif
 
     gethostname(parsec_hostname_array, sizeof(parsec_hostname_array));
     parsec_app_name = parsec_process_name();
@@ -675,7 +682,7 @@ parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[] )
 
     parsec_mca_param_reg_string_name("profile", "filename",
 #if defined(PARSEC_PROF_TRACE)
-                                    "Path to the profiling file (<none> to disable, <app> for app name, <*> otherwise)",
+                                    "Path to the profiling file/archive for file-based profiling substrates (<none> to disable, <app> for app name, <*> otherwise). NVTX does not require this.",
                                     false, false,
 #else
                                     "Path to the profiling file (unused due to profiling being turned off during building)",
@@ -683,26 +690,45 @@ parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[] )
 #endif  /* defined(PARSEC_PROF_TRACE) */
                                     "<none>", &parsec_enable_profiling);
 #if defined(PARSEC_PROF_TRACE)
-    if( (0 != strncasecmp(parsec_enable_profiling, "<none>", 6)) && (0 == parsec_profiling_init( profiling_id )) ) {
+    profiling_file_requested = (0 != strncasecmp(parsec_enable_profiling, "<none>", 6));
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    profiling_nvtx_enabled = parsec_profiling_nvtx_register_mca();
+#endif
+    if( (profiling_file_requested
+#if defined(PARSEC_PROF_TRACE_NVTX)
+         || profiling_nvtx_enabled
+#endif
+        ) && (0 == parsec_profiling_init( profiling_id )) ) {
         int i, l;
         char *cmdline_info = NULL;
 
-        /* Use either the app name (argv[0]) or the user provided filename */
-        if( 0 == strncmp(parsec_enable_profiling, "<app>", 5) ) {
-            /* Specialize the profiling filename to avoid collision with other instances */
-            ret = asprintf( &cmdline_info, "%s_%d", parsec_app_name, (int)getpid() );
-            if (ret < 0) {
-                cmdline_info = strdup(parsec_app_name);
+        if( profiling_file_requested ) {
+            /* Use either the app name (argv[0]) or the user provided filename */
+            if( 0 == strncmp(parsec_enable_profiling, "<app>", 5) ) {
+                /* Specialize the profiling filename to avoid collision with other instances */
+                ret = asprintf( &cmdline_info, "%s_%d", parsec_app_name, (int)getpid() );
+                if (ret < 0) {
+                    cmdline_info = strdup(parsec_app_name);
+                }
+                ret = parsec_profiling_dbp_start( cmdline_info, parsec_app_name );
+                free(cmdline_info);
+            } else {
+                ret = parsec_profiling_dbp_start( parsec_enable_profiling, parsec_app_name );
             }
-            ret = parsec_profiling_dbp_start( cmdline_info, parsec_app_name );
-            free(cmdline_info);
-        } else {
-            ret = parsec_profiling_dbp_start( parsec_enable_profiling, parsec_app_name );
-        }
-        if( ret != 0 ) {
-            parsec_warning("Profiling framework deactivated because of error %s.", parsec_profiling_strerror());
-        } else {
-            profiling_enabled = 1;
+            if( ret != 0 ) {
+                parsec_warning("Profiling file substrate deactivated because of error %s.", parsec_profiling_strerror());
+#if defined(PARSEC_PROF_TRACE_NVTX)
+                if( !profiling_nvtx_enabled ) {
+                    (void)parsec_profiling_fini();
+                    goto profiling_setup_done;
+                }
+#else
+                (void)parsec_profiling_fini();
+                goto profiling_setup_done;
+#endif
+            } else {
+                profiling_enabled = 1;
+            }
         }
 
         l = strlen(parsec_app_name);  /* use the known application name */
@@ -762,6 +788,8 @@ parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[] )
         parsec_profiling_add_dictionary_keyword( "Device delegate", "fill:#EAE7C6",
                                                 0, NULL,
                                                 &device_delegate_begin, &device_delegate_end);
+profiling_setup_done:
+        ;
     }
 #endif  /* PARSEC_PROF_TRACE */
     assert (NULL != parsec_enable_profiling);

--- a/parsec/parsec_binary_profile.h
+++ b/parsec/parsec_binary_profile.h
@@ -24,6 +24,10 @@
 
 BEGIN_C_DECLS
 
+#if defined(PARSEC_PROF_TRACE_NVTX)
+struct parsec_profiling_nvtx_range_s;
+#endif
+
 typedef struct parsec_profiling_output_base_event_s {
     uint16_t  key;
     uint16_t  flags;
@@ -143,6 +147,10 @@ struct parsec_profiling_stream_s {
     pthread_t                  thread_owner;
     off_t                      current_events_buffer_offset;
     parsec_profiling_buffer_t *current_events_buffer;     /* points to the events buffer in which we are writing. */
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    struct parsec_profiling_nvtx_range_s *nvtx_ranges;
+    struct parsec_profiling_nvtx_range_s *nvtx_freelist;
+#endif
 };
 
 typedef struct {

--- a/parsec/profiling.c
+++ b/parsec/profiling.c
@@ -24,6 +24,9 @@
 
 #include "parsec/profiling.h"
 #include "parsec/parsec_binary_profile.h"
+#if defined(PARSEC_PROF_TRACE_NVTX)
+#include "parsec/profiling_nvtx.h"
+#endif
 #include "parsec/data_distribution.h"
 #include "parsec/utils/debug.h"
 #include "parsec/class/list.h"
@@ -106,6 +109,15 @@ static PARSEC_TLS_DECLARE(tls_profiling);
 
 static int parsec_profiling_show_profiling_performance = 0;
 static parsec_profiling_perf_t parsec_profiling_global_perf[PERF_MAX];
+
+static int parsec_profiling_has_active_substrate(void)
+{
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    return (-1 != file_backend_fd) || parsec_profiling_nvtx_is_enabled();
+#else
+    return (-1 != file_backend_fd);
+#endif
+}
 
 #define do_and_measure_perf( perf_counter, code ) do {                  \
         parsec_time_t start, end;                                       \
@@ -295,8 +307,56 @@ free_to_freelist(tl_freelist_t *fl, parsec_profiling_buffer_t *b)
     pthread_mutex_unlock(&fl->lock);
 }
 
-
 #if defined(PARSEC_PROFILING_USE_HELPER_THREAD)
+static void set_last_error(const char *format, ...);
+
+static void profiling_release_buffer_memory(parsec_profiling_buffer_t *buffer)
+{
+    if( NULL == buffer ) {
+        return;
+    }
+
+#if defined(PARSEC_PROFILING_USE_MMAP)
+    do_and_measure_perf(PERF_MUNMAP,
+      if( munmap(buffer, event_buffer_size) == -1 ) {
+          fprintf(stderr, "Warning profiling system: unmap of the events backend file at %p failed: %s\n",
+                  (void*)buffer, strerror(errno));
+      });
+#else
+    do_and_measure_perf(PERF_FREE,
+      free(buffer));
+#endif
+}
+
+static void profiling_cleanup_file_backend(void)
+{
+    tl_freelist_buffer_t *b;
+
+    profiling_release_buffer_memory((parsec_profiling_buffer_t*)profile_head);
+    profile_head = NULL;
+
+    if( NULL != default_freelist ) {
+        while(default_freelist->first != NULL) {
+            b = default_freelist->first;
+            default_freelist->first = b->next;
+            profiling_release_buffer_memory((parsec_profiling_buffer_t*)b);
+        }
+        pthread_mutex_destroy(&default_freelist->lock);
+        free(default_freelist);
+        default_freelist = NULL;
+    }
+
+    if( -1 != file_backend_fd ) {
+        close(file_backend_fd);
+        file_backend_fd = -1;
+    }
+    free(bpf_filename);
+    bpf_filename = NULL;
+    file_backend_extendable = 0;
+    file_backend_size = 0;
+    file_backend_next_offset = 0;
+}
+
 /**
  * Profiling I/O command structure
  *
@@ -329,6 +389,7 @@ typedef struct io_cmd_queue_s {
 static io_cmd_queue_t cmd_queue;
 static io_cmd_queue_t free_cmd_queue;
 static pthread_t io_helper_thread_id;
+static int io_helper_thread_started = 0;
 
 static int             io_cmd_flush_counter;
 static pthread_mutex_t io_cmd_flush_mutex;
@@ -418,15 +479,31 @@ static void *io_helper_thread_fct(void *_)
     return NULL;
 }
 
-static void io_helper_thread_init(void)
+static int io_helper_thread_init(void)
 {
+    int rc;
+
+    if( io_helper_thread_started ) {
+        return 0;
+    }
+
     io_cmd_queue_init(&cmd_queue);
     io_cmd_queue_init(&free_cmd_queue);
     io_cmd_flush_counter = 0;
     pthread_mutex_init(&io_cmd_flush_mutex, NULL);
     pthread_cond_init(&io_cmd_flush_cond, NULL);
 
-    pthread_create(&io_helper_thread_id, NULL, io_helper_thread_fct, NULL);
+    rc = pthread_create(&io_helper_thread_id, NULL, io_helper_thread_fct, NULL);
+    if( 0 != rc ) {
+        set_last_error("Profiling system: unable to create I/O helper thread: %s\n", strerror(rc));
+        pthread_mutex_destroy(&io_cmd_flush_mutex);
+        pthread_cond_destroy(&io_cmd_flush_cond);
+        io_cmd_queue_destroy(&cmd_queue);
+        io_cmd_queue_destroy(&free_cmd_queue);
+        return PARSEC_ERROR;
+    }
+    io_helper_thread_started = 1;
+    return 0;
 }
 #endif /* PARSEC_PROFILING_USE_HELPER_THREAD */
 
@@ -475,6 +552,7 @@ int parsec_profiling_init( int process_id )
     parsec_profiling_buffer_t dummy_events_buffer;
     long ps = (16 * 1024);  /* a sane default value */
     int parsec_profiling_minimal_ebs;
+    int na_s, na_e;
 
     if( __profile_initialized ) return PARSEC_ERR_NOT_SUPPORTED;
 
@@ -505,6 +583,9 @@ int parsec_profiling_init( int process_id )
     parsec_mca_param_reg_int_name("profile", "show_profiling_performance", "Print profiling performance at the end of the execution"
                                       " (default is no/0)",
                                       false, false, parsec_profiling_show_profiling_performance, &parsec_profiling_show_profiling_performance);
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_init(process_id);
+#endif
     if( parsec_profiling_minimal_ebs <= 0 )
         parsec_profiling_minimal_ebs = 10;
     if( parsec_profiling_file_multiplier <= 0 )
@@ -560,17 +641,19 @@ int parsec_profiling_init( int process_id )
     } else
         parsec_profiling_add_information("cwd", "");
 
-#if defined(PARSEC_PROFILING_USE_HELPER_THREAD)
-    io_helper_thread_init();
-#endif
-    
     __profile_initialized = 1; //* confirmed */
+    /* Reserve keys 0/1 to catch traces that use an uninitialized key. */
+    parsec_profiling_add_dictionary_keyword( "N/A", "fill:#000000", 0, "", &na_s, &na_e);
+    assert(na_s == 0 && na_e == 1);
+    (void)na_s; (void)na_e;
     return 0;
 }
 
 void parsec_profiling_start(void)
 {
     if(start_called)
+        return;
+    if( !__profile_initialized || !parsec_profiling_has_active_substrate() )
         return;
 
     start_called = 1;
@@ -582,43 +665,52 @@ parsec_profiling_stream_t* parsec_profiling_stream_init( size_t length, const ch
     parsec_profiling_stream_t *sprof;
     va_list ap;
     int rc;
+    int file_backend_enabled = (-1 != file_backend_fd);
 
     if( !__profile_initialized ) return NULL;
-    if( -1 == file_backend_fd ) {
-        set_last_error("Profiling system: parsec_profiling_stream_init: call before parsec_profiling_dbp_start");
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    if( !file_backend_enabled && !parsec_profiling_nvtx_is_enabled() ) {
+#else
+    if( !file_backend_enabled ) {
+#endif
+        set_last_error("Profiling system: parsec_profiling_stream_init: call before a profiling substrate was started");
         return NULL;
     }
-    if( 0 == file_backend_extendable ) {
+    if( file_backend_enabled && (0 == file_backend_extendable) ) {
         set_last_error("Profiling system: parsec_profiling_stream_init called on a blocked backend");
         return NULL;
     }
 
-    sprof = (parsec_profiling_stream_t*)malloc( sizeof(parsec_profiling_stream_t) + length );
+    sprof = (parsec_profiling_stream_t*)malloc( sizeof(parsec_profiling_stream_t) +
+                                                (file_backend_enabled ? length : 0) );
     if( NULL == sprof ) {
         set_last_error("Profiling system: parsec_profiling_stream_init: unable to allocate %u bytes", length);
         fprintf(stderr, "*** %s\n", parsec_profiling_strerror());
         return NULL;
     }
 
-    sprof->buffers_freelist = (tl_freelist_t*)malloc(sizeof(tl_freelist_t));
-    tl_freelist_t *t_fl = sprof->buffers_freelist;
-    tl_freelist_buffer_t *e;
-    pthread_mutex_init(&t_fl->lock, NULL);
-    e = (tl_freelist_buffer_t*)profiling_allocate_new_buffer();
-    if( NULL == e ) {
-        free(sprof->buffers_freelist);
-        free(sprof);
-        return NULL;
-    }
-    e->next = NULL;
-    t_fl->first = e;
-    t_fl->nb_allocated = 1;
-    for(rc = 1; rc < parsec_profiling_per_thread_buffer_freelist_min; rc++) {
-        e->next = (tl_freelist_buffer_t*)profiling_allocate_new_buffer();
-        assert(NULL != e->next);
-        e = e->next;
+    sprof->buffers_freelist = NULL;
+    if( file_backend_enabled ) {
+        sprof->buffers_freelist = (tl_freelist_t*)malloc(sizeof(tl_freelist_t));
+        tl_freelist_t *t_fl = sprof->buffers_freelist;
+        tl_freelist_buffer_t *e;
+        pthread_mutex_init(&t_fl->lock, NULL);
+        e = (tl_freelist_buffer_t*)profiling_allocate_new_buffer();
+        if( NULL == e ) {
+            free(sprof->buffers_freelist);
+            free(sprof);
+            return NULL;
+        }
         e->next = NULL;
-        t_fl->nb_allocated++;
+        t_fl->first = e;
+        t_fl->nb_allocated = 1;
+        for(rc = 1; rc < parsec_profiling_per_thread_buffer_freelist_min; rc++) {
+            e->next = (tl_freelist_buffer_t*)profiling_allocate_new_buffer();
+            assert(NULL != e->next);
+            e = e->next;
+            e->next = NULL;
+            t_fl->nb_allocated++;
+        }
     }
 
     PARSEC_OBJ_CONSTRUCT(sprof, parsec_list_item_t);
@@ -626,20 +718,30 @@ parsec_profiling_stream_t* parsec_profiling_stream_init( size_t length, const ch
     rc = vasprintf(&sprof->hr_id, format, ap); assert(rc!=-1); (void)rc;
     va_end(ap);
 
-    assert( event_buffer_size != 0 );
-    /* To trigger a buffer allocation at first creation of an event */
-    sprof->next_event_position = event_buffer_size;
+    if( file_backend_enabled ) {
+        assert( event_buffer_size != 0 );
+        /* To trigger a buffer allocation at first creation of an event */
+        sprof->next_event_position = event_buffer_size;
+    } else {
+        sprof->next_event_position = 0;
+    }
     sprof->nb_events = 0;
 
     sprof->infos = NULL;
 
     sprof->first_events_buffer_offset = (off_t)-1;
     sprof->current_events_buffer = NULL;
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    sprof->nvtx_ranges = NULL;
+    sprof->nvtx_freelist = NULL;
+#endif
 
     parsec_list_push_back( &threads, (parsec_list_item_t*)sprof );
 
-    /* Allocate the first page to save time on the first event tracing */
-    switch_event_buffer(sprof);
+    if( file_backend_enabled ) {
+        /* Allocate the first page to save time on the first event tracing */
+        switch_event_buffer(sprof);
+    }
 
     memset(sprof->thread_perf, 0, sizeof(parsec_profiling_perf_t)*PERF_MAX);
 
@@ -670,10 +772,12 @@ int parsec_profiling_fini( void )
     while( (t = (parsec_profiling_stream_t*)parsec_list_nolock_pop_front(&threads)) ) {
         tl_freelist_t *fl = t->buffers_freelist;
         tl_freelist_buffer_t *b;
-        while(fl->first != NULL) {
-            b = fl->first;
-            fl->first = b->next;
-            free(b);
+        if( NULL != fl ) {
+            while(fl->first != NULL) {
+                b = fl->first;
+                fl->first = b->next;
+                free(b);
+            }
         }
         if( parsec_profiling_show_profiling_performance ) {
             for(i = 0; i < PERF_MAX; i++) {
@@ -682,8 +786,14 @@ int parsec_profiling_fini( void )
             }
         }
 
-        pthread_mutex_destroy(&fl->lock);
-        free(fl);
+#if defined(PARSEC_PROF_TRACE_NVTX)
+        parsec_profiling_nvtx_release_stream(&t->nvtx_ranges,
+                                             &t->nvtx_freelist);
+#endif
+        if( NULL != fl ) {
+            pthread_mutex_destroy(&fl->lock);
+            free(fl);
+        }
         free(t->hr_id);
         free(t);
     }
@@ -691,20 +801,25 @@ int parsec_profiling_fini( void )
     PARSEC_OBJ_DESTRUCT(&threads);
 
 #if defined(PARSEC_PROFILING_USE_HELPER_THREAD)
-    io_cmd_t *cmd = io_cmd_allocate();
-    cmd->buffer = IO_CMD_STOP;
-    cmd->fl = NULL;
-    cmd->next = NULL;
-    pthread_mutex_lock(&cmd_queue.lock);
-    if( NULL == cmd_queue.last ) {
-        cmd_queue.last = cmd_queue.next = cmd;
-    } else {
-        cmd_queue.last->next = cmd;
-        cmd_queue.last = cmd;
+    if( io_helper_thread_started ) {
+        io_cmd_t *cmd = io_cmd_allocate();
+        cmd->buffer = IO_CMD_STOP;
+        cmd->fl = NULL;
+        cmd->next = NULL;
+        pthread_mutex_lock(&cmd_queue.lock);
+        if( NULL == cmd_queue.last ) {
+            cmd_queue.last = cmd_queue.next = cmd;
+        } else {
+            cmd_queue.last->next = cmd;
+            cmd_queue.last = cmd;
+        }
+        pthread_cond_signal(&cmd_queue.cond);
+        pthread_mutex_unlock(&cmd_queue.lock);
+        pthread_join(io_helper_thread_id, NULL);
+        pthread_mutex_destroy(&io_cmd_flush_mutex);
+        pthread_cond_destroy(&io_cmd_flush_cond);
+        io_helper_thread_started = 0;
     }
-    pthread_cond_signal(&cmd_queue.cond);
-    pthread_mutex_unlock(&cmd_queue.lock);
-    pthread_join(io_helper_thread_id, NULL);
 #endif
     
     if( parsec_profiling_show_profiling_performance ) {
@@ -755,16 +870,22 @@ int parsec_profiling_fini( void )
     }
     memset(parsec_profiling_global_perf, 0, sizeof(parsec_profiling_perf_t)*PERF_MAX);
 
-    while(default_freelist->first != NULL) {
-        tl_freelist_buffer_t *b = default_freelist->first;
-        default_freelist->first = b->next;
-        free(b);
+    if( NULL != default_freelist ) {
+        while(default_freelist->first != NULL) {
+            tl_freelist_buffer_t *b = default_freelist->first;
+            default_freelist->first = b->next;
+            free(b);
+        }
+        pthread_mutex_destroy(&default_freelist->lock);
+        free(default_freelist);
+        default_freelist = NULL;
     }
-    pthread_mutex_destroy(&default_freelist->lock);
-    free(default_freelist);
 
     parsec_profiling_dictionary_flush();
     free(parsec_prof_keys);
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_fini();
+#endif
     parsec_prof_keys_number = 0;
     start_called = 0;            /* Allow the profiling to be reinitialized */
     parsec_profile_enabled = 0;  /* turn off the profiling */
@@ -781,6 +902,10 @@ int parsec_profiling_reset( void )
     PARSEC_LIST_ITERATOR(&threads, it, {
         t = (parsec_profiling_stream_t*)it;
         t->next_event_position = 0;
+#if defined(PARSEC_PROF_TRACE_NVTX)
+        parsec_profiling_nvtx_release_stream(&t->nvtx_ranges,
+                                             &t->nvtx_freelist);
+#endif
         /* TODO: should reset the backend file / recreate it */
     });
 
@@ -832,6 +957,9 @@ int parsec_profiling_add_dictionary_keyword( const char* key_name, const char* a
 
     *key_start = START_KEY(pos);
     *key_end = END_KEY(pos);
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_register_key(pos, key_name, attributes);
+#endif
 profiling_keyword_out:
     pthread_mutex_unlock(&profiling_keyword_lock);
     return ret;
@@ -852,6 +980,9 @@ int parsec_profiling_dictionary_flush( void )
         }
     }
     parsec_prof_keys_count = 0;
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_dictionary_flush();
+#endif
 
     return 0;
 }
@@ -961,7 +1092,9 @@ int parsec_profiling_ts_trace_flags_info_fn(int key, uint64_t event_id, uint32_t
 {
     parsec_profiling_stream_t* ctx;
 
-    if( (-1 == file_backend_fd) || (!start_called) ) {
+    if( !__profile_initialized ||
+        !start_called ||
+        !parsec_profiling_has_active_substrate() ) {
         return PARSEC_ERR_NOT_SUPPORTED;
     }
 
@@ -991,12 +1124,14 @@ parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key
     size_t this_event_length;
     parsec_time_t now;
 
-    if(flags & PARSEC_PROFILING_EVENT_TIME_AT_START) {
-        now = take_time();
+    if( !__profile_initialized ||
+        !start_called ||
+        !parsec_profiling_has_active_substrate() ) {
+        return PARSEC_ERR_NOT_SUPPORTED;
     }
 
-    if( (-1 == file_backend_fd) || (!start_called) ) {
-        return PARSEC_ERR_NOT_SUPPORTED;
+    if(flags & PARSEC_PROFILING_EVENT_TIME_AT_START) {
+        now = take_time();
     }
 
     if( key < 2 || key >= 2*parsec_prof_keys_count ) {
@@ -1007,6 +1142,17 @@ parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key
             parsec_prof_warning_issued = 1;
         }
         assert(0); /* In DEBUG mode, we provide a catch point here to find what task issued this profiling */
+    }
+
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_trace(&context->nvtx_ranges,
+                                &context->nvtx_freelist,
+                                BASE_KEY(key), KEY_IS_START(key),
+                                event_id, taskpool_id);
+#endif
+
+    if( -1 == file_backend_fd ) {
+        return 0;
     }
 
     this_event_length = EVENT_LENGTH( key, ((NULL != info_fn) && (NULL != info_data)) );
@@ -1484,6 +1630,13 @@ int parsec_profiling_dbp_start( const char *basefile, const char *hr_info )
     profile_head->profile_buffer_size = event_buffer_size;
     strncpy(profile_head->hr_id, hr_info, 127); /* We copy only up to 127 bytes to leave room for the '\0' */
     profile_head->rank = parsec_profiling_process_id;
+
+#if defined(PARSEC_PROFILING_USE_HELPER_THREAD)
+    if( 0 != io_helper_thread_init() ) {
+        profiling_cleanup_file_backend();
+        return PARSEC_ERROR;
+    }
+#endif
 
     /* Reset the error system without printing it on stderr */
     snprintf(parsec_profiling_last_error, MAX_PROFILING_ERROR_STRING_LEN, "Profiling system: success");

--- a/parsec/profiling_nvtx.c
+++ b/parsec/profiling_nvtx.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ */
+
+#include "parsec/parsec_config.h"
+
+#if defined(PARSEC_PROF_TRACE_NVTX)
+
+#include "parsec/profiling_nvtx.h"
+
+#include <ctype.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <nvtx3/nvToolsExt.h>
+
+#include "parsec/utils/mca_param.h"
+
+struct parsec_profiling_nvtx_range_s {
+    struct parsec_profiling_nvtx_range_s *next;
+    struct parsec_profiling_nvtx_range_s *global_next;
+    struct parsec_profiling_nvtx_range_s **owner_active;
+    int                                   key;
+    uint64_t                              event_id;
+    uint32_t                              taskpool_id;
+    nvtxRangeId_t                         range_id;
+};
+
+typedef struct parsec_profiling_nvtx_key_s {
+    char    *name;
+    uint32_t color;
+} parsec_profiling_nvtx_key_t;
+
+static nvtxDomainHandle_t parsec_profiling_nvtx_domain = NULL;
+static parsec_profiling_nvtx_key_t *parsec_profiling_nvtx_keys = NULL;
+static int parsec_profiling_nvtx_keys_count = 0;
+static int parsec_profiling_nvtx_keys_size = 0;
+static int parsec_profiling_nvtx_enabled = 0;
+static int parsec_profiling_nvtx_mca_registered = 0;
+static parsec_profiling_nvtx_range_t *parsec_profiling_nvtx_active_ranges = NULL;
+static pthread_mutex_t parsec_profiling_nvtx_ranges_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static uint32_t parsec_profiling_nvtx_fallback_color(int key)
+{
+    static const uint32_t colors[] = {
+        0xff4e79a7, 0xfff28e2b, 0xffe15759, 0xff76b7b2,
+        0xff59a14f, 0xffedc949, 0xffaf7aa1, 0xffff9da7,
+        0xff9c755f, 0xffbab0ab
+    };
+    return colors[(unsigned int)key % (sizeof(colors) / sizeof(colors[0]))];
+}
+
+static int parsec_profiling_nvtx_hex(char c)
+{
+    if( c >= '0' && c <= '9' ) return c - '0';
+    c = (char)tolower((unsigned char)c);
+    if( c >= 'a' && c <= 'f' ) return c - 'a' + 10;
+    return -1;
+}
+
+static uint32_t parsec_profiling_nvtx_parse_color(const char *attributes, int key)
+{
+    const char *c;
+    uint32_t color = 0;
+
+    if( NULL == attributes ) {
+        return parsec_profiling_nvtx_fallback_color(key);
+    }
+
+    c = strchr(attributes, '#');
+    if( NULL == c ) {
+        return parsec_profiling_nvtx_fallback_color(key);
+    }
+    c++;
+    for(int i = 0; i < 6; i++) {  /* Reading a hex RGB */
+        if( '\0'== c[i] ) {
+            return parsec_profiling_nvtx_fallback_color(key);
+        }
+        int v = parsec_profiling_nvtx_hex(c[i]);
+        if( v < 0 ) {
+            return parsec_profiling_nvtx_fallback_color(key);
+        }
+        color = (color << 4) | (uint32_t)v;
+    }
+    return 0xff000000 | color;
+}
+
+int parsec_profiling_nvtx_register_mca(void)
+{
+    if( !parsec_profiling_nvtx_mca_registered ) {
+        parsec_mca_param_reg_int_name("profile", "nvtx",
+                                      "Enable the NVTX profiling substrate and mirror PaRSEC profiling events as ranges for NVIDIA Nsight Systems",
+                                      false, false,
+                                      parsec_profiling_nvtx_enabled,
+                                      &parsec_profiling_nvtx_enabled);
+        parsec_profiling_nvtx_mca_registered = 1;
+    }
+    return parsec_profiling_nvtx_enabled;
+}
+
+int parsec_profiling_nvtx_is_enabled(void)
+{
+    return parsec_profiling_nvtx_enabled;
+}
+
+void parsec_profiling_nvtx_init(int process_id)
+{
+    (void)process_id;
+
+    parsec_profiling_nvtx_register_mca();
+    if( !parsec_profiling_nvtx_enabled ) {
+        return;
+    }
+
+    parsec_profiling_nvtx_domain = nvtxDomainCreateA("PaRSEC");
+}
+
+void parsec_profiling_nvtx_dictionary_flush(void)
+{
+    for(int i = 0; i < parsec_profiling_nvtx_keys_count; i++) {
+        free(parsec_profiling_nvtx_keys[i].name);
+    }
+    free(parsec_profiling_nvtx_keys);
+    parsec_profiling_nvtx_keys = NULL;
+    parsec_profiling_nvtx_keys_count = 0;
+    parsec_profiling_nvtx_keys_size = 0;
+}
+
+void parsec_profiling_nvtx_fini(void)
+{
+    parsec_profiling_nvtx_dictionary_flush();
+    if( NULL != parsec_profiling_nvtx_domain ) {
+        nvtxDomainDestroy(parsec_profiling_nvtx_domain);
+        parsec_profiling_nvtx_domain = NULL;
+    }
+}
+
+void parsec_profiling_nvtx_register_key(int key, const char *name,
+                                        const char *attributes)
+{
+    char *new_name;
+
+    if( !parsec_profiling_nvtx_enabled ||
+        NULL == parsec_profiling_nvtx_domain ||
+        key < 0 ) {
+        return;
+    }
+
+    if( key >= parsec_profiling_nvtx_keys_size ) {
+        int old_size = parsec_profiling_nvtx_keys_size;
+        int new_size = (0 == old_size) ? 128 : old_size;
+        parsec_profiling_nvtx_key_t *new_keys;
+        while( key >= new_size ) {
+            new_size *= 2;
+        }
+        new_keys = realloc(parsec_profiling_nvtx_keys,
+                           (size_t)new_size * sizeof(parsec_profiling_nvtx_key_t));
+        if( NULL == new_keys ) {
+            return;
+        }
+        parsec_profiling_nvtx_keys = new_keys;
+        memset(&parsec_profiling_nvtx_keys[old_size], 0,
+               (size_t)(new_size - old_size) * sizeof(parsec_profiling_nvtx_key_t));
+        parsec_profiling_nvtx_keys_size = new_size;
+    }
+    if( key >= parsec_profiling_nvtx_keys_count ) {
+        parsec_profiling_nvtx_keys_count = key + 1;
+    }
+
+    new_name = strdup((NULL == name) ? "PaRSEC event" : name);
+    if( NULL == new_name ) {
+        return;
+    }
+    free(parsec_profiling_nvtx_keys[key].name);
+    parsec_profiling_nvtx_keys[key].name = new_name;
+    parsec_profiling_nvtx_keys[key].color =
+        parsec_profiling_nvtx_parse_color(attributes, key);
+    nvtxDomainNameCategoryA(parsec_profiling_nvtx_domain,
+                            (uint32_t)key,
+                            parsec_profiling_nvtx_keys[key].name);
+}
+
+static parsec_profiling_nvtx_range_t*
+parsec_profiling_nvtx_range_alloc(parsec_profiling_nvtx_range_t **freelist)
+{
+    parsec_profiling_nvtx_range_t *range = *freelist;
+    if( NULL != range ) {
+        *freelist = range->next;
+        return range;
+    }
+    return (parsec_profiling_nvtx_range_t*)malloc(sizeof(*range));
+}
+
+static void
+parsec_profiling_nvtx_range_free(parsec_profiling_nvtx_range_t **freelist,
+                                 parsec_profiling_nvtx_range_t *range)
+{
+    range->global_next = NULL;
+    range->owner_active = NULL;
+    range->next = *freelist;
+    *freelist = range;
+}
+
+static void
+parsec_profiling_nvtx_unlink_global_locked(parsec_profiling_nvtx_range_t *range)
+{
+    parsec_profiling_nvtx_range_t *cur = parsec_profiling_nvtx_active_ranges;
+    parsec_profiling_nvtx_range_t *prev = NULL;
+
+    while( NULL != cur ) {
+        if( cur == range ) {
+            if( NULL == prev ) {
+                parsec_profiling_nvtx_active_ranges = cur->global_next;
+            } else {
+                prev->global_next = cur->global_next;
+            }
+            range->global_next = NULL;
+            return;
+        }
+        prev = cur;
+        cur = cur->global_next;
+    }
+}
+
+static void
+parsec_profiling_nvtx_unlink_owner_locked(parsec_profiling_nvtx_range_t *range)
+{
+    parsec_profiling_nvtx_range_t **cur;
+
+    if( NULL == range->owner_active ) {
+        return;
+    }
+
+    cur = range->owner_active;
+    while( NULL != *cur ) {
+        if( *cur == range ) {
+            *cur = range->next;
+            break;
+        }
+        cur = &((*cur)->next);
+    }
+    range->next = NULL;
+    range->owner_active = NULL;
+}
+
+void parsec_profiling_nvtx_release_stream(parsec_profiling_nvtx_range_t **active,
+                                          parsec_profiling_nvtx_range_t **freelist)
+{
+    parsec_profiling_nvtx_range_t *range, *to_end = NULL;
+
+    pthread_mutex_lock(&parsec_profiling_nvtx_ranges_lock);
+    while( NULL != *active ) {
+        range = *active;
+        *active = range->next;
+        parsec_profiling_nvtx_unlink_global_locked(range);
+        range->next = to_end;
+        range->owner_active = NULL;
+        to_end = range;
+    }
+    pthread_mutex_unlock(&parsec_profiling_nvtx_ranges_lock);
+
+    while( NULL != to_end ) {
+        range = to_end;
+        to_end = range->next;
+        if( NULL != parsec_profiling_nvtx_domain ) {
+            nvtxDomainRangeEnd(parsec_profiling_nvtx_domain, range->range_id);
+        }
+        free(range);
+    }
+    while( NULL != *freelist ) {
+        range = *freelist;
+        *freelist = range->next;
+        free(range);
+    }
+}
+
+static int parsec_profiling_nvtx_same_range(parsec_profiling_nvtx_range_t *range,
+                                            int key,
+                                            uint64_t event_id,
+                                            uint32_t taskpool_id)
+{
+    if( range->key != key || range->event_id != event_id ) {
+        return 0;
+    }
+    return (range->taskpool_id == taskpool_id) ||
+           (range->taskpool_id == PROFILE_OBJECT_ID_NULL) ||
+           (taskpool_id == PROFILE_OBJECT_ID_NULL);
+}
+
+static parsec_profiling_nvtx_range_t*
+parsec_profiling_nvtx_find_active_locked(int key,
+                                         uint64_t event_id,
+                                         uint32_t taskpool_id)
+{
+    parsec_profiling_nvtx_range_t *range = parsec_profiling_nvtx_active_ranges;
+
+    while( NULL != range ) {
+        if( parsec_profiling_nvtx_same_range(range, key, event_id, taskpool_id) ) {
+            parsec_profiling_nvtx_unlink_global_locked(range);
+            parsec_profiling_nvtx_unlink_owner_locked(range);
+            return range;
+        }
+        range = range->global_next;
+    }
+    return NULL;
+}
+
+void parsec_profiling_nvtx_trace(parsec_profiling_nvtx_range_t **active,
+                                 parsec_profiling_nvtx_range_t **freelist,
+                                 int key, int is_start,
+                                 uint64_t event_id, uint32_t taskpool_id)
+{
+    parsec_profiling_nvtx_range_t *range;
+    nvtxEventAttributes_t event_attrib;
+
+    if( !parsec_profiling_nvtx_enabled ||
+        NULL == parsec_profiling_nvtx_domain ||
+        key < 0 ||
+        key >= parsec_profiling_nvtx_keys_count ||
+        NULL == parsec_profiling_nvtx_keys[key].name ) {
+        return;
+    }
+
+    if( is_start ) {
+        memset(&event_attrib, 0, sizeof(event_attrib));
+        event_attrib.version = NVTX_VERSION;
+        event_attrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+        event_attrib.category = (uint32_t)key;
+        event_attrib.colorType = NVTX_COLOR_ARGB;
+        event_attrib.color = parsec_profiling_nvtx_keys[key].color;
+        event_attrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+        event_attrib.message.ascii = parsec_profiling_nvtx_keys[key].name;
+        event_attrib.payloadType = NVTX_PAYLOAD_TYPE_UNSIGNED_INT64;
+        event_attrib.payload.ullValue = event_id;
+
+        range = parsec_profiling_nvtx_range_alloc(freelist);
+        if( NULL == range ) {
+            return;
+        }
+        range->key = key;
+        range->event_id = event_id;
+        range->taskpool_id = taskpool_id;
+        range->range_id = nvtxDomainRangeStartEx(parsec_profiling_nvtx_domain,
+                                                 &event_attrib);
+        pthread_mutex_lock(&parsec_profiling_nvtx_ranges_lock);
+        range->owner_active = active;
+        range->next = *active;
+        *active = range;
+        range->global_next = parsec_profiling_nvtx_active_ranges;
+        parsec_profiling_nvtx_active_ranges = range;
+        pthread_mutex_unlock(&parsec_profiling_nvtx_ranges_lock);
+        return;
+    }
+
+    pthread_mutex_lock(&parsec_profiling_nvtx_ranges_lock);
+    range = parsec_profiling_nvtx_find_active_locked(key, event_id, taskpool_id);
+    pthread_mutex_unlock(&parsec_profiling_nvtx_ranges_lock);
+    if( NULL != range ) {
+        nvtxDomainRangeEnd(parsec_profiling_nvtx_domain, range->range_id);
+        parsec_profiling_nvtx_range_free(freelist, range);
+    }
+}
+
+#endif /* defined(PARSEC_PROF_TRACE_NVTX) */

--- a/parsec/profiling_nvtx.h
+++ b/parsec/profiling_nvtx.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ */
+
+#ifndef PARSEC_PROFILING_NVTX_H_HAS_BEEN_INCLUDED
+#define PARSEC_PROFILING_NVTX_H_HAS_BEEN_INCLUDED
+
+#include "parsec/parsec_config.h"
+
+#if defined(PARSEC_PROF_TRACE_NVTX)
+
+#include <stdint.h>
+
+#include "parsec/profiling.h"
+
+typedef struct parsec_profiling_nvtx_range_s parsec_profiling_nvtx_range_t;
+
+int parsec_profiling_nvtx_register_mca(void);
+int parsec_profiling_nvtx_is_enabled(void);
+void parsec_profiling_nvtx_init(int process_id);
+void parsec_profiling_nvtx_fini(void);
+void parsec_profiling_nvtx_register_key(int key, const char *name,
+                                        const char *attributes);
+void parsec_profiling_nvtx_dictionary_flush(void);
+void parsec_profiling_nvtx_release_stream(parsec_profiling_nvtx_range_t **active,
+                                          parsec_profiling_nvtx_range_t **freelist);
+void parsec_profiling_nvtx_trace(parsec_profiling_nvtx_range_t **active,
+                                 parsec_profiling_nvtx_range_t **freelist,
+                                 int key, int is_start,
+                                 uint64_t event_id, uint32_t taskpool_id);
+
+#endif /* defined(PARSEC_PROF_TRACE_NVTX) */
+
+#endif /* PARSEC_PROFILING_NVTX_H_HAS_BEEN_INCLUDED */

--- a/parsec/profiling_otf2.c
+++ b/parsec/profiling_otf2.c
@@ -7,6 +7,9 @@
 #include "parsec/parsec_config.h"
 
 #include "parsec/profiling.h"
+#if defined(PARSEC_PROF_TRACE_NVTX)
+#include "parsec/profiling_nvtx.h"
+#endif
 #include "parsec/data_distribution.h"
 #include "parsec/utils/debug.h"
 #include "parsec/parsec_hwloc.h"
@@ -50,6 +53,10 @@ struct parsec_profiling_stream_s {
     parsec_list_t      informations;
     OTF2_EvtWriter    *evt_writer;
     parsec_profiling_stream_data_t data;
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_range_t *nvtx_ranges;
+    parsec_profiling_nvtx_range_t *nvtx_freelist;
+#endif
 };
 
 typedef struct {
@@ -164,6 +171,18 @@ static OTF2_GlobalDefWriter* global_def_writer = NULL;
 static int32_t next_strid = 1;
 static int emptystrid = 0;
 
+static int parsec_profiling_has_active_substrate(void)
+{
+    if( NULL != otf2_archive ) {
+        return 1;
+    }
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    return parsec_profiling_nvtx_is_enabled();
+#else
+    return 0;
+#endif
+}
+
 static int next_otf2_global_strid(void)
 {
     return parsec_atomic_fetch_inc_int32(&next_strid);
@@ -231,6 +250,9 @@ int parsec_profiling_init( int process_id )
 
     parsec_mca_param_reg_int_name("profile", "max_streams", "Maximum number of profiling streams per process",
                                   false, false, max_stream_id, &max_stream_id);
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_init(process_id);
+#endif
 
     /* As we called the _start function automatically, the timing will be
      * based on this moment. By forcing back the __already_called to 0, we
@@ -314,7 +336,7 @@ parsec_profiling_stream_t* parsec_profiling_stream_init( size_t length, const ch
     va_end(ap);
 
 
-    if (start_called) {
+    if (start_called && NULL != otf2_archive) {
         /* adjust for the communicator rank */
         res->data.id += process_id*max_stream_id;
         res->evt_writer = OTF2_Archive_GetEvtWriter( otf2_archive, res->data.id );
@@ -464,25 +486,28 @@ void parsec_profiling_start(void)
     if(start_called)
         return;
 
-    if( NULL == otf2_archive )
+    if( !__profile_initialized || !parsec_profiling_has_active_substrate() ) {
         return;
-
-    parsec_list_lock( &threads );
-    for( r = PARSEC_LIST_ITERATOR_FIRST(&threads);
-         r != PARSEC_LIST_ITERATOR_END(&threads);
-         r = PARSEC_LIST_ITERATOR_NEXT(r) ) {
-        tp = (parsec_profiling_stream_t*)r;
-        /* adjust the id for the communicator rank */
-        tp->data.id += process_id*max_stream_id;
-        tp->evt_writer = OTF2_Archive_GetEvtWriter( otf2_archive, tp->data.id );
-        if( NULL == tp->evt_writer ) {
-            parsec_warning("PaRSEC Profiling -- OTF2: could not allocate event writer for location %d\n", tp->data.id);
-        }
     }
-    parsec_list_unlock( &threads );
 
-    if( parsec_profiling_mpi_on ) {
-        MPI_Barrier(parsec_otf2_profiling_comm);
+    if( NULL != otf2_archive ) {
+        parsec_list_lock( &threads );
+        for( r = PARSEC_LIST_ITERATOR_FIRST(&threads);
+             r != PARSEC_LIST_ITERATOR_END(&threads);
+             r = PARSEC_LIST_ITERATOR_NEXT(r) ) {
+            tp = (parsec_profiling_stream_t*)r;
+            /* adjust the id for the communicator rank */
+            tp->data.id += process_id*max_stream_id;
+            tp->evt_writer = OTF2_Archive_GetEvtWriter( otf2_archive, tp->data.id );
+            if( NULL == tp->evt_writer ) {
+                parsec_warning("PaRSEC Profiling -- OTF2: could not allocate event writer for location %d\n", tp->data.id);
+            }
+        }
+        parsec_list_unlock( &threads );
+
+        if( parsec_profiling_mpi_on ) {
+            MPI_Barrier(parsec_otf2_profiling_comm);
+        }
     }
 
     start_called = 1;
@@ -526,6 +551,9 @@ int parsec_profiling_add_dictionary_keyword( const char* key_name, const char* a
     regions[region].info_length = info_length;
     regions[region].attr_info = NULL;
     regions[region].otf2_nb_attributes = 0;
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_register_key(region, key_name, attributes);
+#endif
 
     if( NULL == orig_convertor_code ) {
         /* skip converter code parsing */
@@ -686,6 +714,9 @@ malformed_convertor_code:
 
 int parsec_profiling_dictionary_flush( void )
 {
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_dictionary_flush();
+#endif
     return 0;
 }
 
@@ -694,7 +725,9 @@ int parsec_profiling_ts_trace_flags_info_fn(int key, uint64_t event_id, uint32_t
 {
     parsec_profiling_stream_t* ctx;
 
-    if( !start_called ) {
+    if( !__profile_initialized ||
+        !start_called ||
+        !parsec_profiling_has_active_substrate() ) {
         return PARSEC_ERR_NOT_SUPPORTED;
     }
 
@@ -730,16 +763,30 @@ parsec_profiling_trace_flags_info_fn(parsec_profiling_stream_t* context, int key
     (void)event_id;
     (void)flags;
 
-    if( !start_called ) {
+    if( !__profile_initialized ||
+        !start_called ||
+        !parsec_profiling_has_active_substrate() ) {
         return PARSEC_ERR_NOT_SUPPORTED;
-    }
-
-    if( NULL == context->evt_writer ) {
-        return PARSEC_ERR_BAD_PARAM;
     }
 
     if (key > -REGION_ID_OFFSET && key < REGION_ID_OFFSET) {
         /* -1 is an invalid key, silently ignore it */
+        return PARSEC_ERR_BAD_PARAM;
+    }
+
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_trace(&context->nvtx_ranges,
+                                &context->nvtx_freelist,
+                                key < 0 ? -key : key,
+                                key > 0,
+                                event_id, taskpool_id);
+#endif
+
+    if( NULL == otf2_archive ) {
+        return 0;
+    }
+
+    if( NULL == context->evt_writer ) {
         return PARSEC_ERR_BAD_PARAM;
     }
 
@@ -1237,22 +1284,33 @@ int parsec_profiling_fini( void )
 
     if( !__profile_initialized ) return PARSEC_ERR_NOT_SUPPORTED;
 
-    if( 0 != parsec_profiling_dbp_dump() ) {
-        return PARSEC_ERROR;
+    if( NULL != otf2_archive ) {
+        if( 0 != parsec_profiling_dbp_dump() ) {
+            return PARSEC_ERROR;
+        }
     }
 
     while( (t = (parsec_profiling_stream_t*)parsec_list_nolock_pop_front(&threads)) ) {
+#if defined(PARSEC_PROF_TRACE_NVTX)
+        parsec_profiling_nvtx_release_stream(&t->nvtx_ranges,
+                                             &t->nvtx_freelist);
+#endif
         free(t);
     }
     PARSEC_OBJ_DESTRUCT(&threads);
 
     parsec_profiling_dictionary_flush();
+#if defined(PARSEC_PROF_TRACE_NVTX)
+    parsec_profiling_nvtx_fini();
+#endif
     start_called = 0;  /* Allow the profiling to be reinitialized */
     parsec_profile_enabled = 0;  /* turn off the profiling */
     __profile_initialized = 0;  /* not initialized */
 
-    MPI_Comm_free(&parsec_otf2_profiling_comm);
-    parsec_profiling_mpi_on = 0;
+    if( parsec_profiling_mpi_on ) {
+        MPI_Comm_free(&parsec_otf2_profiling_comm);
+        parsec_profiling_mpi_on = 0;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Add an optional PARSEC_PROF_TRACE_NVTX profiling substrate that mirrors PaRSEC profiling events as NVTX ranges for NVIDIA Nsight Systems.

NVTX is enabled at runtime with the new profile_nvtx MCA parameter and does not require profile_filename to be set. File-based substrates keep their existing filename/archive requirements, while NVTX-only profiling can run with profile_filename=<none> and will not create a PaRSEC .prof file.

The binary and OTF2 profiling backends now register dictionary entries with NVTX and emit matching start/end ranges when NVTX is active. Active NVTX ranges are tracked globally so asynchronous completions can close a range from a later event, even if it arrives on a different profiling stream.

Also move binary profiling helper-thread startup into the DBP file start path so NVTX-only mode avoids binary-file I/O setup.

nsys profile --trace=nvtx,cuda -o parsec_report ./app --mca profile_nvtx 1 \ --mca mca_pins task_profiler

nsys profile --trace=nvtx,cuda -o parsec_report ./app --mca profile_filename '<app>' \ --mca profile_nvtx 1 --mca mca_pins task_profiler

PARSEC_MCA_profile_nvtx=1 PARSEC_MCA_mca_pins=task_profiler \ nsys profile --trace=nvtx,cuda -o parsec_report ./app