### PR TITLE
profiling/python: modernize pbt2ptt packaging

### DIFF
--- a/configure
+++ b/configure
@@ -339,7 +339,7 @@ function set_python_venv {
       mkdir -p venv
       ${PYTHON_EXECUTABLE:-python3} -m venv venv --upgrade-deps 2>&1 >venv/config.log || (cat >&2 venv/config.log && exit 3)
         source venv/bin/activate
-        python -m pip install --require-virtualenv Cython pandas matplotlib tables networkx wheel 2>&1 >>venv/config.log || (cat >&2 venv/config.log && exit 3)
+        python -m pip install --require-virtualenv Cython pandas matplotlib tables networkx setuptools wheel 2>&1 >>venv/config.log || (cat >&2 venv/config.log && exit 3)
     else
         echo >&2 "Could not prepare a Python venv because \`-m venv\` is not supported by the selected python..." && exit 3
     fi

--- a/tools/profiling/python/CMakeLists.txt
+++ b/tools/profiling/python/CMakeLists.txt
@@ -25,12 +25,12 @@ if( NOT CYTHON_EXECUTABLE )
   return()
 endif( NOT CYTHON_EXECUTABLE )
 execute_process(
-        COMMAND ${Python_EXECUTABLE} -c "import pandas"
+        COMMAND ${Python_EXECUTABLE} -c "import Cython; import pandas; import setuptools"
         RESULT_VARIABLE PARSEC_PYTHON_CAN_LOAD_PREREQUISITE_MODULES_IF_THIS_IS_ZERO
         ERROR_QUIET
 )
 if ( NOT (PARSEC_PYTHON_CAN_LOAD_PREREQUISITE_MODULES_IF_THIS_IS_ZERO EQUAL 0) )
-  message(WARNING "Prerequisite Python modules (pandas) not found. Disabling the profiling tools")
+  message(WARNING "Prerequisite Python modules (Cython, pandas, setuptools) not found. Disabling the profiling tools")
   set(PARSEC_PYTHON_TOOLS OFF CACHE BOOL "True iff Python tools are enabled in PaRSEC")
   return()
 endif ( NOT (PARSEC_PYTHON_CAN_LOAD_PREREQUISITE_MODULES_IF_THIS_IS_ZERO EQUAL 0) )
@@ -53,6 +53,8 @@ endif(Python_VERSION_MAJOR EQUAL 2)
 # if necessary
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/setup.py @ONLY )
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.in
+               ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml @ONLY )
 
 # Move the files into the build directory (to prevent the pollution of the source directory
 # due to cython compilation) and compile the python module
@@ -61,16 +63,24 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
 # location and import the pbt2ptt module.
 add_custom_command(OUTPUT ${OUTPUT}
                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SRC_PYTHON_SUPPORT} ${CMAKE_CURRENT_BINARY_DIR}
-                   COMMAND ${Python_EXECUTABLE} -m pip install --quiet --upgrade --target=${CMAKE_CURRENT_BINARY_DIR}/python.test .
+                   COMMAND ${Python_EXECUTABLE} -m pip install --quiet --upgrade --use-pep517 --no-build-isolation --no-deps --target=${CMAKE_CURRENT_BINARY_DIR}/python.test .
                    COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
-                   DEPENDS parsec-base ${SRC_PYTHON_SUPPORT})
+                   DEPENDS parsec-base ${SRC_PYTHON_SUPPORT}
+                           ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+                           ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml)
 add_custom_target(pbt2ptt ALL DEPENDS ${OUTPUT})
 
-# Call python distutils to install all python support in the right location
+# Ask pip to install all python support in the right location
 # (aka. according to the OS demands). Prepare to reconfigure the shell
 # helper scripts to point to the right location
-install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} -m pip install --quiet --prefix=\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX} .
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+install(CODE "
+set(_parsec_python_pip_args --quiet --upgrade --use-pep517 --no-build-isolation --no-deps --prefix=${CMAKE_INSTALL_PREFIX})
+if(DEFINED ENV{DESTDIR} AND NOT \"\$ENV{DESTDIR}\" STREQUAL \"\")
+  list(APPEND _parsec_python_pip_args --root=\$ENV{DESTDIR})
+endif()
+execute_process(COMMAND ${Python_EXECUTABLE} -m pip install \${_parsec_python_pip_args} .
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND_ERROR_IS_FATAL ANY)")
 
 # Create bash environment PaRSEC python support
 configure_file(utilities/bash.env.in
@@ -93,5 +103,4 @@ foreach(file ${pyfiles})
 endforeach()
 
 set(PARSEC_PYTHON_TOOLS ON CACHE BOOL "True if Python tools are enabled in PaRSEC")
-
 

--- a/tools/profiling/python/pbt2ptt.pyx
+++ b/tools/profiling/python/pbt2ptt.pyx
@@ -1,6 +1,6 @@
 """ DBPreader Python interface
 
-run 'python setup.py build_ext --inplace' to compile
+run 'python -m pip install .' from the configured build directory to compile
 The preferred nomenclature for the Python Binary Trace is "PBT",
 
 REQUIREMENTS:

--- a/tools/profiling/python/pyproject.toml.in
+++ b/tools/profiling/python/pyproject.toml.in
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "Cython>=0.21.2",
+]
+build-backend = "setuptools.build_meta"

--- a/tools/profiling/python/setup.py.in
+++ b/tools/profiling/python/setup.py.in
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 # build script for pbt2ptt
-# run python setup.py build_ext --inplace to build
+# run python -m pip install . to build and install
 
-from distutils import ccompiler, util
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
 from Cython.Build import cythonize
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 import os, sys
 import socket
+import shlex
 
 c_compiler = '@CMAKE_C_COMPILER@'.replace('FILEPATH=', '')
 cxx_compiler = '@CMAKE_CXX_COMPILER@'.replace('FILEPATH=', '')
@@ -18,7 +17,7 @@ build_type = '@CMAKE_BUILD_TYPE@'
 # Import specific compiler flags from the PaRSEC environment
 # and complement with additional flags required by some
 # specific compilers.
-extra_compile_args = util.split_quoted('@C_WFLAGS@')
+extra_compile_args = shlex.split('@C_WFLAGS@')
 c_compiler_id = '@CMAKE_C_COMPILER_ID@'.replace('FILEPATH=', '')
 if c_compiler_id.startswith('Intel'):
     # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
@@ -66,7 +65,7 @@ class local_compiler_build_ext( build_ext ):
         try:
             self.compiler.compiler = ([c_compiler] +
                                       self.compiler.compiler[1:] +
-                                      util.split_quoted('@CMAKE_C_FLAGS@') +
+                                      shlex.split('@CMAKE_C_FLAGS@') +
                                       extra_compile_args
             )
         except:
@@ -82,7 +81,7 @@ class local_compiler_build_ext( build_ext ):
         try:
             self.compiler.compiler_so = ([c_compiler] +
                                          self.compiler.compiler_so[1:] +
-                                         util.split_quoted('@CMAKE_C_FLAGS@') +
+                                         shlex.split('@CMAKE_C_FLAGS@') +
                                          extra_compile_args
             )
         except:
@@ -91,7 +90,7 @@ class local_compiler_build_ext( build_ext ):
         try:
             self.compiler.linker_so = ([c_compiler] +
                                        self.compiler.linker_so[1:] +
-                                       util.split_quoted('@CMAKE_C_FLAGS@') +
+                                       shlex.split('@CMAKE_C_FLAGS@') +
                                        extra_compile_args
             )
         except:
@@ -100,7 +99,7 @@ class local_compiler_build_ext( build_ext ):
         try:
             self.compiler.compiler_cxx = ([cxx_compiler] +
                                           self.compiler.compiler_cxx[1:] +
-                                          util.split_quoted('@CMAKE_C_FLAGS@') +
+                                          shlex.split('@CMAKE_C_FLAGS@') +
                                           extra_compile_args
             )
         except:
@@ -108,20 +107,6 @@ class local_compiler_build_ext( build_ext ):
 
         # print('compiler is ' + str(self.compiler.__dict__))
         build_ext.build_extensions(self)
-
-def distutils_dir_name(dname):
-    try:
-        import sysconfig
-        """Returns the name of a distutils build directory"""
-        f = "{dirname}.{platform}-{version[0]}.{version[1]}"
-        return f.format(dirname=dname,
-                        platform=sysconfig.get_platform(),
-                        version=sys.version_info)
-    except ImportError as e:
-        print(e)
-        print('Without the sysconfig module, the bash environment setup script may not work.')
-        print('A modern Python installation with the full distutils package is recommended.')
-        return 'LIB_DIR'
 
 setup(
     name = 'pbt2ptt',
@@ -142,7 +127,4 @@ setup(
                   "Topic :: Software Development :: Libraries :: Python Modules"],
     platforms=['all']
 )
-
-#install_dir = distutils_dir_name('lib')
-#print('Installed Python Trace Tables module to %s' % {install_dir})
 


### PR DESCRIPTION
Move the PTT Python module away from distutils-based installation by adding a generated pyproject.toml and switching setup.py.in to setuptools. Keep the existing CMake-generated build directory layout, but drive pip through the PEP 517 backend with no build isolation so the CMake-selected Python environment and dependencies remain authoritative.

Update the CMake install/test-local paths to generate pyproject.toml, require setuptools alongside Cython and pandas, and invoke pip with --use-pep517, --no-build-isolation, and --no-deps. Also add setuptools to the helper venv dependency list and refresh the stale pbt2ptt build note.