### PR TITLE
device: restore late device attachment callback

### DIFF
--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -802,6 +802,8 @@ int parsec_mca_device_registration_complete(parsec_context_t* context)
         parsec_device_module_t* device = parsec_devices[i];
         if( NULL == device ) continue;
         if( PARSEC_DEV_RECURSIVE & device->type ) continue;
+        if( NULL != device->all_devices_attached )
+            device->all_devices_attached(device);
         if( PARSEC_DEV_CPU & device->type ) {
             c = 0;
             for(int p = 0; p < context->nb_vp; p++)


### PR DESCRIPTION
The batched-task integration converted device type checks from exact comparisons to bitmask tests so chore types could carry extra capability flags such as PARSEC_DEV_CHORE_ALLOW_BATCH. During that merge, the parsec_mca_device_registration_complete() loop accidentally dropped the device->all_devices_attached() callback.

That callback is used by CUDA after all devices have been registered to compute each GPU peer_access_mask with cudaDeviceCanAccessPeer() and cudaDeviceEnablePeerAccess(). Without it, CUDA devices keep the default zero peer_access_mask, so PARSEC_CONTEXT_QUERY_DEVICES_FULL_PEER_ACCESS reports no full peer matrix and the nvlink test is skipped even on systems with full NVLink connectivity.

Restore the callback before the registration-complete gflops accounting. This brings back the behavior introduced by f04a310cc and preserved through 342a8ea0c before it was lost in db9e7cfa5.