### PR TITLE
Rework MPI AM request handling and pingpong ranges

### DIFF
--- a/parsec/parsec_mpi_funnelled.c
+++ b/parsec/parsec_mpi_funnelled.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
 
 #include <mpi.h>
@@ -95,13 +96,18 @@ static parsec_atomic_lock_t parsec_ce_am_build_lock = PARSEC_ATOMIC_UNLOCKED;
 static int mpi_funnelled_tag_unregister_unsafe_internal(parsec_ce_tag_t tag);
 
 /* Range of index allowed for each type of request.
- * For registered tags, each will get EACH_STATIC_REQ_RANGE spots in the array of requests.
- * For dynamic tags, there will be a total of MAX_DYNAMIC_REQ_RANGE
- * spots in the request array.
+ * For registered tags, each gets a tested window in array_of_requests,
+ * backed by a larger pool of posted persistent receives owned by the tag.
+ * Dynamic requests use the remaining slots in array_of_requests.
  */
-#define MAX_DYNAMIC_REQ_RANGE 30 /* according to current implementation */
-#define MAX_NUM_RECV_REQ_IN_ARRAY 15
-#define EACH_STATIC_REQ_RANGE 5 /* for each registered tag */
+#define MPI_FUNNELLED_AM_POSTED_DEFAULT      (2 * DEP_NB_CONCURRENT)
+#define MPI_FUNNELLED_DYNAMIC_REQ_DEFAULT    30
+#define MPI_FUNNELLED_DYNAMIC_RECV_DEFAULT   15
+
+static int parsec_param_comm_mpi_am_posted_requests = MPI_FUNNELLED_AM_POSTED_DEFAULT;
+static int parsec_param_comm_mpi_am_tested_requests = 0;
+static int parsec_param_comm_mpi_dynamic_requests = MPI_FUNNELLED_DYNAMIC_REQ_DEFAULT;
+static int parsec_param_comm_mpi_dynamic_recv_requests = MPI_FUNNELLED_DYNAMIC_RECV_DEFAULT;
 
 typedef enum parsec_ce_tag_status_e {
     PARSEC_CE_TAG_STATUS_INACTIVE = 1,
@@ -115,6 +121,9 @@ typedef struct mpi_funnelled_tag_s {
     int16_t start_idx; /* Records the starting index for every TAG
                         * to unregister from the array_of_[requests/indices/statuses]
                         */
+    int req_count; /* Number of posted persistent receives owned by this AM tag. */
+    int tested_count; /* Number of this tag's posted requests present in MPI_Testsome. */
+    int req_idx; /* Next request from the posted pool to move into the tested window. */
     parsec_ce_tag_status_t status;  /* The current status of this tag (inactive/active, enable/disable) */
     size_t  msg_length; /* Maximum length allowed to send for this TAG */
     parsec_ce_am_callback_t callback;  /* callback to call upon reception of the
@@ -125,6 +134,8 @@ typedef struct mpi_funnelled_tag_s {
                                * the msg_length. It is better if the msg_length is a multiple of the
                                * cache lines size.
                                */
+    MPI_Request *reqs; /* All posted persistent receive requests for this tag. */
+    bool *reqs_in_testsome; /* Tracks which posted receives are in the tested window. */
 } mpi_funnelled_tag_t;
 
 static struct mpi_funnelled_tag_s parsec_mpi_funnelled_array_of_registered_tags[PARSEC_MAX_REGISTERED_TAGS];
@@ -222,6 +233,76 @@ PARSEC_DECLSPEC PARSEC_OBJ_CLASS_DECLARATION(mpi_funnelled_dynamic_req_t);
 PARSEC_OBJ_CLASS_INSTANCE(mpi_funnelled_dynamic_req_t, parsec_list_item_t,
                    NULL, NULL);
 
+static void mpi_funnelled_normalize_params(void)
+{
+    if( parsec_param_comm_mpi_am_posted_requests <= 0 ) {
+        parsec_param_comm_mpi_am_posted_requests = MPI_FUNNELLED_AM_POSTED_DEFAULT;
+    }
+    if( parsec_param_comm_mpi_am_tested_requests <= 0 ) {
+        parsec_param_comm_mpi_am_tested_requests = parsec_param_comm_mpi_am_posted_requests / 4;
+        if( parsec_param_comm_mpi_am_tested_requests <= 0 ) {
+            parsec_param_comm_mpi_am_tested_requests = 1;
+        }
+    }
+    if( parsec_param_comm_mpi_am_tested_requests > parsec_param_comm_mpi_am_posted_requests ) {
+        parsec_warning("runtime_comm_mpi_am_tested_requests (%d) is larger than runtime_comm_mpi_am_posted_requests (%d); capping it.",
+                       parsec_param_comm_mpi_am_tested_requests, parsec_param_comm_mpi_am_posted_requests);
+        parsec_param_comm_mpi_am_tested_requests = parsec_param_comm_mpi_am_posted_requests;
+    }
+
+    if( parsec_param_comm_mpi_dynamic_requests <= 0 ) {
+        parsec_param_comm_mpi_dynamic_requests = MPI_FUNNELLED_DYNAMIC_REQ_DEFAULT;
+    }
+    if( parsec_param_comm_mpi_dynamic_recv_requests <= 0 ) {
+        parsec_param_comm_mpi_dynamic_recv_requests = parsec_param_comm_mpi_dynamic_requests / 2;
+        if( parsec_param_comm_mpi_dynamic_recv_requests <= 0 ) {
+            parsec_param_comm_mpi_dynamic_recv_requests = 1;
+        }
+    }
+    if( parsec_param_comm_mpi_dynamic_recv_requests > parsec_param_comm_mpi_dynamic_requests ) {
+        parsec_warning("runtime_comm_mpi_dynamic_recv_requests (%d) is larger than runtime_comm_mpi_dynamic_requests (%d); capping it.",
+                       parsec_param_comm_mpi_dynamic_recv_requests, parsec_param_comm_mpi_dynamic_requests);
+        parsec_param_comm_mpi_dynamic_recv_requests = parsec_param_comm_mpi_dynamic_requests;
+    }
+}
+
+static int
+mpi_funnelled_can_post_dynamic_recv(void)
+{
+    /* A dynamic receive may be posted immediately only if the dynamic region
+     * has room and doing so does not exceed the receive share of MPI_Testsome.
+     */
+    return (mpi_funnelled_last_active_req < current_size_of_total_reqs) &&
+           (mpi_funnelled_num_recv_req_in_arr < parsec_param_comm_mpi_dynamic_recv_requests);
+}
+
+static void
+mpi_funnelled_append_dynamic_request(mpi_funnelled_dynamic_req_t *item)
+{
+    int slot = mpi_funnelled_last_active_req;
+
+    assert(slot >= mpi_funnelled_static_req_idx);
+    assert(slot < current_size_of_total_reqs);
+
+    /* Queued requests are installed through one path so their callback state
+     * always names the slot where MPI_Testsome will report completion.
+     */
+    array_of_callbacks[slot] = item->cb;
+    array_of_callbacks[slot].storage1 = slot;
+
+    if(item->post_isend) {
+        mpi_funnelled_mem_reg_handle_t *ldata = (mpi_funnelled_mem_reg_handle_t *) item->cb.onesided.lreg;
+        MPI_Isend((char *)ldata->mem + item->cb.onesided.ldispl, ldata->count,
+                  ldata->datatype, item->cb.onesided.remote, item->cb.onesided.tag, parsec_ce_mpi_comm,
+                  &array_of_requests[slot]);
+    } else {
+        array_of_requests[slot] = item->request;
+        item->request = MPI_REQUEST_NULL;
+    }
+
+    mpi_funnelled_last_active_req++;
+}
+
 /* Data we pass internally inside GET and PUT for handshake and other
  * synchronizations.
  */
@@ -276,6 +357,7 @@ mpi_funnelled_internal_get_am_callback(parsec_comm_engine_t *ce,
     } else {
         item = (mpi_funnelled_dynamic_req_t *)parsec_thread_mempool_allocate(mpi_funnelled_dynamic_req_mempool->thread_mempools);
         item->post_isend = 1;
+        item->request = MPI_REQUEST_NULL;
         cb = &item->cb;
     }
 
@@ -337,10 +419,8 @@ mpi_funnelled_internal_put_am_callback(parsec_comm_engine_t *ce,
     assert(mpi_funnelled_last_active_req >= mpi_funnelled_static_req_idx);
 
     mpi_funnelled_dynamic_req_t *item = NULL;
-    int post_in_static_array = mpi_funnelled_last_active_req < current_size_of_total_reqs;
-    if (MAX_NUM_RECV_REQ_IN_ARRAY >= mpi_funnelled_num_recv_req_in_arr) {
-        post_in_static_array = 0;
-    } else if (post_in_static_array) {
+    int post_in_static_array = mpi_funnelled_can_post_dynamic_recv();
+    if(post_in_static_array) {
         mpi_funnelled_num_recv_req_in_arr++;
     }
 
@@ -519,6 +599,28 @@ static int mpi_funneled_init_once(parsec_context_t* context)
     parsec_param_enable_mpi_overtake = 0;  /* Don't allow to be changed */
 #endif  /* !defined(PARSEC_HAVE_MPI_OVERTAKE) */
 
+    parsec_mca_param_reg_int_name("runtime", "comm_mpi_am_posted_requests",
+                                  "Maximum number of persistent receive requests posted for each active-message tag. "
+                                  "Only a smaller tested window is kept in MPI_Testsome; set to 0 for the runtime default.",
+                                  false, false, parsec_param_comm_mpi_am_posted_requests,
+                                  &parsec_param_comm_mpi_am_posted_requests);
+    parsec_mca_param_reg_int_name("runtime", "comm_mpi_am_tested_requests",
+                                  "Number of active-message requests per tag kept in MPI_Testsome during progress. "
+                                  "This should be no larger than comm_mpi_am_posted_requests; set to 0 for a runtime-selected value.",
+                                  false, false, parsec_param_comm_mpi_am_tested_requests,
+                                  &parsec_param_comm_mpi_am_tested_requests);
+    parsec_mca_param_reg_int_name("runtime", "comm_mpi_dynamic_requests",
+                                  "Maximum number of dynamic MPI communication requests, such as data GET and PUT operations, "
+                                  "kept in MPI_Testsome.",
+                                  false, false, parsec_param_comm_mpi_dynamic_requests,
+                                  &parsec_param_comm_mpi_dynamic_requests);
+    parsec_mca_param_reg_int_name("runtime", "comm_mpi_dynamic_recv_requests",
+                                  "Maximum number of dynamic receive requests kept in MPI_Testsome. "
+                                  "This value is capped by comm_mpi_dynamic_requests.",
+                                  false, false, parsec_param_comm_mpi_dynamic_recv_requests,
+                                  &parsec_param_comm_mpi_dynamic_recv_requests);
+    mpi_funnelled_normalize_params();
+
     (void)context;
     return 0;
 }
@@ -542,9 +644,15 @@ mpi_funnelled_init(parsec_context_t *context)
         parsec_mpi_funnelled_array_of_registered_tags[i].am_backend_memory = NULL;
         parsec_mpi_funnelled_array_of_registered_tags[i].callback = NULL;
         parsec_mpi_funnelled_array_of_registered_tags[i].status = PARSEC_CE_TAG_STATUS_INACTIVE;
+        parsec_mpi_funnelled_array_of_registered_tags[i].start_idx = -1;
+        parsec_mpi_funnelled_array_of_registered_tags[i].req_count = 0;
+        parsec_mpi_funnelled_array_of_registered_tags[i].tested_count = 0;
+        parsec_mpi_funnelled_array_of_registered_tags[i].req_idx = 0;
+        parsec_mpi_funnelled_array_of_registered_tags[i].reqs = NULL;
+        parsec_mpi_funnelled_array_of_registered_tags[i].reqs_in_testsome = NULL;
     }
 
-    size_of_total_reqs = MAX_DYNAMIC_REQ_RANGE;
+    size_of_total_reqs = parsec_param_comm_mpi_dynamic_requests;
 
      /* Make all the fn pointers point to this component's function */
     parsec_ce.enable              = mpi_no_thread_enable;
@@ -685,20 +793,42 @@ mpi_no_thread_tag_register(parsec_ce_tag_t tag,
     tag_struct->msg_length = (msg_length + 15) & ~0xF;  /* align to 16 bytes */
     tag_struct->callback = callback;
     tag_struct->cb_data = cb_data;
+    tag_struct->req_count = parsec_param_comm_mpi_am_posted_requests;
+    tag_struct->tested_count = parsec_param_comm_mpi_am_tested_requests;
+    tag_struct->req_idx = 0;
     tag_struct->status = PARSEC_CE_TAG_STATUS_ENABLE;
 
     /* Update the total number of requests we know about */
-    size_of_total_reqs += EACH_STATIC_REQ_RANGE;
+    size_of_total_reqs += tag_struct->tested_count;
     /* Make sure the AM infrastructure is rebuilt at the next progress cycle */
     parsec_ce_am_design_version++;
     parsec_atomic_unlock(&parsec_ce_am_build_lock);
     return PARSEC_SUCCESS;
 }
 
+static void
+mpi_funnelled_set_am_request_slot(mpi_funnelled_callback_t *callbacks,
+                                  MPI_Request *requests,
+                                  int slot,
+                                  mpi_funnelled_tag_t *tag_struct,
+                                  int req_idx)
+{
+    mpi_funnelled_callback_t *cb = &callbacks[slot];
+
+    assert(!tag_struct->reqs_in_testsome[req_idx]);
+    requests[slot] = tag_struct->reqs[req_idx];
+    tag_struct->reqs_in_testsome[req_idx] = true;
+    cb->cb_type.am.fct = tag_struct->callback;
+    cb->cb_data        = tag_struct->cb_data;
+    cb->storage1       = slot;
+    cb->storage2       = req_idx;
+    cb->tag_reg        = tag_struct;
+    cb->type           = MPI_FUNNELLED_TYPE_AM;
+    cb->is_dynamic_recv = false;
+}
+
 static int parsec_ce_rebuild_am_requests(void)
 {
-    mpi_funnelled_callback_t* cb;
-
     if(parsec_ce_am_build_version == parsec_ce_am_design_version) {
         /* There is nothing to update, the engine is ready to rock */
         return PARSEC_SUCCESS;
@@ -711,8 +841,11 @@ static int parsec_ce_rebuild_am_requests(void)
      */
     array_of_indices = realloc(array_of_indices, size_of_total_reqs * sizeof(int));
     array_of_statuses = realloc(array_of_statuses, size_of_total_reqs * sizeof(MPI_Status));
-    mpi_funnelled_callback_t *tmp_array_cb = malloc(sizeof(mpi_funnelled_callback_t) * size_of_total_reqs);
+    mpi_funnelled_callback_t *tmp_array_cb = calloc(size_of_total_reqs, sizeof(mpi_funnelled_callback_t));
     MPI_Request *tmp_array_req = malloc(sizeof(MPI_Request) * size_of_total_reqs);
+    for( int i = 0; i < size_of_total_reqs; i++ ) {
+        tmp_array_req[i] = MPI_REQUEST_NULL;
+    }
 
     int idx = 0, old_idx = 0;
     for( int tag = 0; tag < PARSEC_MAX_REGISTERED_TAGS; tag++ ) {
@@ -721,51 +854,53 @@ static int parsec_ce_rebuild_am_requests(void)
             (tag_struct->status == PARSEC_CE_TAG_STATUS_INACTIVE) )  /* No changes for this tag */
             continue;
         if( tag_struct->status == PARSEC_CE_TAG_STATUS_DISABLE ) {
+            old_idx += tag_struct->tested_count;
             mpi_funnelled_tag_unregister_unsafe_internal(tag);
-            old_idx += EACH_STATIC_REQ_RANGE;
             continue;
         }
         if( tag_struct->status == PARSEC_CE_TAG_STATUS_ACTIVE ) {
             memcpy(&tmp_array_cb[idx], &array_of_callbacks[old_idx],
-                   sizeof(mpi_funnelled_callback_t) * EACH_STATIC_REQ_RANGE);
+                   sizeof(mpi_funnelled_callback_t) * tag_struct->tested_count);
             memcpy(&tmp_array_req[idx], &array_of_requests[old_idx],
-                   sizeof(MPI_Request) * EACH_STATIC_REQ_RANGE);
-            idx     += EACH_STATIC_REQ_RANGE;
-            old_idx += EACH_STATIC_REQ_RANGE;
+                   sizeof(MPI_Request) * tag_struct->tested_count);
+            tag_struct->start_idx = idx;
+            for( int i = 0; i < tag_struct->tested_count; i++ ) {
+                tmp_array_cb[idx + i].storage1 = idx + i;
+            }
+            idx     += tag_struct->tested_count;
+            old_idx += tag_struct->tested_count;
             continue;
         }
         assert(PARSEC_CE_TAG_STATUS_ENABLE == tag_struct->status);
 
-        char *buf = (char *) calloc(EACH_STATIC_REQ_RANGE, tag_struct->msg_length * sizeof(char));
+        char *buf = (char *) calloc(tag_struct->req_count, tag_struct->msg_length * sizeof(char));
 
         tag_struct->am_backend_memory = buf;
+        tag_struct->reqs = (MPI_Request *) calloc(tag_struct->req_count, sizeof(MPI_Request));
+        tag_struct->reqs_in_testsome = (bool *) calloc(tag_struct->req_count, sizeof(bool));
         tag_struct->start_idx  = idx;
         tag_struct->status = PARSEC_CE_TAG_STATUS_ACTIVE;
 
-        for(int i = 0; i < EACH_STATIC_REQ_RANGE; i++) {
+        for(int i = 0; i < tag_struct->req_count; i++) {
             buf = tag_struct->am_backend_memory + i * tag_struct->msg_length * sizeof(char);
 
-            /* Even though the address of array_of_requests changes after every
-             * new registration of tags, the initialization of the requests will
-             * still work as the memory is copied after initialization.
-             */
             MPI_Recv_init(buf, tag_struct->msg_length, MPI_BYTE,
                           MPI_ANY_SOURCE, tag, parsec_ce_mpi_am_comm[tag],
-                          &tmp_array_req[idx]);
+                          &tag_struct->reqs[i]);
+        }
+        /* Tag ready to receive data, start all persistent receives. */
+        MPI_Startall(tag_struct->req_count, tag_struct->reqs);
 
-            cb = &tmp_array_cb[idx];
-            cb->cb_type.am.fct = tag_struct->callback;
-            cb->cb_data        = tag_struct->cb_data;
-            cb->storage1       = idx;
-            cb->storage2       = i;
-            cb->tag_reg        = tag_struct;
-            cb->type           = MPI_FUNNELLED_TYPE_AM;
-            cb->is_dynamic_recv = false;
+        /* Keep only the oldest posted receives in MPI_Testsome. The rest stay
+         * posted and rotate into the tested window as earlier requests complete.
+         */
+        for(int i = 0; i < tag_struct->tested_count; i++) {
+            mpi_funnelled_set_am_request_slot(tmp_array_cb, tmp_array_req, idx, tag_struct, i);
             idx++;
         }
-        /* Tag ready to receive data, start all persistent receives */
-        MPI_Startall(EACH_STATIC_REQ_RANGE, &tmp_array_req[idx - EACH_STATIC_REQ_RANGE]);
+        tag_struct->req_idx = tag_struct->tested_count % tag_struct->req_count;
     }
+    mpi_funnelled_static_req_idx = idx;
     /* Replace the arrays of callbacks and requests with the newly populated ones */
     free(array_of_callbacks);
     array_of_callbacks = tmp_array_cb;
@@ -775,7 +910,7 @@ static int parsec_ce_rebuild_am_requests(void)
     mpi_funnelled_last_active_req = idx;
 
     current_size_of_total_reqs = size_of_total_reqs;
-    assert((idx + MAX_DYNAMIC_REQ_RANGE) == current_size_of_total_reqs);
+    assert((idx + parsec_param_comm_mpi_dynamic_requests) == current_size_of_total_reqs);
     parsec_atomic_unlock(&parsec_ce_am_build_lock);
     return PARSEC_SUCCESS;
 }
@@ -790,21 +925,28 @@ mpi_funnelled_tag_unregister_unsafe_internal(parsec_ce_tag_t tag)
         (PARSEC_CE_TAG_STATUS_DISABLE == tag_struct->status) ) {
         MPI_Status status;
 
-        for(int flag, i = tag_struct->start_idx; i < tag_struct->start_idx + EACH_STATIC_REQ_RANGE; i++) {
+        for(int flag, i = 0; i < tag_struct->req_count; i++) {
 #if !defined(CRAY_MPICH_VERSION)
             // MPI Cancel broken on Cray
-            MPI_Cancel(&array_of_requests[i]);
-            MPI_Test(&array_of_requests[i], &flag, &status);
+            MPI_Cancel(&tag_struct->reqs[i]);
+            MPI_Test(&tag_struct->reqs[i], &flag, &status);
 #endif
-            MPI_Request_free(&array_of_requests[i]);
-            assert( MPI_REQUEST_NULL == array_of_requests[i] );
+            MPI_Request_free(&tag_struct->reqs[i]);
+            assert( MPI_REQUEST_NULL == tag_struct->reqs[i] );
         }
+        free(tag_struct->reqs);
+        tag_struct->reqs = NULL;
+        free(tag_struct->reqs_in_testsome);
+        tag_struct->reqs_in_testsome = NULL;
         free(tag_struct->am_backend_memory);
         tag_struct->am_backend_memory = NULL;
     }
     tag_struct->callback = NULL;
     tag_struct->cb_data = NULL;
     tag_struct->start_idx = -1;
+    tag_struct->req_count = 0;
+    tag_struct->tested_count = 0;
+    tag_struct->req_idx = 0;
     tag_struct->status = PARSEC_CE_TAG_STATUS_INACTIVE;
 
     return PARSEC_SUCCESS;
@@ -824,10 +966,18 @@ mpi_no_thread_tag_unregister(parsec_ce_tag_t tag)
     parsec_atomic_lock(&parsec_ce_am_build_lock);
     if( PARSEC_CE_TAG_STATUS_ENABLE == tag_struct->status ) {
         /* requests not yet create, change the status and return */
+        size_of_total_reqs -= tag_struct->tested_count;
+        tag_struct->callback = NULL;
+        tag_struct->cb_data = NULL;
+        tag_struct->req_count = 0;
+        tag_struct->tested_count = 0;
+        tag_struct->req_idx = 0;
+        tag_struct->reqs_in_testsome = NULL;
         tag_struct->status = PARSEC_CE_TAG_STATUS_INACTIVE;
         parsec_atomic_unlock(&parsec_ce_am_build_lock);
         return PARSEC_SUCCESS;
     }
+    size_of_total_reqs -= tag_struct->tested_count;
     tag_struct->status = PARSEC_CE_TAG_STATUS_DISABLE;
     /* if the engine is active, notify it to rebuild the arrays of requests at the next cycle */
     parsec_ce_am_design_version++;
@@ -960,6 +1110,7 @@ mpi_no_thread_put(parsec_comm_engine_t *ce,
     } else {
         item = (mpi_funnelled_dynamic_req_t *)parsec_thread_mempool_allocate(mpi_funnelled_dynamic_req_mempool->thread_mempools);
         item->post_isend = 1;
+        item->request = MPI_REQUEST_NULL;
         cb = &item->cb;
     }
 
@@ -1038,10 +1189,8 @@ mpi_no_thread_get(parsec_comm_engine_t *ce,
 
     assert(mpi_funnelled_last_active_req >= mpi_funnelled_static_req_idx);
 
-    int post_in_static_array = mpi_funnelled_last_active_req < current_size_of_total_reqs;
-    if (MAX_NUM_RECV_REQ_IN_ARRAY >= mpi_funnelled_num_recv_req_in_arr) {
-        post_in_static_array = 0;
-    } else if (post_in_static_array) {
+    int post_in_static_array = mpi_funnelled_can_post_dynamic_recv();
+    if(post_in_static_array) {
         mpi_funnelled_num_recv_req_in_arr++;
     }
 
@@ -1114,8 +1263,12 @@ mpi_no_thread_serve_cb(parsec_comm_engine_t *ce, mpi_funnelled_callback_t *cb,
             ret = cb->cb_type.am.fct(ce, mpi_tag, buf, length,
                                      mpi_source, cb->cb_data);
         }
-        /* this is a persistent request, let's reset it */
-        MPI_Start(&array_of_requests[cb->storage1]);
+        /* Restart the completed persistent receive, but leave it outside the
+         * tested window until the per-tag rotation brings it back in.
+         */
+        MPI_Start(&cb->tag_reg->reqs[cb->storage2]);
+        cb->tag_reg->reqs_in_testsome[cb->storage2] = false;
+        array_of_requests[cb->storage1] = MPI_REQUEST_NULL;
     } else if(cb->type == MPI_FUNNELLED_TYPE_ONESIDED) {
         if(NULL != cb->onesided.fct) {
             ret = cb->onesided.fct(ce, cb->onesided.lreg,
@@ -1140,15 +1293,65 @@ mpi_no_thread_serve_cb(parsec_comm_engine_t *ce, mpi_funnelled_callback_t *cb,
     return ret;
 }
 
+static void
+mpi_funnelled_refill_am_requests(void)
+{
+    for( int tag = 0; tag < PARSEC_MAX_REGISTERED_TAGS; tag++ ) {
+        mpi_funnelled_tag_t *tag_struct = &parsec_mpi_funnelled_array_of_registered_tags[tag];
+        int start, end, write;
+
+        if( PARSEC_CE_TAG_STATUS_ACTIVE != tag_struct->status ) {
+            continue;
+        }
+
+        start = tag_struct->start_idx;
+        end = start + tag_struct->tested_count;
+        write = start;
+
+        /* Keep the tested AM windows packed, preserving the order of the
+         * requests still present in MPI_Testsome.
+         */
+        for( int read = start; read < end; read++ ) {
+            if( MPI_REQUEST_NULL == array_of_requests[read] ) {
+                continue;
+            }
+            if( write != read ) {
+                array_of_requests[write] = array_of_requests[read];
+                array_of_callbacks[write] = array_of_callbacks[read];
+                array_of_callbacks[write].storage1 = write;
+                array_of_requests[read] = MPI_REQUEST_NULL;
+            }
+            write++;
+        }
+
+        /* Refill the empty tail with already-posted receives from the tag's
+         * private pool. These receives were active all along; moving only a
+         * small window into MPI_Testsome keeps progress scans bounded.
+         */
+        for( ; write < end; write++ ) {
+            for( int i = 0; i < tag_struct->req_count; i++ ) {
+                if( !tag_struct->reqs_in_testsome[tag_struct->req_idx] ) {
+                    break;
+                }
+                tag_struct->req_idx = (tag_struct->req_idx + 1) % tag_struct->req_count;
+            }
+            assert(!tag_struct->reqs_in_testsome[tag_struct->req_idx]);
+            mpi_funnelled_set_am_request_slot(array_of_callbacks, array_of_requests,
+                                              write, tag_struct, tag_struct->req_idx);
+            tag_struct->req_idx = (tag_struct->req_idx + 1) % tag_struct->req_count;
+        }
+    }
+}
+
 static int
 mpi_no_thread_push_posted_req(parsec_comm_engine_t *ce)
 {
     (void) ce;
     assert(mpi_funnelled_last_active_req < current_size_of_total_reqs);
-    assert(MAX_NUM_RECV_REQ_IN_ARRAY >= mpi_funnelled_num_recv_req_in_arr);
+    assert(parsec_param_comm_mpi_dynamic_recv_requests >= mpi_funnelled_num_recv_req_in_arr);
 
     mpi_funnelled_dynamic_req_t *item = NULL;
-    if (MAX_NUM_RECV_REQ_IN_ARRAY > mpi_funnelled_num_recv_req_in_arr) {
+    if (parsec_param_comm_mpi_dynamic_recv_requests > mpi_funnelled_num_recv_req_in_arr) {
         item = (mpi_funnelled_dynamic_req_t *) parsec_list_nolock_pop_front(&mpi_funnelled_dynamic_recvreq_fifo);
         if (NULL != item) {
             mpi_funnelled_num_recv_req_in_arr++;
@@ -1162,37 +1365,12 @@ mpi_no_thread_push_posted_req(parsec_comm_engine_t *ce)
         return 0;
     }
 
-    array_of_requests[mpi_funnelled_last_active_req] = item->request;
-    item->request = MPI_REQUEST_NULL;
-
-    array_of_callbacks[mpi_funnelled_last_active_req].storage1 = item->cb.storage1;
-    array_of_callbacks[mpi_funnelled_last_active_req].storage2 = item->cb.storage2;
-    array_of_callbacks[mpi_funnelled_last_active_req].cb_data = item->cb.cb_data;
-    array_of_callbacks[mpi_funnelled_last_active_req].type = item->cb.type;
-    array_of_callbacks[mpi_funnelled_last_active_req].tag_reg = item->cb.tag_reg;
-    array_of_callbacks[mpi_funnelled_last_active_req].is_dynamic_recv = item->cb.is_dynamic_recv;
-
-    if(item->cb.type == MPI_FUNNELLED_TYPE_ONESIDED) {
-        array_of_callbacks[mpi_funnelled_last_active_req].onesided = item->cb.onesided;
-    } else if (item->cb.type == MPI_FUNNELLED_TYPE_ONESIDED_MIMIC_AM) {
-        array_of_callbacks[mpi_funnelled_last_active_req].onesided = item->cb.onesided;
-        array_of_callbacks[mpi_funnelled_last_active_req].cb_type.onesided_mimic_am.fct =
-            item->cb.cb_type.onesided_mimic_am.fct;
-        array_of_callbacks[mpi_funnelled_last_active_req].cb_type.onesided_mimic_am.msg =
-            item->cb.cb_type.onesided_mimic_am.msg;
-    } else {
+    if((item->cb.type != MPI_FUNNELLED_TYPE_ONESIDED) &&
+       (item->cb.type != MPI_FUNNELLED_TYPE_ONESIDED_MIMIC_AM)) {
         /* No other types of callbacks should be postponed */
         assert(0);
     }
-
-    if(item->post_isend) {
-        mpi_funnelled_mem_reg_handle_t *ldata = (mpi_funnelled_mem_reg_handle_t *) item->cb.onesided.lreg;
-        MPI_Isend((char *)ldata->mem + item->cb.onesided.ldispl, ldata->count,
-                  ldata->datatype, item->cb.onesided.remote, item->cb.onesided.tag, parsec_ce_mpi_comm,
-                  &array_of_requests[mpi_funnelled_last_active_req]);
-    }
-
-    mpi_funnelled_last_active_req++;
+    mpi_funnelled_append_dynamic_request(item);
 
     parsec_thread_mempool_free(mpi_funnelled_dynamic_req_mempool->thread_mempools, item);
 
@@ -1206,6 +1384,7 @@ mpi_no_thread_progress(parsec_comm_engine_t *ce)
     int ret = 0, idx, outcount, pos;
     mpi_funnelled_callback_t *cb;
     int length;
+    void *buf;
 
     do {
         MPI_Testsome(mpi_funnelled_last_active_req, array_of_requests,
@@ -1215,22 +1394,29 @@ mpi_no_thread_progress(parsec_comm_engine_t *ce)
 
         /* Trigger the callbacks */
         for( idx = 0; idx < outcount; idx++ ) {
-            cb = &array_of_callbacks[array_of_indices[idx]];
+            pos = array_of_indices[idx];
+            cb = &array_of_callbacks[pos];
             if (cb->is_dynamic_recv) {
                 mpi_funnelled_num_recv_req_in_arr--;
             }
             status = &(array_of_statuses[idx]);
 
             MPI_Get_count(status, MPI_PACKED, &length);
+            cb->storage1 = pos;
+            buf = (MPI_FUNNELLED_TYPE_AM == cb->type) ?
+                  (cb->tag_reg->am_backend_memory + cb->tag_reg->msg_length * cb->storage2) : NULL;
 
             /* Serve the callback and comeback */
             mpi_no_thread_serve_cb(ce, cb, status->MPI_TAG,
-                                   status->MPI_SOURCE, length,
-                                   MPI_FUNNELLED_TYPE_AM == cb->type ? (cb->tag_reg->am_backend_memory + cb->tag_reg->msg_length * cb->storage2) : NULL);
+                                   status->MPI_SOURCE, length, buf);
             ret++;
         }
+        mpi_funnelled_refill_am_requests();
         for( idx = outcount-1; idx >= 0; idx-- ) {
             pos = array_of_indices[idx];
+            if( pos < mpi_funnelled_static_req_idx ) {
+                continue;
+            }
             if(MPI_REQUEST_NULL != array_of_requests[pos])
                 continue;  /* The callback replaced the completed request, keep going */
             assert(pos >= mpi_funnelled_static_req_idx);
@@ -1239,6 +1425,7 @@ mpi_no_thread_progress(parsec_comm_engine_t *ce)
             if(mpi_funnelled_last_active_req > pos) {
                 array_of_requests[pos]  = array_of_requests[mpi_funnelled_last_active_req];
                 array_of_callbacks[pos] = array_of_callbacks[mpi_funnelled_last_active_req];
+                array_of_callbacks[pos].storage1 = pos;
             }
             array_of_requests[mpi_funnelled_last_active_req] = MPI_REQUEST_NULL;
         }
@@ -1360,13 +1547,13 @@ mpi_no_thread_enable(parsec_comm_engine_t *ce)
     parsec_ce.send_am             = mpi_no_thread_send_active_message;
 
     /* Initialize the arrays */
-    array_of_callbacks = (mpi_funnelled_callback_t *) calloc(MAX_DYNAMIC_REQ_RANGE,
+    array_of_callbacks = (mpi_funnelled_callback_t *) calloc(parsec_param_comm_mpi_dynamic_requests,
                             sizeof(mpi_funnelled_callback_t));
-    array_of_requests  = (MPI_Request *) calloc(MAX_DYNAMIC_REQ_RANGE, sizeof(MPI_Request));
-    array_of_indices   = (int *) calloc(MAX_DYNAMIC_REQ_RANGE, sizeof(int));
-    array_of_statuses  = (MPI_Status *) calloc(MAX_DYNAMIC_REQ_RANGE, sizeof(MPI_Status));
+    array_of_requests  = (MPI_Request *) calloc(parsec_param_comm_mpi_dynamic_requests, sizeof(MPI_Request));
+    array_of_indices   = (int *) calloc(parsec_param_comm_mpi_dynamic_requests, sizeof(int));
+    array_of_statuses  = (MPI_Status *) calloc(parsec_param_comm_mpi_dynamic_requests, sizeof(MPI_Status));
 
-    for(i = 0; i < MAX_DYNAMIC_REQ_RANGE; i++) {
+    for(i = 0; i < parsec_param_comm_mpi_dynamic_requests; i++) {
         array_of_requests[i] = MPI_REQUEST_NULL;
     }
 

--- a/tests/apps/pingpong/bandwidth.jdf
+++ b/tests/apps/pingpong/bandwidth.jdf
@@ -3,6 +3,7 @@ extern "C" %{
  * Copyright (c) 2019-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
 
 /* includes parsec headers */
@@ -15,6 +16,7 @@ extern "C" %{
 #include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #if defined(PARSEC_HAVE_MPI)
 #include <mpi.h>
@@ -72,6 +74,27 @@ END
 
 extern "C" %{
 
+static int next_message_size(int current, int upper)
+{
+    int base = 1, next;
+
+    if( current >= upper ) {
+        return upper;
+    }
+    if( current < 4 ) {
+        next = current + 1;
+    } else {
+        while( base <= current / 2 ) {
+            base <<= 1;
+        }
+        next = (current == base) ? current + base / 2 : base << 1;
+    }
+    if( next <= current ) {
+        next = current + 1;
+    }
+    return (next > upper) ? upper : next;
+}
+
 /**
  * @brief bandwidth,  no-blocking 
  *
@@ -80,7 +103,7 @@ extern "C" %{
  * @param [in] loops: loops of bandwidth 
  * @param [in] frags: fragments
  * @param [in] ws: number of process
- * @param [in] size: number of doubles
+ * @param [in] size: message size in bytes
  */
 parsec_taskpool_t*
 parsec_bandwidth_New(parsec_tiled_matrix_t *dcA,
@@ -99,7 +122,7 @@ parsec_bandwidth_New(parsec_tiled_matrix_t *dcA,
   bandwidth_taskpool = (parsec_taskpool_t*)taskpool;
 
   parsec_matrix_adt_define_rect( &taskpool->arenas_datatypes[PARSEC_bandwidth_DEFAULT_ADT_IDX],
-                           parsec_datatype_double_t, 1, size, 1);
+                           parsec_datatype_uint8_t, 1, size, 1);
 
   return bandwidth_taskpool;
 }
@@ -122,7 +145,7 @@ void parsec_bandwidth_Destruct(parsec_taskpool_t *taskpool)
  * @param [in] loops: loops of bandwidth
  * @param [in] frags: fragments
  * @param [in] ws: number of process 
- * @param [in] size: number of doubles
+ * @param [in] size: message size in bytes
  */
 int parsec_bandwidth(parsec_context_t *parsec,
                     parsec_tiled_matrix_t *dcA,
@@ -152,12 +175,13 @@ int main(int argc, char *argv[])
     int pargc = 0;
     char **pargv = NULL;
     struct timeval tstart, tend;
-    double t, bw;
+    double t, bw, messages;
 
     /* Default */
     int loops = 100;
     int frags = 60;
-    int size = 1024;
+    int size, idx;
+    int start_length = 1, end_length = 8 * 1024 * 1024;
     int cores = 1;
     int nb_runs = 1;
 
@@ -173,23 +197,31 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    while ((ch = getopt(argc, argv, "n:f:l:c:h:e:")) != -1) {
+    while ((ch = getopt(argc, argv, "n:f:l:u:c:h:e:")) != -1) {
         switch (ch) {
             case 'n': loops = atoi(optarg); break;
             case 'f': frags = atoi(optarg); break;
-            case 'l': size = atoi(optarg) / sizeof(double); break;
+            case 'l': start_length = atoi(optarg); break;
+            case 'u': end_length = atoi(optarg); break;
             case 'e': nb_runs = atoi(optarg); break;
             case 'c': cores = atoi(optarg); break;
             case '?': case 'h': default:
                 fprintf(stderr,
                         "-n : loops of bandwidth(default: 100)\n"
                         "-f : frags, number of fragments (default: 60)\n"
-                        "-l : size, size of message (default: 1024 * sizeof(double))\n"
+                        "-l : lower message size in bytes (default: 1)\n"
+                        "-u : upper message size in bytes (default: 8MB)\n"
                         "-c : number of cores used (default: 1)\n"
                         "-e : number of runs (default: 1)\n"
                         "\n");
                  exit(1);
         }
+    }
+    if( start_length < 1 ) {
+        start_length = 1;
+    }
+    if( end_length < start_length ) {
+        end_length = start_length;
     }
 
     for(i = 1; i < argc; i++) {
@@ -220,17 +252,6 @@ int main(int argc, char *argv[])
         cores = nb_total_comp_threads;
     }
 
-    /* initializing matrix structure */
-    parsec_matrix_block_cyclic_t dcA;
-    parsec_matrix_block_cyclic_init(&dcA, PARSEC_MATRIX_DOUBLE, PARSEC_MATRIX_TILE,
-                              rank, 1, size, frags, size, 0, 0,
-                              frags, size,
-                              1, nodes, 1, 1, 0, 0);
-    dcA.mat = parsec_data_allocate((size_t)dcA.super.nb_local_tiles *
-                                   (size_t)dcA.super.bsiz *
-                                   (size_t)parsec_datadist_getsizeoftype(dcA.super.mtype));
-    parsec_data_collection_set_key((parsec_data_collection_t*)&dcA, "dcA");
-
     parsec_matrix_block_cyclic_t Disk;
     parsec_matrix_block_cyclic_init(&Disk, PARSEC_MATRIX_DOUBLE, PARSEC_MATRIX_TILE,
                               rank, 1, 1, 1, nodes, 0, 0,
@@ -239,42 +260,64 @@ int main(int argc, char *argv[])
     parsec_data_collection_set_key((parsec_data_collection_t*)&Disk, "Disk");
 
     for(i = 0; i < nb_runs; i++) {
-        /* bandwidth */
-        taskpool = parsec_bandwidth_new((parsec_tiled_matrix_t *)&dcA,
-                                       (parsec_tiled_matrix_t *)&Disk,
-                                       loops, frags, nodes);
+        for(idx = 0, size = start_length; ; idx++) {
+            /* Keep the collection datatype in sync with the arena datatype.
+             * Otherwise the receiver initially expects the upper-bound tile
+             * shape and has to fall back to a byte receive for smaller sizes.
+             */
+            parsec_matrix_block_cyclic_t dcA;
+            parsec_matrix_block_cyclic_init(&dcA, PARSEC_MATRIX_BYTE, PARSEC_MATRIX_TILE,
+                                      rank, 1, size, frags, size, 0, 0,
+                                      frags, size,
+                                      1, nodes, 1, 1, 0, 0);
+            dcA.mat = parsec_data_allocate((size_t)dcA.super.nb_local_tiles *
+                                           (size_t)dcA.super.bsiz *
+                                           (size_t)parsec_datadist_getsizeoftype(dcA.super.mtype));
+            parsec_data_collection_set_key((parsec_data_collection_t*)&dcA, "dcA");
 
-        bandwidth_taskpool = (parsec_taskpool_t*)taskpool;
+            /* bandwidth */
+            taskpool = parsec_bandwidth_new((parsec_tiled_matrix_t *)&dcA,
+                                           (parsec_tiled_matrix_t *)&Disk,
+                                           loops, frags, nodes);
 
-        parsec_matrix_adt_define_rect( &taskpool->arenas_datatypes[PARSEC_bandwidth_DEFAULT_ADT_IDX],
-                                 parsec_datatype_double_t, 1, size, 1);
+            bandwidth_taskpool = (parsec_taskpool_t*)taskpool;
 
-        /* Time start */
+            parsec_matrix_adt_define_rect( &taskpool->arenas_datatypes[PARSEC_bandwidth_DEFAULT_ADT_IDX],
+                                     parsec_datatype_uint8_t, 1, size, 1);
+
+            /* Time start */
 #if defined(PARSEC_HAVE_MPI)
-        MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Barrier(MPI_COMM_WORLD);
 #endif  /* defined(PARSEC_HAVE_MPI) */
-        gettimeofday(&tstart, NULL);
+            gettimeofday(&tstart, NULL);
 
-        parsec_context_add_taskpool(parsec, bandwidth_taskpool);
-        parsec_context_start(parsec);
-        parsec_context_wait(parsec);
+            parsec_context_add_taskpool(parsec, bandwidth_taskpool);
+            parsec_context_start(parsec);
+            parsec_context_wait(parsec);
 
-        /* Time end */
+            /* Time end */
 #if defined(PARSEC_HAVE_MPI)
-        MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Barrier(MPI_COMM_WORLD);
 #endif  /* defined(PARSEC_HAVE_MPI) */
-        gettimeofday(&tend, NULL);
+            gettimeofday(&tend, NULL);
 
-        if( 0 == rank ) {
-            t = (tend.tv_sec - tstart.tv_sec) * 1000000.0 + (tend.tv_usec - tstart.tv_usec);
-            bw = ((double)loops * (double)frags * (double)size) / t * 1000.0 * 1000.0 / (1000.0 * 1000.0 * 1000.0) * sizeof(double) * 8;
-            printf("%d %d %zu %08.4g %4.8g GB/s\n", loops, frags, size*sizeof(double), t / 1000000.0, bw);
+            if( 0 == rank ) {
+                t = (tend.tv_sec - tstart.tv_sec) * 1000000.0 + (tend.tv_usec - tstart.tv_usec);
+                messages = (double)loops * (double)frags;
+                bw = (0.0 == t) ? 0.0 : messages * (double)size * 8.0 * 1000000.0 / (t * 1024.0 * 1024.0);
+                printf("%3d: %8d bytes %d times --> %10.2f Mib/s in %10.2f usec\n",
+                       idx, size, loops * frags, bw, t / messages);
+            }
+
+            parsec_bandwidth_Destruct(bandwidth_taskpool);
+            parsec_tiled_matrix_destroy((parsec_tiled_matrix_t*)&dcA);
+            if( size == end_length ) {
+                break;
+            }
+            size = next_message_size(size, end_length);
         }
-
-        parsec_bandwidth_Destruct(bandwidth_taskpool);
     }
 
-    parsec_tiled_matrix_destroy((parsec_tiled_matrix_t*)&dcA);
     parsec_tiled_matrix_destroy((parsec_tiled_matrix_t*)&Disk);
 
     /* Clean up parsec*/

--- a/tests/apps/pingpong/main.c
+++ b/tests/apps/pingpong/main.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  */
 
 #include "parsec/runtime.h"
@@ -10,16 +11,47 @@
 #if defined(PARSEC_HAVE_STRING_H)
 #include <string.h>
 #endif  /* defined(PARSEC_HAVE_STRING_H) */
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <unistd.h>
 #if defined(PARSEC_HAVE_MPI)
 #include <mpi.h>
 #endif  /* defined(PARSEC_HAVE_MPI) */
 #include "parsec/utils/debug.h"
 
+static int next_message_size(int current, int upper)
+{
+    int base = 1, next;
+
+    if( current >= upper ) {
+        return upper;
+    }
+    if( current < 4 ) {
+        next = current + 1;
+    } else {
+        while( base <= current / 2 ) {
+            base <<= 1;
+        }
+        next = (current == base) ? current + base / 2 : base << 1;
+    }
+    if( next <= current ) {
+        next = current + 1;
+    }
+    return (next > upper) ? upper : next;
+}
+
 int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
-    int rank, world;
-    int size, nb, rc;
+    int rank, world, ch, i;
+    int size, nb, rc, idx;
+    int pargc = 0;
+    char **pargv = NULL;
+    int loops = 4;
+    int start_length = 256, end_length = 256;
+    struct timeval tstart, tend;
+    double t, bw;
     parsec_data_collection_t *dcA;
     parsec_taskpool_t *rtt;
 
@@ -35,27 +67,83 @@ int main(int argc, char *argv[])
     rank = 0;
 #endif
 
-    parsec = parsec_init(-1, &argc, &argv);
+    while ((ch = getopt(argc, argv, "n:l:u:h")) != -1) {
+        switch (ch) {
+            case 'n': loops = atoi(optarg); break;
+            case 'l': start_length = atoi(optarg); break;
+            case 'u': end_length = atoi(optarg); break;
+            case '?': case 'h': default:
+                fprintf(stderr,
+                        "-n : round trips across all ranks (default: 4)\n"
+                        "-l : lower message size in bytes (default: 256)\n"
+                        "-u : upper message size in bytes (default: lower size)\n"
+                        "\n");
+                 exit(1);
+        }
+    }
+    if( loops < 1 ) {
+        loops = 1;
+    }
+    if( start_length < 1 ) {
+        start_length = 1;
+    }
+    if( end_length < start_length ) {
+        end_length = start_length;
+    }
 
-    size = 256;
+    for(i = 1; i < argc; i++) {
+        if( strcmp(argv[i], "--") == 0 ) {
+            pargc = argc - i;
+            pargv = argv + i;
+            break;
+        }
+    }
 
-    dcA = create_and_distribute_data(rank, world, size);
-    parsec_data_collection_set_key(dcA, "A");
+    parsec = parsec_init(-1, &pargc, &pargv);
 
-    nb   = 4 * world;
-    rtt = rtt_new(dcA, size, nb);
-    rc = parsec_context_add_taskpool(parsec, rtt);
-    PARSEC_CHECK_ERROR(rc, "parsec_context_add_taskpool");
+    nb = loops * world;
+    for(idx = 0, size = start_length; ; idx++) {
+        /* Match the collection datatype to the message currently under test.
+         * Reusing an upper-bound collection works but makes the distributed
+         * receive path reshape every smaller short message back to bytes.
+         */
+        dcA = create_and_distribute_data(rank, world, size);
+        parsec_data_collection_set_key(dcA, "A");
 
-    rc = parsec_context_start(parsec);
-    PARSEC_CHECK_ERROR(rc, "parsec_context_start");
+        rtt = rtt_new(dcA, size, nb);
+        rc = parsec_context_add_taskpool(parsec, rtt);
+        PARSEC_CHECK_ERROR(rc, "parsec_context_add_taskpool");
 
-    rc = parsec_context_wait(parsec);
-    PARSEC_CHECK_ERROR(rc, "parsec_context_wait");
+#if defined(PARSEC_HAVE_MPI)
+        MPI_Barrier(MPI_COMM_WORLD);
+#endif
+        gettimeofday(&tstart, NULL);
 
-    parsec_taskpool_free((parsec_taskpool_t*)rtt);
+        rc = parsec_context_start(parsec);
+        PARSEC_CHECK_ERROR(rc, "parsec_context_start");
 
-    free_data(dcA);
+        rc = parsec_context_wait(parsec);
+        PARSEC_CHECK_ERROR(rc, "parsec_context_wait");
+
+#if defined(PARSEC_HAVE_MPI)
+        MPI_Barrier(MPI_COMM_WORLD);
+#endif
+        gettimeofday(&tend, NULL);
+
+        if( 0 == rank ) {
+            t = (tend.tv_sec - tstart.tv_sec) * 1000000.0 + (tend.tv_usec - tstart.tv_usec);
+            bw = (0.0 == t) ? 0.0 : (double)nb * (double)size * 8.0 * 1000000.0 / (t * 1024.0 * 1024.0);
+            printf("%3d: %8d bytes %d hops --> %10.2f Mib/s, %10.2f usec/hop, %10.2f usec/round-trip\n",
+                   idx, size, nb, bw, t / (double)nb, t / (double)loops);
+        }
+
+        parsec_taskpool_free((parsec_taskpool_t*)rtt);
+        free_data(dcA);
+        if( size == end_length ) {
+            break;
+        }
+        size = next_message_size(size, end_length);
+    }
 
     parsec_fini(&parsec);
 

--- a/tests/profiling/Testings.cmake
+++ b/tests/profiling/Testings.cmake
@@ -1,7 +1,9 @@
+# Copyright (c) 2026 NVIDIA Corporation.  All rights reserved.
+
 find_package (Python COMPONENTS Interpreter)
 if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
   # BW test
-  parsec_addtest_cmd(profiling/bw_generate_prof:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
+  parsec_addtest_cmd(profiling/bw_generate_prof:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -u 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
   set_property(TEST profiling/bw_generate_prof:mp PROPERTY FIXTURES_SETUP bw_prof_files)
 
   set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/")
@@ -39,7 +41,7 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
 
   if(PARSEC_PROF_GRAPHER)
     # BW with DOT test; do not use the same file names as BW tests to avoid requiring serialization of tests (RESOURCE_LOCK)
-    parsec_addtest_cmd(profiling/bwd_generate_prof_and_dot:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 3 -f 2 -l 2097152 -- --mca profile_filename bwd  --mca mca_pins task_profiler --mca profile_dot bwd)
+    parsec_addtest_cmd(profiling/bwd_generate_prof_and_dot:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 3 -f 2 -l 2097152 -u 2097152 -- --mca profile_filename bwd  --mca mca_pins task_profiler --mca profile_dot bwd)
     set_property(TEST profiling/bwd_generate_prof_and_dot:mp PROPERTY FIXTURES_SETUP bwd_prof_and_dot_files)
 
     parsec_addtest_cmd(profiling/bwd_generate_hdf5 ${SHM_TEST_CMD_LIST}


### PR DESCRIPTION
Reimplement the communication-engine ideas from PR #327 on top of the current MPI funnelled code.

The MPI path now separates posted AM receive pools from the subset exposed to MPI_Testsome, adds MCA controls for AM and dynamic request windows, and rotates completed AM receives back through the tested window. Dynamic send and receive requests are also packed into the available request slots instead of using fixed compile-time ranges.

Also bring over the PR #327 pingpong benchmark intent: bw_test and rtt can now sweep byte message ranges with -l/-u, using the same 1, 2, 3, 4, 6, 8... progression. The bandwidth calculations now use the actual byte count, and the profiling bandwidth tests keep their previous single-size behavior by setting matching lower and upper bounds.