### PR TITLE
device: gate task batching on selected incarnation

### DIFF
--- a/docs/doxygen/task-batching.md
+++ b/docs/doxygen/task-batching.md
@@ -6,25 +6,37 @@ into one device operation. The runtime still owns dependency management, data
 movement, completion, and release; the submit hook only decides which pending
 tasks are compatible with the task it was asked to submit.
 
-Batching is opt-in at the chore level. A task that does not advertise batching
-is always delivered to the submit hook as a singleton task.
+Batching is opt-in at the incarnation level and in the device submit hook. A
+batch-capable incarnation may call `parsec_gpu_task_collect_batch()` from its
+submit hook; a hook that does not call the collector always submits the
+singleton task it was given.
 
 Enabling batching
 -----------------
 
-For PTG-generated tasks, use the `batch = true` body property on a device body:
+For PTG-generated tasks, mark the body with `batch = true` and call the
+collector from the device body that can use a batch. The `batch` property marks
+that generated incarnation as batch-capable; it does not force the runtime to
+batch tasks.
 
 ```c
 BODY [type=CUDA
       batch = true
       dyld=cublasDgemm dyldtype=cublas_dgemm_t]
 {
-    /* GPU submit body. */
+    int nb_batched = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
+                                                   gemm_batch_match, NULL);
+    if( nb_batched < 0 ) {
+        return nb_batched;
+    }
+
+    /* Submit gpu_task, whose ring may now contain 1 + nb_batched tasks. */
 }
 ```
 
 For DTD tasks, add `PARSEC_DEV_CHORE_ALLOW_BATCH` to the device type when
-registering or selecting the chore:
+registering the chore that can batch, then use the same collection approach
+inside the registered device hook:
 
 ```c
 parsec_dtd_task_class_add_chore(tp, tc,
@@ -32,13 +44,17 @@ parsec_dtd_task_class_add_chore(tp, tc,
                                 kernel_cuda);
 ```
 
-The selected device type must also support batching at runtime. The device layer
-uses `parsec_mca_device_type_supports_batch()` to check this and
-`parsec_mca_device_type_sanitize_batch()` to drop the batching hint when the
-selected device cannot batch. The MCA parameter `device_enable_batching`
-defaults to the compile-time batching capability and can be used to disable
-batching globally at runtime.
-It is read-only when batching support is not compiled in.
+The head task's selected device type must support batching at runtime, and the
+selected incarnation of the task passed to the submit hook must be marked
+batch-capable. The collector checks these conditions before iterating over
+pending work. If either condition fails, it leaves `gpu_task` as a singleton and
+returns 0. While scanning the stream, it skips pending tasks whose selected
+incarnation is not batch-capable on that same selected device before calling the
+user callback.
+
+The MCA parameter `device_enable_batching` defaults to the compile-time batching
+capability and can be used to disable batching globally at runtime. It is
+read-only when batching support is not compiled in.
 
 Recommended collection helper
 -----------------------------
@@ -87,15 +103,15 @@ gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
                  parsec_gpu_task_t *gpu_task,
                  parsec_gpu_exec_stream_t *gpu_stream)
 {
-    int batch_count;
+    int nb_batched;
     parsec_gpu_task_t *current;
 
     (void)gpu_device;
 
-    batch_count = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
-                                                gemm_batch_match, NULL);
-    if( batch_count < 0 ) {
-        return batch_count;
+    nb_batched = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
+                                               gemm_batch_match, NULL);
+    if( nb_batched < 0 ) {
+        return nb_batched;
     }
 
     current = gpu_task;
@@ -113,9 +129,12 @@ gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
 }
 ```
 
-`parsec_gpu_task_collect_batch()` returns the number of tasks in the ring on
-success, including the original `gpu_task`, or the negative callback error.
-Tasks accepted before an error remain attached to `gpu_task`; tasks not accepted
+`parsec_gpu_task_collect_batch()` returns the number of additional tasks appended
+to the ring on success, or the negative callback error. A return value of 0
+means no task was batched, either because no compatible pending task was found,
+because batching is disabled or unsupported by the head task's selected device,
+or because the head task's selected incarnation is not batch-capable. Tasks
+accepted before an error remain attached to `gpu_task`; tasks not accepted
 remain in `gpu_stream->fifo_pending`.
 
 The submit hook does not need a completion callback merely to return the ring to
@@ -186,4 +205,3 @@ The direct style avoids the generic iterator and callback dispatch, and it can
 fold the compatibility test into a tight kernel-specific loop. The cost is that
 the submit hook now depends on internal list and stream details and must be
 updated if the GPU stream internals change.
-

--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2346,9 +2346,45 @@ static parsec_hook_return_t parsec_dtd_cpu_task_submit(parsec_execution_stream_t
 }
 
 static inline int
-parsec_dtd_effective_chore_type(int device_type)
+parsec_dtd_concrete_device_type(int device_type)
 {
-    return (int)parsec_mca_device_type_sanitize_batch((uint32_t)device_type);
+    return device_type & PARSEC_DEV_ANY_TYPE;
+}
+
+static inline int
+parsec_dtd_is_exact_chore_device_type(int device_type)
+{
+    int concrete_type = parsec_dtd_concrete_device_type(device_type);
+
+    return (0 != concrete_type) && (0 == (concrete_type & (concrete_type - 1)));
+}
+
+static int
+parsec_dtd_taskpool_supports_device_type(parsec_taskpool_t *tp,
+                                         int device_type,
+                                         int require_exact)
+{
+    int concrete_type = parsec_dtd_concrete_device_type(device_type);
+
+    if( (0 == concrete_type) ||
+        (require_exact && !parsec_dtd_is_exact_chore_device_type(device_type)) ) {
+        return 0;
+    }
+
+    for( uint32_t i = 0; i < parsec_nb_devices; i++ ) {
+        parsec_device_module_t *device = parsec_mca_device_get(i);
+
+        if( NULL == device ) {
+            continue;
+        }
+        if( !(tp->devices_index_mask & (1 << device->device_index)) ) {
+            continue;
+        }
+        if( device->type & concrete_type ) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 int parsec_dtd_task_class_add_chore(parsec_taskpool_t *tp,
@@ -2364,11 +2400,20 @@ int parsec_dtd_task_class_add_chore(parsec_taskpool_t *tp,
                        tc->name);
         return PARSEC_ERR_BAD_PARAM;
     }
+    if( !parsec_dtd_is_exact_chore_device_type(device_type) ) {
+        parsec_warning("DTD task class '%s' cannot add a chore for device mask %#x; "
+                       "chores must use exactly one concrete CPU/GPU device type\n",
+                       (NULL == tc->name) ? "<unnamed>" : tc->name, device_type);
+        return PARSEC_ERR_BAD_PARAM;
+    }
+    if( !parsec_dtd_taskpool_supports_device_type(tp, device_type, 1) ) {
+        parsec_warning("DTD task class '%s' cannot add a chore for unsupported device type %#x\n",
+                       (NULL == tc->name) ? "<unnamed>" : tc->name, device_type);
+        return PARSEC_ERR_NOT_SUPPORTED;
+    }
 
     parsec_dtd_taskpool_t *dtd_tp = (parsec_dtd_taskpool_t*)tp;
     parsec_dtd_task_class_t *dtd_tc = (parsec_dtd_task_class_t*)tc;
-
-    device_type = parsec_dtd_effective_chore_type(device_type);
 
     /* We assume that incarnations is big enough, because it has been pre-allocated
      * with PARSEC_DEV_MAX_NB_TYPE+1 chores, as this is a DTD task class */
@@ -3156,8 +3201,6 @@ __parsec_dtd_taskpool_create_task(parsec_taskpool_t *tp,
     int nb_params = 0;
     parsec_dtd_param_t params[PARSEC_DTD_MAX_PARAMS];
 
-    device_type = parsec_dtd_effective_chore_type(device_type);
-
     if( dtd_tp == NULL) {
         parsec_fatal("You need to pass a correct parsec taskpool in order to insert task. "
                      "Please use \"parsec_dtd_taskpool_new()\" to create new taskpool"
@@ -3168,6 +3211,15 @@ __parsec_dtd_taskpool_create_task(parsec_taskpool_t *tp,
         parsec_fatal("Sorry! You can not insert task without enqueuing the taskpool to parsec_context"
                      " first. Please make sure you call parsec_context_add_taskpool(parsec_context, taskpool) before"
                      " you try inserting task in PaRSEC\n");
+    }
+
+    if( NULL != fpointer && !parsec_dtd_is_exact_chore_device_type(device_type) ) {
+        parsec_fatal("Direct DTD task creation for '%s' requires exactly one concrete CPU/GPU device type, got %#x\n",
+                     name_of_kernel, device_type);
+    }
+    if( !parsec_dtd_taskpool_supports_device_type(tp, device_type, NULL != fpointer) ) {
+        parsec_fatal("Direct DTD task creation for '%s' requested unsupported device type %#x\n",
+                     name_of_kernel, device_type);
     }
 
 #if defined(PARSEC_PROF_TRACE)
@@ -3304,10 +3356,12 @@ __parsec_dtd_taskpool_create_task(parsec_taskpool_t *tp,
     this_task->super.priority = priority;
 
     if( NULL == fpointer ) {
+        int concrete_device_type = parsec_dtd_concrete_device_type(device_type);
+
         this_task->super.chore_mask = 0;
         /* We take only the chores that are defined and that allowed by the user */
         for( int i = 0; NULL != tc->incarnations[i].hook; i++ ) {
-            if( tc->incarnations[i].type & device_type ) {
+            if( tc->incarnations[i].type & concrete_device_type ) {
                 this_task->super.chore_mask |= (1<<i);
             }
         }

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -3968,10 +3968,8 @@ jdf_generate_function_incarnation_list( const jdf_t *jdf,
         }
         string_arena_add_string(sa, "#if defined(PARSEC_HAVE_DEV_%s_SUPPORT)\n", dev_upper);
         string_arena_add_string(sa, "    { .type     = PARSEC_DEV_%s", dev_upper);
-        if( NULL != batch_property) {
-#if PARSEC_HAVE_DEV_CAPABILITY_BATCH
+        if( NULL != batch_property ) {
             string_arena_add_string(sa, " | PARSEC_DEV_CHORE_ALLOW_BATCH");
-#endif  /* PARSEC_HAVE_DEV_CAPABILITY_BATCH */
         }
         string_arena_add_string(sa, ",\n");
         if( NULL == dyld_property ) {
@@ -4224,7 +4222,6 @@ static void jdf_generate_one_function( const jdf_t *jdf, jdf_function_entry_t *f
     }
 
     jdf_generate_function_properties( jdf, f, sa );
-
 #if defined(PARSEC_SCHED_DEPS_MASK)
     use_mask = 1;
 #else

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -321,16 +321,6 @@ parsec_mca_device_type_supports_batch(uint32_t device_type)
 #endif  /* PARSEC_HAVE_DEV_CAPABILITY_BATCH */
 }
 
-uint32_t
-parsec_mca_device_type_sanitize_batch(uint32_t device_type)
-{
-    if( (device_type & PARSEC_DEV_CHORE_ALLOW_BATCH) &&
-        !parsec_mca_device_type_supports_batch(device_type) ) {
-        device_type &= ~PARSEC_DEV_CHORE_ALLOW_BATCH;
-    }
-    return device_type;
-}
-
 int parsec_mca_device_init(void)
 {
     char** parsec_device_list = NULL;

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -215,12 +215,6 @@ PARSEC_DECLSPEC extern int parsec_select_best_device( parsec_task_t* this_task);
 PARSEC_DECLSPEC int parsec_mca_device_type_supports_batch(uint32_t device_type);
 
 /**
- * Drop the batching hint from a chore type if batching is disabled or the
- * selected device type cannot batch.
- */
-PARSEC_DECLSPEC uint32_t parsec_mca_device_type_sanitize_batch(uint32_t device_type);
-
-/**
  * Initialize the internal structures for managing external devices such as
  * accelerators and GPU. Memory nodes can as well be managed using the same
  * mechanism.

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -1601,6 +1601,26 @@ parsec_gpu_stream_push_pending(parsec_gpu_exec_stream_t *stream,
     PARSEC_PUSH_TASK(stream->fifo_pending, &task->list_item);
 }
 
+static inline int
+parsec_gpu_task_selected_chore_allows_batch(parsec_task_t *task,
+                                            parsec_device_module_t *device)
+{
+    const __parsec_chore_t *chore;
+
+    if( (NULL == task) ||
+        (NULL == task->task_class) ||
+        (NULL == device) ||
+        (task->selected_device != device) ||
+        (task->selected_chore < 0) ) {
+        return 0;
+    }
+
+    chore = &task->task_class->incarnations[task->selected_chore];
+    return (PARSEC_DEV_NONE != (chore->type & PARSEC_DEV_ANY_TYPE)) &&
+           (0 != (chore->type & device->type)) &&
+           (0 != (chore->type & PARSEC_DEV_CHORE_ALLOW_BATCH));
+}
+
 int
 parsec_gpu_task_collect_batch(parsec_gpu_exec_stream_t *gpu_stream,
                               parsec_gpu_task_t *batch_head,
@@ -1609,23 +1629,42 @@ parsec_gpu_task_collect_batch(parsec_gpu_exec_stream_t *gpu_stream,
 {
     parsec_list_t *fifo_pending;
     parsec_list_item_t *item, *next;
-    int nb_tasks = 1;
+    parsec_task_t *head_task;
+    parsec_device_module_t *device;
+    int nb_tasks = 0;
     int rc;
 
     assert(NULL != gpu_stream);
     assert(NULL != batch_head);
     assert(NULL != callback);
 
+    parsec_list_item_singleton(&batch_head->list_item);
+
+    head_task = batch_head->ec;
+    if( (NULL == head_task) || (NULL == head_task->selected_device) ) {
+        return nb_tasks;
+    }
+    device = head_task->selected_device;
+    if( !parsec_mca_device_type_supports_batch(device->type) ||
+        !parsec_gpu_task_selected_chore_allows_batch(head_task, device) ) {
+        return nb_tasks;
+    }
+
     fifo_pending = gpu_stream->fifo_pending;
     assert(NULL != fifo_pending);
-    parsec_list_item_singleton(&batch_head->list_item);
 
     parsec_list_lock(fifo_pending);
     for(item = (parsec_list_item_t *)fifo_pending->ghost_element.list_next;
         item != &fifo_pending->ghost_element;
         item = next) {
+        parsec_gpu_task_t *candidate = (parsec_gpu_task_t *)item;
+        parsec_task_t *candidate_task = candidate->ec;
+
         next = (parsec_list_item_t *)item->list_next;
-        rc = callback((parsec_gpu_task_t *)item, batch_head, callback_data);
+        if( !parsec_gpu_task_selected_chore_allows_batch(candidate_task, device) ) {
+            continue;
+        }
+        rc = callback(candidate, batch_head, callback_data);
         if( rc < 0 ) {
             parsec_list_unlock(fifo_pending);
             return rc;

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -327,10 +327,16 @@ int parsec_gpu_complete_w2r_task(parsec_device_gpu_module_t *gpu_device, parsec_
  * the candidate to batch_head's ring, a positive value to leave it pending, or
  * a negative error code to stop the iteration.
  * The callback must not modify gpu_stream->fifo_pending directly.
+ * If batching is disabled, unsupported by the head task's selected device, or
+ * not enabled on batch_head's selected incarnation, no iteration is performed
+ * and batch_head remains a singleton. Pending tasks whose selected incarnation
+ * does not support batching on that same selected device are skipped without
+ * calling the callback.
  *
- * Returns the number of tasks in batch_head's ring on success, or the negative
- * callback error code. If an error is returned, tasks already accepted remain
- * attached to batch_head and the remaining candidates stay in fifo_pending.
+ * Returns the number of additional tasks appended to batch_head's ring on
+ * success, or the negative callback error code. If an error is returned, tasks
+ * already accepted remain attached to batch_head and the remaining candidates
+ * stay in fifo_pending.
  */
 int parsec_gpu_task_collect_batch(parsec_gpu_exec_stream_t *gpu_stream,
                                   parsec_gpu_task_t *batch_head,

--- a/tests/dsl/dtd/dtd_test_batch_cpu.c
+++ b/tests/dsl/dtd/dtd_test_batch_cpu.c
@@ -77,14 +77,13 @@ main(int argc, char **argv)
                                          batch_cpu_task);
     PARSEC_CHECK_ERROR(rc, "parsec_dtd_task_class_add_chore");
     assert(tc->incarnations[0].type & PARSEC_DEV_CPU);
-    assert(!!(tc->incarnations[0].type & PARSEC_DEV_CHORE_ALLOW_BATCH) ==
-           !!parsec_mca_device_type_supports_batch(PARSEC_DEV_CPU));
+    assert(tc->incarnations[0].type & PARSEC_DEV_CHORE_ALLOW_BATCH);
 
     for( int i = 0; i < ntasks; i++ ) {
         int value = i + 1;
         expected += value;
         parsec_dtd_insert_task_with_task_class(dtd_tp, tc, 0,
-                                               PARSEC_DEV_CPU | PARSEC_DEV_CHORE_ALLOW_BATCH,
+                                               PARSEC_DEV_CPU,
                                                PARSEC_DTD_EMPTY_FLAG, &value,
                                                PARSEC_DTD_ARG_END);
     }

--- a/tests/dsl/dtd/dtd_test_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_test_simple_gemm.c
@@ -185,18 +185,6 @@ int initialize_matrix(parsec_context_t *parsec_context, int rank, parsec_matrix_
 }
 
 static int
-gemm_cuda_task_allows_batch(parsec_gpu_task_t *gpu_task)
-{
-    parsec_task_t *this_task = gpu_task->ec;
-    int selected_chore = this_task->selected_chore;
-
-    return use_cuda_batch &&
-           (selected_chore >= 0) &&
-           (this_task->task_class->incarnations[selected_chore].type & PARSEC_DEV_CHORE_ALLOW_BATCH) &&
-           parsec_mca_device_type_supports_batch(this_task->selected_device->type);
-}
-
-static int
 gemm_cuda_batch_match(parsec_gpu_task_t *candidate,
                       parsec_gpu_task_t *batch_head,
                       void *callback_data)
@@ -221,12 +209,13 @@ int gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
     parsec_gpu_task_t *current_gpu_task;
     int batch_count = 1;
 
-    if( gemm_cuda_task_allows_batch(gpu_task) ) {
-        batch_count = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
-                                                    gemm_cuda_batch_match, NULL);
-        if( batch_count < 0 ) {
-            return batch_count;
+    if( use_cuda_batch ) {
+        int nb_batched = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
+                                                       gemm_cuda_batch_match, NULL);
+        if( nb_batched < 0 ) {
+            return nb_batched;
         }
+        batch_count += nb_batched;
     }
 
     handle = parsec_info_get(&gpu_stream->infos, CuHI);
@@ -362,8 +351,7 @@ int simple_gemm(parsec_context_t *parsec_context, parsec_matrix_block_cyclic_t *
                 keyA = A->super.super.data_key(&A->super.super, i, k);
                 keyB = B->super.super.data_key(&B->super.super, k, j);
                 parsec_dtd_insert_task_with_task_class(tp, gemm_tc, C->super.mt*C->super.nt*A->super.nt - i*C->super.nt + j,
-                                                       use_cuda_batch && (PARSEC_DEV_CUDA == device) ?
-                                                       (device | PARSEC_DEV_CHORE_ALLOW_BATCH) : device,
+                                                       device,
                                                        PARSEC_INPUT, PARSEC_DTD_TILE_OF_KEY(&A->super.super, keyA),
                                                        PARSEC_INPUT, PARSEC_DTD_TILE_OF_KEY(&B->super.super, keyB),
                                                        k == A->super.nt - 1 ? (PARSEC_INOUT | PARSEC_PUSHOUT) : PARSEC_INOUT,

--- a/tests/dsl/dtd/dtd_test_simple_gemm.c
+++ b/tests/dsl/dtd/dtd_test_simple_gemm.c
@@ -52,21 +52,104 @@ extern void cblas_dgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
 
 #include <unistd.h>
 #include <getopt.h>
+#include <string.h>
+#include <strings.h>
+#include <stdlib.h>
+#include <stdint.h>
 
 static int TILE_FULL = -1;
 static parsec_info_id_t CuHI = -1;
 static parsec_info_id_t Cu1 = -1;
 static int verbose = 0;
 static int device = PARSEC_DEV_CUDA;
-static int use_cuda_batch = 0;
 static int P = -1;
 static int Q = -1;
+static int cuda_max_batch_size = 32;
+static int cuda_max_submitted_batches = 4;
+
+typedef enum {
+    GEMM_CUDA_BATCH_NONE,
+    GEMM_CUDA_BATCH_ONE_BY_ONE,
+    GEMM_CUDA_BATCH_CUBLAS
+} gemm_cuda_batch_mode_t;
+
+static gemm_cuda_batch_mode_t cuda_batch_mode = GEMM_CUDA_BATCH_NONE;
+
+typedef struct gemm_cuda_batch_pool_s {
+    double **ptrs;
+    int max_batch_size;
+    int max_submitted_batches;
+    int cuda_device_index;
+    uint64_t next_submit;
+    uint64_t next_complete;
+} gemm_cuda_batch_pool_t;
+
+typedef struct gemm_cuda_stream_state_s {
+    cublasHandle_t handle;
+    gemm_cuda_batch_pool_t batch_pool;
+} gemm_cuda_stream_state_t;
+
+typedef struct gemm_cuda_batch_match_data_s {
+    int max_batch_size;
+    int accepted;
+} gemm_cuda_batch_match_data_t;
 
 #define Rnd64_A 6364136223846793005ULL
 #define Rnd64_C 1ULL
 #define RndF_Mul 5.4210108624275222e-20f
 #define RndD_Mul 5.4210108624275222e-20
 #define NBELEM 1
+#define GEMM_CUDA_BATCH_LIMIT_REACHED (-1000000)
+
+static int
+gemm_cuda_batch_enabled(void)
+{
+    return GEMM_CUDA_BATCH_NONE != cuda_batch_mode;
+}
+
+static void
+gemm_cuda_set_batch_mode(const char *mode)
+{
+    if( 0 == strcmp(mode, "none") ) {
+        cuda_batch_mode = GEMM_CUDA_BATCH_NONE;
+    } else if( (0 == strcmp(mode, "one-by-one")) ||
+               (0 == strcmp(mode, "submit")) ) {
+        cuda_batch_mode = GEMM_CUDA_BATCH_ONE_BY_ONE;
+    } else if( (0 == strcmp(mode, "cublas")) ||
+               (0 == strcmp(mode, "batched")) ) {
+        cuda_batch_mode = GEMM_CUDA_BATCH_CUBLAS;
+    } else {
+        fprintf(stderr, "Error: batch mode should be 'none', 'one-by-one', or 'cublas' (got '%s')\n", mode);
+        exit(1);
+    }
+}
+
+static const char *
+gemm_cuda_batch_mode_name(void)
+{
+    switch(cuda_batch_mode) {
+    case GEMM_CUDA_BATCH_ONE_BY_ONE:
+        return "one-by-one";
+    case GEMM_CUDA_BATCH_CUBLAS:
+        return "cublas";
+    case GEMM_CUDA_BATCH_NONE:
+    default:
+        return "none";
+    }
+}
+
+static int
+gemm_parse_positive_int_arg(const char *option, const char *value)
+{
+    int result = atoi(value);
+
+    if( result <= 0 ) {
+        fprintf(stderr, "Error: %s expects a positive integer (got '%s')\n",
+                option, value);
+        exit(1);
+    }
+    return result;
+}
 
 static unsigned long long int Rnd64_jump(unsigned long long int n, unsigned long long int seed)
 {
@@ -189,60 +272,180 @@ gemm_cuda_batch_match(parsec_gpu_task_t *candidate,
                       parsec_gpu_task_t *batch_head,
                       void *callback_data)
 {
-    (void)callback_data;
+    gemm_cuda_batch_match_data_t *batch_data = (gemm_cuda_batch_match_data_t *)callback_data;
+
+    if( (NULL != batch_data) &&
+        (batch_data->accepted >= batch_data->max_batch_size - 1) ) {
+        return GEMM_CUDA_BATCH_LIMIT_REACHED;
+    }
 
     if( (batch_head->ec->task_class == candidate->ec->task_class) &&
         (batch_head->ec->selected_chore == candidate->ec->selected_chore) &&
         (batch_head->ec->selected_device == candidate->ec->selected_device) ) {
+        if( NULL != batch_data ) {
+            batch_data->accepted++;
+        }
         return 0;
     }
     return 1;
 }
 
-int gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
-                     parsec_gpu_task_t *gpu_task,
-                     parsec_gpu_exec_stream_t *gpu_stream)
+static void
+gemm_cuda_unpack_task(parsec_gpu_task_t *gpu_task,
+                      double **a_gpu, double **b_gpu, double **c_gpu,
+                      int *m, int *n, int *k,
+                      int *mb, int *nb, int *kb)
 {
-    cublasStatus_t status;
-    cublasHandle_t handle;
-    double *one_device = NULL;
-    parsec_gpu_task_t *current_gpu_task;
-    int batch_count = 1;
+    double *A, *B, *C;
+    parsec_task_t *this_task = gpu_task->ec;
 
-    if( use_cuda_batch ) {
-        int nb_batched = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
-                                                       gemm_cuda_batch_match, NULL);
-        if( nb_batched < 0 ) {
-            return nb_batched;
-        }
-        batch_count += nb_batched;
+    parsec_dtd_unpack_args(this_task,
+                           &A, &B, &C,
+                           m, n, k,
+                           mb, nb, kb);
+    (void)A; (void)B; (void)C;
+
+    *a_gpu = parsec_dtd_get_dev_ptr(this_task, 0);
+    *b_gpu = parsec_dtd_get_dev_ptr(this_task, 1);
+    *c_gpu = parsec_dtd_get_dev_ptr(this_task, 2);
+}
+
+static size_t
+gemm_cuda_batch_pool_ptrs_per_slot(gemm_cuda_batch_pool_t *pool)
+{
+    return (size_t)3 * (size_t)pool->max_batch_size;
+}
+
+static double **
+gemm_cuda_batch_pool_ptrs(gemm_cuda_batch_pool_t *pool, uint64_t position)
+{
+    int index = (int)(position % (uint64_t)pool->max_submitted_batches);
+
+    return pool->ptrs + (size_t)index * gemm_cuda_batch_pool_ptrs_per_slot(pool);
+}
+
+static int
+gemm_cuda_batch_pool_can_submit(gemm_cuda_batch_pool_t *pool)
+{
+    return (pool->next_submit - pool->next_complete) <
+           (uint64_t)pool->max_submitted_batches;
+}
+
+static void
+gemm_cuda_batch_pool_mark_pending(gemm_cuda_batch_pool_t *pool)
+{
+    assert(gemm_cuda_batch_pool_can_submit(pool));
+
+    pool->next_submit++;
+}
+
+static int
+gemm_cuda_batch_pool_release_completed(gemm_cuda_batch_pool_t *pool)
+{
+    if( pool->next_complete == pool->next_submit ) {
+        parsec_warning("Completed GEMM batch has no preallocated batch slot");
+        return PARSEC_HOOK_RETURN_ERROR;
     }
 
-    handle = parsec_info_get(&gpu_stream->infos, CuHI);
-    assert(NULL != handle);
-    one_device = parsec_info_get(&gpu_device->super.infos, Cu1);
-    assert(NULL != one_device);
+    pool->next_complete++;
+    return PARSEC_HOOK_RETURN_DONE;
+}
 
-    current_gpu_task = gpu_task;
+static void
+gemm_cuda_batch_pool_fini(gemm_cuda_batch_pool_t *pool)
+{
+    if( NULL == pool ) {
+        return;
+    }
+
+    if( pool->cuda_device_index >= 0 ) {
+        (void)cudaSetDevice(pool->cuda_device_index);
+    }
+
+    if( NULL != pool->ptrs ) {
+        (void)cudaFree(pool->ptrs);
+    }
+    memset(pool, 0, sizeof(*pool));
+    pool->cuda_device_index = -1;
+}
+
+static int
+gemm_cuda_batch_pool_init(gemm_cuda_batch_pool_t *pool)
+{
+    size_t ptrs_per_slot;
+    size_t ptrs_size;
+    size_t all_ptrs_size;
+    cudaError_t status;
+
+    memset(pool, 0, sizeof(*pool));
+    pool->max_batch_size = cuda_max_batch_size;
+    pool->max_submitted_batches = cuda_max_submitted_batches;
+    pool->cuda_device_index = -1;
+    ptrs_per_slot = gemm_cuda_batch_pool_ptrs_per_slot(pool);
+    ptrs_size = ptrs_per_slot * sizeof(double *);
+    all_ptrs_size = (size_t)pool->max_submitted_batches * ptrs_size;
+
+    status = cudaGetDevice(&pool->cuda_device_index);
+    PARSEC_CUDA_CHECK_ERROR("cudaGetDevice", status, { goto error; });
+
+    status = cudaMallocManaged((void **)&pool->ptrs, all_ptrs_size, cudaMemAttachGlobal);
+    PARSEC_CUDA_CHECK_ERROR("cudaMallocManaged", status, { goto error; });
+
+    return PARSEC_SUCCESS;
+
+  error:
+    gemm_cuda_batch_pool_fini(pool);
+    return PARSEC_ERROR;
+}
+
+static int
+gemm_cuda_batch_complete(parsec_device_gpu_module_t *gpu_device,
+                         parsec_gpu_task_t **gpu_task,
+                         parsec_gpu_exec_stream_t *gpu_stream)
+{
+    gemm_cuda_stream_state_t *stream_state;
+    parsec_gpu_task_t *completed_task = *gpu_task;
+    int rc;
+
+    (void)gpu_device;
+
+    stream_state = parsec_info_get(&gpu_stream->infos, CuHI);
+    if( NULL == stream_state ) {
+        parsec_warning("Completed GEMM batch task %p has no CUDA stream state",
+                       (void *)completed_task);
+        completed_task->complete_stage = NULL;
+        return PARSEC_HOOK_RETURN_ERROR;
+    }
+
+    rc = gemm_cuda_batch_pool_release_completed(&stream_state->batch_pool);
+    completed_task->complete_stage = NULL;
+    return rc;
+}
+
+static int
+gemm_kernel_cuda_submit_one_by_one(parsec_gpu_task_t *gpu_task,
+                                   parsec_gpu_exec_stream_t *gpu_stream,
+                                   cublasHandle_t handle,
+                                   double *one_device,
+                                   int batch_count)
+{
+    parsec_gpu_task_t *current_gpu_task = gpu_task;
+    struct timeval start, end, diff;
+    double delta;
+
+    if( verbose ) {
+        gettimeofday(&start, NULL);
+    }
     do {
-        double *A, *B, *C;
         int m, n, k, mb, nb, kb;
         parsec_task_t *this_task = current_gpu_task->ec;
-        struct timeval start, end, diff;
-        double delta;
         double *a_gpu, *b_gpu, *c_gpu;
+        cublasStatus_t status;
 
-        parsec_dtd_unpack_args(this_task,
-                               &A, &B, &C,
-                               &m, &n, &k,
-                               &mb, &nb, &kb);
-        (void)A; (void)B; (void)C;
-
-        a_gpu = parsec_dtd_get_dev_ptr(this_task, 0);
-        b_gpu = parsec_dtd_get_dev_ptr(this_task, 1);
-        c_gpu = parsec_dtd_get_dev_ptr(this_task, 2);
-
-        gettimeofday(&start, NULL);
+        gemm_cuda_unpack_task(current_gpu_task,
+                              &a_gpu, &b_gpu, &c_gpu,
+                              &m, &n, &k,
+                              &mb, &nb, &kb);
 
         status = cublasDgemm_v2(handle,
                                 CUBLAS_OP_N, CUBLAS_OP_N,
@@ -250,15 +453,13 @@ int gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
                                 one_device, a_gpu, mb,
                                 b_gpu, kb,
                                 one_device, c_gpu, mb);
-        gettimeofday(&end, NULL);
-        timersub(&end, &start, &diff);
-        delta = (double)diff.tv_sec + (double)diff.tv_usec/1e6;
+
         if(verbose) {
-            fprintf(stderr, "GEMM(%d, %d, %d) with tiles of %dx%d, %dx%d, %dx%d on node %d, GPU %s submitted in %g s%s\n",
+            fprintf(stderr, "GEMM(%d, %d, %d) with tiles of %dx%d, %dx%d, %dx%d on node %d, GPU %s submitted%s\n",
                     m, n, k, mb, kb, kb, nb, mb, kb,
                     this_task->taskpool->context->my_rank,
-                    gpu_stream->name, delta,
-                    batch_count > 1 ? " as part of a batch" : "");
+                    gpu_stream->name,
+                    batch_count > 1 ? " as part of a one-by-one batch" : "");
         }
 
         PARSEC_CUDA_CHECK_ERROR("cublasDgemm_v2", status,
@@ -267,12 +468,136 @@ int gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
         current_gpu_task = (parsec_gpu_task_t *)current_gpu_task->list_item.list_next;
     } while( current_gpu_task != gpu_task );
 
-    if( verbose && batch_count > 1 ) {
-        fprintf(stderr, "Submitted %d batched GEMM tasks on GPU stream %s\n",
-                batch_count, gpu_stream->name);
+    if( verbose ) {
+        gettimeofday(&end, NULL);
+        timersub(&end, &start, &diff);
+        delta = (double)diff.tv_sec + (double)diff.tv_usec/1e6;
+        fprintf(stderr, "Submitted %d GEMM task%s one-by-one on GPU stream %s in %g s\n",
+                batch_count, batch_count > 1 ? "s" : "", gpu_stream->name, delta);
     }
 
     return PARSEC_HOOK_RETURN_DONE;
+}
+
+static int
+gemm_kernel_cuda_submit_cublas_batched(parsec_gpu_task_t *gpu_task,
+                                       parsec_gpu_exec_stream_t *gpu_stream,
+                                       cublasHandle_t handle,
+                                       double *one_device,
+                                       gemm_cuda_batch_pool_t *batch_pool,
+                                       int batch_count)
+{
+    parsec_gpu_task_t *current_gpu_task = gpu_task;
+    double **ptr_A, **ptr_B, **ptr_C;
+    struct timeval start, end, diff;
+    double delta;
+    int first_m = 0, first_n = 0, first_k = 0;
+    int mb = 0, nb = 0, kb = 0;
+    int first_mb = 0, first_nb = 0, first_kb = 0;
+    int rank = gpu_task->ec->taskpool->context->my_rank;
+    cublasStatus_t status;
+    uint64_t submit_position = batch_pool->next_submit;
+
+    assert(batch_count <= batch_pool->max_batch_size);
+
+    ptr_A = gemm_cuda_batch_pool_ptrs(batch_pool, submit_position);
+    ptr_B = ptr_A + batch_count;
+    ptr_C = ptr_B + batch_count;
+
+    for( int i = 0; i < batch_count; i++ ) {
+        int m, n, k;
+
+        gemm_cuda_unpack_task(current_gpu_task,
+                              &ptr_A[i], &ptr_B[i], &ptr_C[i],
+                              &m, &n, &k,
+                              &mb, &nb, &kb);
+        if( 0 == i ) {
+            first_m = m; first_n = n; first_k = k;
+            first_mb = mb; first_nb = nb; first_kb = kb;
+        } else if( (first_mb != mb) || (first_nb != nb) || (first_kb != kb) ) {
+            parsec_warning("cublas batched GEMM requires uniform tile shapes; falling back to one-by-one submission");
+            return gemm_kernel_cuda_submit_one_by_one(gpu_task, gpu_stream, handle, one_device, batch_count);
+        }
+        current_gpu_task = (parsec_gpu_task_t *)current_gpu_task->list_item.list_next;
+    }
+
+    if( verbose ) {
+        gettimeofday(&start, NULL);
+    }
+    status = cublasDgemmBatched(handle,
+                                CUBLAS_OP_N, CUBLAS_OP_N,
+                                first_mb, first_nb, first_kb,
+                                one_device, (const double * const *)ptr_A, first_mb,
+                                (const double * const *)ptr_B, first_kb,
+                                one_device, ptr_C, first_mb,
+                                batch_count);
+
+    PARSEC_CUDA_CHECK_ERROR("cublasDgemmBatched", status,
+                            { return PARSEC_HOOK_RETURN_ERROR; });
+    gemm_cuda_batch_pool_mark_pending(batch_pool);
+    gpu_task->complete_stage = gemm_cuda_batch_complete;
+
+    if(verbose) {
+        gettimeofday(&end, NULL);
+        timersub(&end, &start, &diff);
+        delta = (double)diff.tv_sec + (double)diff.tv_usec/1e6;
+        fprintf(stderr, "Batched GEMM(%d, %d, %d) with tiles of %dx%d, %dx%d, %dx%d on node %d, GPU %s submitted in %g s with %d tasks\n",
+                first_m, first_n, first_k, first_mb, first_kb, first_kb, first_nb, first_mb, first_kb,
+                rank, gpu_stream->name, delta, batch_count);
+    }
+
+    return PARSEC_HOOK_RETURN_DONE;
+}
+
+int gemm_kernel_cuda(parsec_device_gpu_module_t *gpu_device,
+                     parsec_gpu_task_t *gpu_task,
+                     parsec_gpu_exec_stream_t *gpu_stream)
+{
+    gemm_cuda_stream_state_t *stream_state;
+    cublasHandle_t handle;
+    double *one_device = NULL;
+    int batch_count = 1;
+    gemm_cuda_batch_pool_t *batch_pool = NULL;
+
+    stream_state = parsec_info_get(&gpu_stream->infos, CuHI);
+    if( NULL == stream_state ) {
+        return PARSEC_HOOK_RETURN_ERROR;
+    }
+    handle = stream_state->handle;
+
+    if( GEMM_CUDA_BATCH_CUBLAS == cuda_batch_mode ) {
+        batch_pool = &stream_state->batch_pool;
+        if( !gemm_cuda_batch_pool_can_submit(batch_pool) ) {
+            return PARSEC_HOOK_RETURN_AGAIN;
+        }
+    }
+
+    if( gemm_cuda_batch_enabled() && (cuda_max_batch_size > 1) ) {
+        gemm_cuda_batch_match_data_t batch_data = {
+            .max_batch_size = cuda_max_batch_size,
+            .accepted = 0
+        };
+        int nb_batched = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
+                                                       gemm_cuda_batch_match, &batch_data);
+        if( GEMM_CUDA_BATCH_LIMIT_REACHED == nb_batched ) {
+            nb_batched = batch_data.accepted;
+        } else if( nb_batched < 0 ) {
+            return nb_batched;
+        }
+        batch_count += nb_batched;
+    }
+
+    one_device = parsec_info_get(&gpu_device->super.infos, Cu1);
+    assert(NULL != one_device);
+
+    if( GEMM_CUDA_BATCH_CUBLAS == cuda_batch_mode ) {
+        (void)gpu_device;
+        return gemm_kernel_cuda_submit_cublas_batched(gpu_task, gpu_stream,
+                                                      handle, one_device,
+                                                      batch_pool, batch_count);
+    }
+    return gemm_kernel_cuda_submit_one_by_one(gpu_task, gpu_stream, handle,
+                                              one_device, batch_count);
 }
 
 #if defined(HAVE_BLAS)
@@ -293,18 +618,21 @@ int gemm_kernel_cpu(parsec_execution_stream_t *es,
                            &m, &n, &k,
                            &mb, &nb, &kb);
 
-    gettimeofday(&start, NULL);
+    if( verbose ) {
+        gettimeofday(&start, NULL);
+    }
     cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, mb, nb, kb, alpha, A, mb, B, kb, beta, C, mb);
-    gettimeofday(&end, NULL);
-    timersub(&end, &start, &diff);
 
-    delta = (double)diff.tv_sec + (double)diff.tv_usec/1e6;
-    if( verbose )
+    if( verbose ) {
+        gettimeofday(&end, NULL);
+        timersub(&end, &start, &diff);
+        delta = (double)diff.tv_sec + (double)diff.tv_usec/1e6;
         fprintf(stderr, "GEMM(%d, %d, %d) with tiles of %dx%d, %dx%d, %dx%d on node %d, on core %d: %g s\n",
                 m, n, k, mb, kb, kb, nb, mb, kb,
                 this_task->taskpool->context->my_rank,
                 es->core_id,
                 delta);
+    }
 
     return PARSEC_HOOK_RETURN_DONE;
 }
@@ -338,7 +666,7 @@ int simple_gemm(parsec_context_t *parsec_context, parsec_matrix_block_cyclic_t *
                                            sizeof(int), PARSEC_VALUE,               /* kb */
                                            PARSEC_DTD_ARG_END);
     parsec_dtd_task_class_add_chore(tp, gemm_tc,
-                                    use_cuda_batch ? (PARSEC_DEV_CUDA | PARSEC_DEV_CHORE_ALLOW_BATCH) : PARSEC_DEV_CUDA,
+                                    gemm_cuda_batch_enabled() ? (PARSEC_DEV_CUDA | PARSEC_DEV_CHORE_ALLOW_BATCH) : PARSEC_DEV_CUDA,
                                     gemm_kernel_cuda);
 #if defined(HAVE_BLAS)
     parsec_dtd_task_class_add_chore(tp, gemm_tc, PARSEC_DEV_CPU, gemm_kernel_cpu);
@@ -414,30 +742,94 @@ int *get_gpu_device_index()
     return dev_index;
 }
 
-static void destroy_cublas_handle(void *_h, void *_n)
+static int preallocate_cuda_stream_states(void)
 {
-#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
-    cublasHandle_t cublas_handle = (cublasHandle_t)_h;
-    cublasDestroy_v2(cublas_handle);
-#endif
-    (void)_n;
-    (void)_h;
+    if( PARSEC_INFO_ID_UNDEFINED == CuHI ) {
+        return 0;
+    }
+
+    for( int dev = 0; dev < (int)parsec_nb_devices; dev++ ) {
+        parsec_device_module_t *device = parsec_mca_device_get(dev);
+        parsec_device_gpu_module_t *gpu_device;
+
+        if( 0 == (PARSEC_DEV_CUDA & device->type) ) {
+            continue;
+        }
+
+        gpu_device = (parsec_device_gpu_module_t *)device;
+        if( PARSEC_SUCCESS != gpu_device->set_device(gpu_device) ) {
+            parsec_warning("Failed to select CUDA device %d while preallocating GEMM CUDA stream states",
+                           device->device_index);
+            return PARSEC_ERROR;
+        }
+
+        for( int stream = 0; stream < gpu_device->num_exec_streams; stream++ ) {
+            gemm_cuda_stream_state_t *stream_state;
+
+            stream_state = parsec_info_get(&gpu_device->exec_stream[stream]->infos, CuHI);
+            if( NULL == stream_state ) {
+                parsec_warning("Failed to preallocate GEMM CUDA stream state for CUDA device %d stream %d",
+                               device->device_index, stream);
+                return PARSEC_ERROR;
+            }
+        }
+    }
+
+    return PARSEC_SUCCESS;
 }
 
-static void *create_cublas_handle(void *obj, void *p)
+static void destroy_cuda_stream_state(void *_state, void *_n)
 {
 #if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
-    cublasHandle_t handle;
+    gemm_cuda_stream_state_t *stream_state = (gemm_cuda_stream_state_t *)_state;
+
+    if( NULL != stream_state ) {
+        if( GEMM_CUDA_BATCH_CUBLAS == cuda_batch_mode ) {
+            gemm_cuda_batch_pool_fini(&stream_state->batch_pool);
+        }
+        cublasDestroy_v2(stream_state->handle);
+        free(stream_state);
+    }
+#endif
+    (void)_n;
+    (void)_state;
+}
+
+static void *create_cuda_stream_state(void *obj, void *p)
+{
+#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
+    gemm_cuda_stream_state_t *stream_state;
     cublasStatus_t status;
     parsec_cuda_exec_stream_t *stream = (parsec_cuda_exec_stream_t *)obj;
     (void)p;
+
+    stream_state = (gemm_cuda_stream_state_t *)calloc(1, sizeof(gemm_cuda_stream_state_t));
+    if( NULL == stream_state ) {
+        return NULL;
+    }
+    stream_state->batch_pool.cuda_device_index = -1;
+
     /* No need to call cudaSetDevice, as this has been done by PaRSEC before calling the task body */
-    status = cublasCreate(&handle);
-    assert(CUBLAS_STATUS_SUCCESS == status);
-    status = cublasSetStream(handle, stream->cuda_stream);
-    assert(CUBLAS_STATUS_SUCCESS == status);
-    (void)status;
-    return (void *)handle;
+    status = cublasCreate(&stream_state->handle);
+    if( CUBLAS_STATUS_SUCCESS != status ) {
+        free(stream_state);
+        return NULL;
+    }
+    status = cublasSetStream(stream_state->handle, stream->cuda_stream);
+    if( CUBLAS_STATUS_SUCCESS != status ) {
+        cublasDestroy_v2(stream_state->handle);
+        free(stream_state);
+        return NULL;
+    }
+
+    if( GEMM_CUDA_BATCH_CUBLAS == cuda_batch_mode ) {
+        if( PARSEC_SUCCESS != gemm_cuda_batch_pool_init(&stream_state->batch_pool) ) {
+            cublasDestroy_v2(stream_state->handle);
+            free(stream_state);
+            return NULL;
+        }
+    }
+    return (void *)stream_state;
 #else
     (void)obj;
     (void)p;
@@ -551,13 +943,16 @@ int main(int argc, char **argv)
                 {"nruns",   required_argument, 0, 't'},
                 {"verbose", no_argument,       0, 'v'},
                 {"batch",   no_argument,       0, 'b'},
+                {"batch-mode", required_argument, 0, 'B'},
+                {"batch-size", required_argument, 0, 'S'},
+                {"batch-slots", required_argument, 0, 'L'},
                 {"Debug",   required_argument, 0, 'D'},
                 {"Alarm",   required_argument, 0, 'A'},
                 {"help",    no_argument,       0, 'h'},
                 {0, 0,                         0, 0}
         };
 
-        int c = getopt_long(argc, argv, "M:N:K:m:n:k:P:Q:t:d:D:A:vbh",
+        int c = getopt_long(argc, argv, "M:N:K:m:n:k:P:Q:t:d:B:S:L:D:A:vbh",
                             long_options, &option_index);
         if( c == -1 )
             break;
@@ -594,12 +989,21 @@ int main(int argc, char **argv)
                 verbose = !verbose;
                 break;
             case 'b':
-                use_cuda_batch = 1;
+                cuda_batch_mode = GEMM_CUDA_BATCH_ONE_BY_ONE;
+                break;
+            case 'B':
+                gemm_cuda_set_batch_mode(optarg);
+                break;
+            case 'S':
+                cuda_max_batch_size = gemm_parse_positive_int_arg("--batch-size", optarg);
+                break;
+            case 'L':
+                cuda_max_submitted_batches = gemm_parse_positive_int_arg("--batch-slots", optarg);
                 break;
             case 'd':
-                if(strcmp(optarg, "GPU") == 0) {
+                if(strcasecmp(optarg, "GPU") == 0) {
                     device=PARSEC_DEV_CUDA;
-                } else if(strcmp(optarg, "CPU") == 0) {
+                } else if(strcasecmp(optarg, "CPU") == 0) {
 #if defined(HAVE_BLAS)
                     device=PARSEC_DEV_CPU;
 #else
@@ -607,7 +1011,7 @@ int main(int argc, char **argv)
                     exit(1);
 #endif
                 } else {
-                    fprintf(stderr, "Error: device parameter should either be 'GPU' or 'CPU' (got '%s')\n", optarg);
+                    fprintf(stderr, "Error: device parameter should either be 'gpu' or 'cpu' (got '%s')\n", optarg);
                     exit(1);
                 }
                 break;
@@ -634,7 +1038,14 @@ int main(int argc, char **argv)
                             "   --mb|-m / --kb/-k / --nb|-n:  set mb, kb and nb (resp.)\n"
                             "   --nruns|-t:                   set the number of runs to do\n"
                             "   --device|-d:                  which device to use (CPU or GPU)\n"
-                            "   --batch|-b:                   enable CUDA batched GEMM chores\n"
+                            "   --batch|-b:                   enable CUDA batch collection and submit\n"
+                            "                                 the collected GEMMs one by one\n"
+                            "   --batch-mode|-B:              CUDA batching mode: none, one-by-one,\n"
+                            "                                 or cublas (default: %s)\n"
+                            "   --batch-size|-S:              maximum number of GEMM tasks per CUDA\n"
+                            "                                 batch (default: %d)\n"
+                            "   --batch-slots|-L:             maximum number of in-flight cuBLAS\n"
+                            "                                 batched submissions per stream (default: %d)\n"
                             "   --verbose|-v:                 display which GEMM runs on which GPU\n"
                             "                                 as execution is unfolding\n"
                             "   --help|-h|-?:                 display this help\n"
@@ -648,7 +1059,8 @@ int main(int argc, char **argv)
                             " Nota Bene: this test should not be used to evaluate performance of GEMM!\n"
                             "    Use DPLASMA or other linear algebra libraries written on top of PaRSEC to evaluate this.\n"
                             "\n",
-                            argv[0]);
+                            argv[0], gemm_cuda_batch_mode_name(),
+                            cuda_max_batch_size, cuda_max_submitted_batches);
                 }
 #if defined(PARSEC_HAVE_MPI)
                 MPI_Finalize();
@@ -693,10 +1105,10 @@ int main(int argc, char **argv)
         }
         gpu_device_index = get_gpu_device_index();
 
-        // Prepare CUBLAS Handle marshaller
-        CuHI = parsec_info_register(&parsec_per_stream_infos, "CUBLAS::HANDLE",
-                                    destroy_cublas_handle, NULL,
-                                    create_cublas_handle, NULL,
+        // Prepare the CUDA stream state, including the CUBLAS handle.
+        CuHI = parsec_info_register(&parsec_per_stream_infos, "DTD_GEMM::CUDA_STREAM_STATE",
+                                    destroy_cuda_stream_state, NULL,
+                                    create_cuda_stream_state, NULL,
                                     NULL);
         assert(CuHI != -1);
         Cu1 = parsec_info_register(&parsec_per_device_infos, "DEVICE::ONE",
@@ -704,6 +1116,14 @@ int main(int argc, char **argv)
                                    allocate_one_on_device, NULL,
                                    NULL);
         assert(Cu1 != -1);
+        rc = preallocate_cuda_stream_states();
+        if( PARSEC_SUCCESS != rc ) {
+            fprintf(stderr, "Failed to preallocate CUDA GEMM stream states\n");
+#if defined(PARSEC_HAVE_MPI)
+            MPI_Abort(MPI_COMM_WORLD, rc);
+#endif
+            return rc;
+        }
     }
 
     // Create datatypes
@@ -734,11 +1154,11 @@ int main(int argc, char **argv)
         timersub(&end, &start, &diff);
         double t = (double)diff.tv_sec + (double)diff.tv_usec / 1e6;
         double gflops = gflop / t;
-        (void)t;
-        (void)gflops;
         if( 0 == rank && r > 0 ) {
-            fprintf(stderr, "DTD_GEMM PxQxg: %d %d %d M: %d N: %d K: %d mb: %d nb: %d kb: %d -- done\n",
-                    P, Q, nbgpus, M, N, K, mb, nb, kb);
+            fprintf(stderr, "DTD_GEMM PxQxg: %d %d %d M: %d N: %d K: %d mb: %d nb: %d kb: %d batch_mode: %s batch_size: %d batch_slots: %d time: %.6f gflops: %.6f -- done\n",
+                    P, Q, nbgpus, M, N, K, mb, nb, kb,
+                    gemm_cuda_batch_mode_name(), cuda_max_batch_size,
+                    cuda_max_submitted_batches, t, gflops);
         }
     }
     // deactivate the alarm if it was set

--- a/tests/dsl/dtd/plot_simple_gemm_batch_sweep.py
+++ b/tests/dsl/dtd/plot_simple_gemm_batch_sweep.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import re
+import shlex
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+FLOAT_RE = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+PERF_RE = re.compile(
+    r"DTD_GEMM\s+PxQxg:\s+"
+    r"(?P<P>\d+)\s+(?P<Q>\d+)\s+(?P<gpus>\d+)\s+"
+    r"M:\s+(?P<M>\d+)\s+N:\s+(?P<N>\d+)\s+K:\s+(?P<K>\d+)\s+"
+    r"mb:\s+(?P<mb>\d+)\s+nb:\s+(?P<nb>\d+)\s+kb:\s+(?P<kb>\d+)"
+    r"(?:\s+batch_mode:\s+(?P<mode>\S+))?"
+    r".*?\btime:\s+(?P<time>{float_re})\s+"
+    r"gflops:\s+(?P<gflops>{float_re})".format(float_re=FLOAT_RE)
+)
+
+BEGIN_PREFIX = "PARSEC_SIMPLE_GEMM_RUN_BEGIN "
+END_PREFIX = "PARSEC_SIMPLE_GEMM_RUN_END "
+
+
+def parse_kv_payload(payload):
+    values = {}
+    for token in shlex.split(payload):
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        values[key] = value
+    return values
+
+
+def read_records(log_path):
+    records = []
+    current = {}
+
+    with open(log_path, "r", encoding="utf-8", errors="replace") as log:
+        for line_no, line in enumerate(log, 1):
+            line = line.rstrip("\n")
+            if line.startswith(BEGIN_PREFIX):
+                current = parse_kv_payload(line[len(BEGIN_PREFIX):])
+                continue
+            if line.startswith(END_PREFIX):
+                current = {}
+                continue
+
+            match = PERF_RE.search(line)
+            if not match:
+                continue
+
+            item = dict(current)
+            item["line_no"] = line_no
+            for key, value in match.groupdict().items():
+                if value is not None:
+                    item[key] = value
+            item["mode"] = item.get("mode", "unknown")
+            records.append(normalize_record(item))
+
+    return records
+
+
+def normalize_record(item):
+    int_fields = ["P", "Q", "gpus", "M", "N", "K", "mb", "nb", "kb"]
+    for field in int_fields:
+        item[field] = int(item[field])
+    item["time"] = float(item["time"])
+    item["gflops"] = float(item["gflops"])
+    item["tile"] = item["mb"] if item["mb"] == item["nb"] == item["kb"] else item["mb"]
+    item["tile_label"] = (
+        str(item["mb"])
+        if item["mb"] == item["nb"] == item["kb"]
+        else f"{item['mb']}x{item['nb']}x{item['kb']}"
+    )
+    item["matrix_key"] = (item["M"], item["N"], item["K"])
+    item["matrix_label"] = (
+        f"M=N=K={item['M']}"
+        if item["M"] == item["N"] == item["K"]
+        else f"M={item['M']} N={item['N']} K={item['K']}"
+    )
+    return item
+
+
+def summarize(records, metric):
+    grouped = defaultdict(list)
+    examples = {}
+    for record in records:
+        key = (
+            record["matrix_key"],
+            record["gpus"],
+            record["mode"],
+            record["tile"],
+            record["tile_label"],
+        )
+        grouped[key].append(record["gflops"])
+        examples[key] = record
+
+    rows = []
+    for key, values in grouped.items():
+        matrix_key, gpus, mode, tile, tile_label = key
+        example = examples[key]
+        stats = {
+            "avg": statistics.mean(values),
+            "best": max(values),
+            "median": statistics.median(values),
+            "min": min(values),
+            "max": max(values),
+        }
+        rows.append({
+            "matrix_key": matrix_key,
+            "matrix_label": example["matrix_label"],
+            "M": matrix_key[0],
+            "N": matrix_key[1],
+            "K": matrix_key[2],
+            "gpus": gpus,
+            "mode": mode,
+            "tile": tile,
+            "tile_label": tile_label,
+            "count": len(values),
+            "avg": stats["avg"],
+            "best": stats["best"],
+            "median": stats["median"],
+            "min": stats["min"],
+            "max": stats["max"],
+            "selected": stats[metric],
+        })
+
+    return sorted(rows, key=lambda r: (r["matrix_key"], r["gpus"], r["mode"], r["tile"]))
+
+
+def write_summary(rows, summary_path):
+    fields = [
+        "M", "N", "K", "gpus", "mode", "tile", "tile_label", "count",
+        "avg", "best", "median", "min", "max", "selected",
+    ]
+    with open(summary_path, "w", encoding="utf-8", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row[field] for field in fields})
+
+
+def safe_filename(label):
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", label).strip("_")
+
+
+def plot_rows(rows, output_dir, image_format, metric, dpi, show):
+    try:
+        import matplotlib
+        if not show:
+            matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise SystemExit(
+            "matplotlib is required to plot the sweep results. "
+            "Install it, or use the generated CSV summary with another plotting tool."
+        ) from exc
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    by_matrix = defaultdict(list)
+    for row in rows:
+        by_matrix[row["matrix_key"]].append(row)
+
+    written = []
+    for matrix_key, matrix_rows in sorted(by_matrix.items()):
+        matrix_label = matrix_rows[0]["matrix_label"]
+        series = defaultdict(list)
+        for row in matrix_rows:
+            label = f"{row['mode']}, {row['gpus']} GPU"
+            if row["gpus"] != 1:
+                label += "s"
+            series[label].append(row)
+
+        fig, ax = plt.subplots(figsize=(8.0, 5.0))
+        for label, points in sorted(series.items()):
+            points = sorted(points, key=lambda r: r["tile"])
+            ax.plot(
+                [p["tile"] for p in points],
+                [p["selected"] for p in points],
+                marker="o",
+                linewidth=1.8,
+                label=label,
+            )
+
+        ax.set_title(f"DTD simple_gemm performance, {matrix_label}")
+        ax.set_xlabel("Tile size (mb=nb=kb)")
+        ax.set_ylabel(f"Performance ({metric} GF/s)")
+        ax.grid(True, linestyle=":", linewidth=0.8)
+        ax.legend()
+        fig.tight_layout()
+
+        filename = output_dir / f"simple_gemm_{safe_filename(matrix_label)}.{image_format}"
+        fig.savefig(filename, dpi=dpi)
+        written.append(filename)
+        if show:
+            plt.show()
+        plt.close(fig)
+
+    return written
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Plot DTD simple_gemm batch sweep results."
+    )
+    parser.add_argument("log", type=Path, help="Log produced by run_simple_gemm_batch_sweep.sh")
+    parser.add_argument(
+        "-o", "--output-dir", type=Path, default=Path("simple_gemm_plots"),
+        help="Directory for generated figures and summary CSV."
+    )
+    parser.add_argument(
+        "--summary", type=Path,
+        help="CSV summary path (default: OUTPUT_DIR/simple_gemm_summary.csv)."
+    )
+    parser.add_argument(
+        "--metric", choices=("avg", "best", "median", "min", "max"), default="avg",
+        help="Metric to plot when several measured runs exist for one configuration."
+    )
+    parser.add_argument("--format", default="png", help="Image format passed to matplotlib.")
+    parser.add_argument("--dpi", type=int, default=150, help="Figure resolution.")
+    parser.add_argument("--show", action="store_true", help="Display figures interactively.")
+    args = parser.parse_args(argv)
+
+    records = read_records(args.log)
+    if not records:
+        raise SystemExit(
+            f"No simple_gemm performance records found in {args.log}. "
+            "The log must contain DTD_GEMM lines with 'time:' and 'gflops:'."
+        )
+
+    rows = summarize(records, args.metric)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.summary or (args.output_dir / "simple_gemm_summary.csv")
+    write_summary(rows, summary_path)
+    figures = plot_rows(rows, args.output_dir, args.format, args.metric, args.dpi, args.show)
+
+    print(f"Read {len(records)} performance samples")
+    print(f"Wrote summary: {summary_path}")
+    for figure in figures:
+        print(f"Wrote figure: {figure}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dsl/dtd/run_simple_gemm_batch_sweep.sh
+++ b/tests/dsl/dtd/run_simple_gemm_batch_sweep.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: run_simple_gemm_batch_sweep.sh -e DTD_SIMPLE_GEMM [options]
+
+Run the DTD simple_gemm test on one node while sweeping CUDA batch mode, GPU
+count, matrix size, and tile size. The output file is a structured log that can
+be consumed by plot_simple_gemm_batch_sweep.py.
+
+Required:
+  -e, --exe PATH             Path to the dtd_test_simple_gemm executable.
+
+Options:
+  -o, --output PATH          Output log file (default: simple_gemm_sweep.log).
+  -g, --gpus LIST            GPU counts to expose, comma or space separated
+                             (default: 1). Example: 1,2,4
+  -s, --sizes LIST           Cubic matrix sizes M=N=K (default: 4096).
+  -t, --tiles LIST           Cubic tile sizes mb=nb=kb (default: 256).
+  -m, --modes LIST           Batch modes (default: none,one-by-one,cublas).
+  -r, --runs N               Number of measured runs passed to simple_gemm
+                             (default: 5; simple_gemm also does one warmup).
+      --batch-size N         Maximum number of GEMM tasks collected per batch.
+      --batch-slots N        Maximum in-flight cuBLAS-batched submissions per
+                             CUDA stream.
+      --mpirun PATH          Optional mpirun/mpiexec path.
+      --np N                 MPI ranks when --mpirun is used (default: 1).
+      --timeout DURATION     Timeout for each individual run, using the
+                             timeout command's duration syntax. Example: 10m
+      --timeout-cmd PATH     Timeout command to use when --timeout is set
+                             (default: timeout).
+      --gpu-offset N         First CUDA device id to expose (default: 0).
+      --extra-gemm-args STR  Extra arguments before simple_gemm's "--".
+      --extra-parsec-args STR
+                             Extra PaRSEC MCA arguments after "--".
+      --append               Append to the output file instead of replacing it.
+      --allow-non-divisible  Run matrix/tile pairs even when size % tile != 0.
+      --stop-on-error        Stop the sweep at the first failed run.
+  -h, --help                 Show this help.
+
+Environment variables with the same upper-case names can be used for defaults,
+for example GPU_COUNTS="1,2,4" MATRIX_SIZES="8192 16384".
+EOF
+}
+
+split_list() {
+    local value="$1"
+    value="${value//,/ }"
+    # shellcheck disable=SC2086
+    printf '%s\n' $value
+}
+
+gpu_visible_list() {
+    local count="$1"
+    local offset="$2"
+    local visible=""
+
+    if [[ "${count}" == "all" ]]; then
+        printf 'all\n'
+        return 0
+    fi
+
+    for ((i = 0; i < count; i++)); do
+        if [[ -n "${visible}" ]]; then
+            visible+=","
+        fi
+        visible+="$((offset + i))"
+    done
+    printf '%s\n' "${visible}"
+}
+
+quote_command() {
+    local item
+    for item in "$@"; do
+        printf '%q ' "${item}"
+    done
+}
+
+EXE="${DTD_SIMPLE_GEMM:-}"
+OUTPUT="${OUTPUT:-simple_gemm_sweep.log}"
+GPU_COUNTS="${GPU_COUNTS:-1}"
+MATRIX_SIZES="${MATRIX_SIZES:-4096}"
+TILE_SIZES="${TILE_SIZES:-256}"
+BATCH_MODES="${BATCH_MODES:-none,one-by-one,cublas}"
+RUNS="${RUNS:-5}"
+BATCH_SIZE="${BATCH_SIZE:-}"
+BATCH_SLOTS="${BATCH_SLOTS:-}"
+MPIRUN="${MPIRUN:-}"
+NP="${NP:-1}"
+RUN_TIMEOUT="${RUN_TIMEOUT:-}"
+TIMEOUT_CMD="${TIMEOUT_CMD:-timeout}"
+GPU_OFFSET="${GPU_OFFSET:-0}"
+EXTRA_GEMM_ARGS="${EXTRA_GEMM_ARGS:-}"
+EXTRA_PARSEC_ARGS="${EXTRA_PARSEC_ARGS:-}"
+APPEND=0
+ALLOW_NON_DIVISIBLE=0
+STOP_ON_ERROR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -e|--exe)
+            EXE="$2"; shift 2 ;;
+        -o|--output)
+            OUTPUT="$2"; shift 2 ;;
+        -g|--gpus)
+            GPU_COUNTS="$2"; shift 2 ;;
+        -s|--sizes|--matrix-sizes)
+            MATRIX_SIZES="$2"; shift 2 ;;
+        -t|--tiles|--tile-sizes)
+            TILE_SIZES="$2"; shift 2 ;;
+        -m|--modes)
+            BATCH_MODES="$2"; shift 2 ;;
+        -r|--runs)
+            RUNS="$2"; shift 2 ;;
+        --batch-size)
+            BATCH_SIZE="$2"; shift 2 ;;
+        --batch-slots)
+            BATCH_SLOTS="$2"; shift 2 ;;
+        --mpirun)
+            MPIRUN="$2"; shift 2 ;;
+        --np)
+            NP="$2"; shift 2 ;;
+        --timeout)
+            RUN_TIMEOUT="$2"; shift 2 ;;
+        --timeout-cmd)
+            TIMEOUT_CMD="$2"; shift 2 ;;
+        --gpu-offset)
+            GPU_OFFSET="$2"; shift 2 ;;
+        --extra-gemm-args)
+            EXTRA_GEMM_ARGS="$2"; shift 2 ;;
+        --extra-parsec-args)
+            EXTRA_PARSEC_ARGS="$2"; shift 2 ;;
+        --append)
+            APPEND=1; shift ;;
+        --allow-non-divisible)
+            ALLOW_NON_DIVISIBLE=1; shift ;;
+        --stop-on-error)
+            STOP_ON_ERROR=1; shift ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2 ;;
+    esac
+done
+
+if [[ -z "${EXE}" ]]; then
+    echo "Missing required --exe PATH" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -x "${EXE}" ]]; then
+    echo "Executable not found or not executable: ${EXE}" >&2
+    exit 2
+fi
+
+if [[ -n "${RUN_TIMEOUT}" ]] && ! command -v "${TIMEOUT_CMD}" >/dev/null 2>&1; then
+    echo "Timeout command not found: ${TIMEOUT_CMD}" >&2
+    exit 2
+fi
+
+mkdir -p "$(dirname "${OUTPUT}")"
+
+if [[ "${APPEND}" -eq 0 ]]; then
+    {
+        printf '# parsec simple_gemm batch sweep log v1\n'
+        printf '# created_utc=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        printf '# executable=%s\n' "${EXE}"
+        printf '# gpu_counts=%s\n' "${GPU_COUNTS}"
+        printf '# matrix_sizes=%s\n' "${MATRIX_SIZES}"
+        printf '# tile_sizes=%s\n' "${TILE_SIZES}"
+        printf '# batch_modes=%s\n' "${BATCH_MODES}"
+        printf '# runs=%s\n' "${RUNS}"
+        printf '# timeout=%s\n' "${RUN_TIMEOUT:-none}"
+        printf '# timeout_cmd=%s\n' "${TIMEOUT_CMD}"
+        printf '# batch_size=%s\n' "${BATCH_SIZE:-default}"
+        printf '# batch_slots=%s\n' "${BATCH_SLOTS:-default}"
+    } > "${OUTPUT}"
+fi
+
+read -r -a extra_gemm_args <<< "${EXTRA_GEMM_ARGS}"
+read -r -a extra_parsec_args <<< "${EXTRA_PARSEC_ARGS}"
+
+run_id=0
+failed=0
+for mode in $(split_list "${BATCH_MODES}"); do
+    for gpus in $(split_list "${GPU_COUNTS}"); do
+        visible="$(gpu_visible_list "${gpus}" "${GPU_OFFSET}")"
+        for matrix in $(split_list "${MATRIX_SIZES}"); do
+            for tile in $(split_list "${TILE_SIZES}"); do
+                if [[ "${ALLOW_NON_DIVISIBLE}" -eq 0 && "$((matrix % tile))" -ne 0 ]]; then
+                    echo "Skipping M=N=K=${matrix}, tile=${tile}: matrix size is not divisible by tile size" >&2
+                    continue
+                fi
+
+                run_id=$((run_id + 1))
+                cmd=("${EXE}"
+                     --device GPU
+                     --M "${matrix}" --N "${matrix}" --K "${matrix}"
+                     --mb "${tile}" --nb "${tile}" --kb "${tile}"
+                     --nruns "${RUNS}"
+                     --batch-mode "${mode}")
+                if [[ -n "${BATCH_SIZE}" ]]; then
+                    cmd+=(--batch-size "${BATCH_SIZE}")
+                fi
+                if [[ -n "${BATCH_SLOTS}" ]]; then
+                    cmd+=(--batch-slots "${BATCH_SLOTS}")
+                fi
+                if [[ "${#extra_gemm_args[@]}" -gt 0 && -n "${extra_gemm_args[0]}" ]]; then
+                    cmd+=("${extra_gemm_args[@]}")
+                fi
+                if [[ "${#extra_parsec_args[@]}" -gt 0 && -n "${extra_parsec_args[0]}" ]]; then
+                    cmd+=(-- "${extra_parsec_args[@]}")
+                fi
+
+                full_cmd=()
+                if [[ -n "${MPIRUN}" ]]; then
+                    full_cmd+=("${MPIRUN}" -np "${NP}")
+                fi
+                if [[ "${visible}" == "all" ]]; then
+                    full_cmd+=("${cmd[@]}")
+                else
+                    full_cmd+=(env "CUDA_VISIBLE_DEVICES=${visible}" "${cmd[@]}")
+                fi
+                if [[ -n "${RUN_TIMEOUT}" ]]; then
+                    full_cmd=("${TIMEOUT_CMD}" "${RUN_TIMEOUT}" "${full_cmd[@]}")
+                fi
+
+                echo "Running mode=${mode} gpus=${gpus} matrix=${matrix} tile=${tile}" >&2
+                {
+                    printf 'PARSEC_SIMPLE_GEMM_RUN_BEGIN run_id=%d mode=%s gpus=%s cuda_visible_devices=%s matrix=%s tile=%s runs=%s timeout=%s utc=%s\n' \
+                           "${run_id}" "${mode}" "${gpus}" "${visible}" "${matrix}" "${tile}" "${RUNS}" "${RUN_TIMEOUT:-none}" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+                    printf 'PARSEC_SIMPLE_GEMM_COMMAND run_id=%d ' "${run_id}"
+                    quote_command "${full_cmd[@]}"
+                    printf '\n'
+                } >> "${OUTPUT}"
+
+                if "${full_cmd[@]}" >> "${OUTPUT}" 2>&1; then
+                    rc=0
+                else
+                    rc=$?
+                    failed=1
+                fi
+
+                printf 'PARSEC_SIMPLE_GEMM_RUN_END run_id=%d rc=%d utc=%s\n' \
+                       "${run_id}" "${rc}" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "${OUTPUT}"
+
+                if [[ "${rc}" -ne 0 ]]; then
+                    echo "Run ${run_id} failed with rc=${rc}" >&2
+                    if [[ "${STOP_ON_ERROR}" -ne 0 ]]; then
+                        exit "${rc}"
+                    fi
+                fi
+            done
+        done
+    done
+done
+
+exit "${failed}"

--- a/tests/runtime/cuda/stage_custom.jdf
+++ b/tests/runtime/cuda/stage_custom.jdf
@@ -167,13 +167,13 @@ BODY [type=CUDA
       dyld=cublasDgemm dyldtype=cublas_dgemm_t]
 {
     int how_many = 1;
-    how_many = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
-                                             stage_custom_batch_match,
-                                             &how_many);
-    if( how_many < 0 ) {
-        return how_many;
+    int nb_batched = parsec_gpu_task_collect_batch(gpu_stream, gpu_task,
+                                                   stage_custom_batch_match,
+                                                   &how_many);
+    if( nb_batched < 0 ) {
+        return nb_batched;
     }
-    if( how_many > 1 ) {
+    if( nb_batched > 0 ) {
         PARSEC_DEBUG_VERBOSE(10, parsec_debug_output,
                              "submit multiple tasks into one %p on stream %s{%p}\n",
                              gpu_task, gpu_stream->name, (void*)gpu_stream);


### PR DESCRIPTION
Move the batching eligibility check back to the incarnation level. The PARSEC_DEV_CHORE_ALLOW_BATCH marker remains attached to the chore/device type, and the GPU batch collector now validates the selected_chore of the head task before iterating over pending work.

The collector derives the device from the head task's selected_device, checks that batching is enabled for that device type, and skips pending candidates whose selected incarnation is not batch-capable on the same selected device.

Update DTD and PTG handling to preserve batching as a chore property, adjust the DTD insertion path to match chores using only the concrete device type, and refresh the batching documentation and tests for the new contract.