### PR TITLE
Make PTG compiler optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ mark_as_advanced(BUILD_TOOLS)
 option(BUILD_PARSEC
        "Compile the PaRSEC framework" ON)
 mark_as_advanced(BUILD_PARSEC)
+option(PARSEC_BUILD_PTGPP
+       "Build the parsec-ptgpp JDF compiler" ON)
 ### Misc options
 option(BUILD_SHARED_LIBS
     "Build shared libraries" ON)
@@ -966,53 +968,55 @@ mark_as_advanced(PARSEC_NVTX_INCLUDE_DIR)
 # First go for the tools.
 #
 add_subdirectory(tools)
-if(CMAKE_CROSSCOMPILING)
-  #
-  # Import the EXPORT file from external native ptgpp.
-  #
-  set(IMPORT_EXECUTABLES "IMPORTFILE-NOTFOUND" CACHE FILEPATH "Point it to the export file from a native build")
-  message(STATUS "Prepare cross-compiling using ${IMPORT_EXECUTABLES}")
-  include(${IMPORT_EXECUTABLES})
-  set_target_properties(parsec-ptgpp PROPERTIES IMPORTED_GLOBAL ON)
-  get_target_property(PARSEC_PTGPP_EXECUTABLE parsec-ptgpp LOCATION)
-  # Build it, now
-  get_filename_component(NATIVE_BINARY_DIR "${IMPORT_EXECUTABLES}" DIRECTORY BASE_DIR ${PROJECT_BINARY_DIR} CACHE)
-  include(ExternalProject)
-  ExternalProject_add(native
-    PREFIX ${NATIVE_BINARY_DIR}/CMakeFiles
-    SOURCE_DIR ${PROJECT_SOURCE_DIR}
-    BINARY_DIR ${NATIVE_BINARY_DIR}
-    CONFIGURE_COMMAND "" # Do not reconfigure, this must have been done before to produce $IMPORT_EXECUTABLES
-    # Do not do BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>/parsec/interfaces/ptg
-    #   because that breaks parallel make
-    BUILD_COMMAND "$(MAKE)" -C parsec/interfaces/ptg
-          COMMAND "$(MAKE)" -C tools
-    BUILD_ALWAYS TRUE
-    INSTALL_COMMAND "$(MAKE)" -C parsec/interfaces/ptg install
-            COMMAND "$(MAKE)" -C tools install
-    EXCLUDE_FROM_ALL TRUE
-    STEP_TARGETS build install test clean
-    BYPRODUCTS ${PARSEC_PTGPP_EXECUTABLE}
-  )
-  ExternalProject_Add_Step(native test
-    WORKING_DIRECTORY <BINARY_DIR>
-    ALWAYS TRUE
-    COMMAND "$(MAKE)" -C parsec/interfaces/ptg test
-    COMMAND "$(MAKE)" -C tools test
-  )
-  ExternalProject_Add_Step(native clean
-    WORKING_DIRECTORY <BINARY_DIR>
-    ALWAYS TRUE
-    COMMAND "$(MAKE)" -C parsec/interfaces/ptg clean
-    COMMAND "$(MAKE)" -C tools clean
-  )
-  add_dependencies(parsec-ptgpp native-build)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target native-install)")
-  add_test(NAME native-test COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target native-test)
-else()
-  set(PARSEC_PTGPP_EXECUTABLE parsec-ptgpp)
-endif(CMAKE_CROSSCOMPILING)
-set(PARSEC_PTGPP_EXECUTABLE ${PARSEC_PTGPP_EXECUTABLE} CACHE STRING "Point to the parsec-ptgpp executable")
+if(PARSEC_BUILD_PTGPP)
+  if(CMAKE_CROSSCOMPILING)
+    #
+    # Import the EXPORT file from external native ptgpp.
+    #
+    set(IMPORT_EXECUTABLES "IMPORTFILE-NOTFOUND" CACHE FILEPATH "Point it to the export file from a native build")
+    message(STATUS "Prepare cross-compiling using ${IMPORT_EXECUTABLES}")
+    include(${IMPORT_EXECUTABLES})
+    set_target_properties(parsec-ptgpp PROPERTIES IMPORTED_GLOBAL ON)
+    get_target_property(PARSEC_PTGPP_EXECUTABLE parsec-ptgpp LOCATION)
+    # Build it, now
+    get_filename_component(NATIVE_BINARY_DIR "${IMPORT_EXECUTABLES}" DIRECTORY BASE_DIR ${PROJECT_BINARY_DIR} CACHE)
+    include(ExternalProject)
+    ExternalProject_add(native
+      PREFIX ${NATIVE_BINARY_DIR}/CMakeFiles
+      SOURCE_DIR ${PROJECT_SOURCE_DIR}
+      BINARY_DIR ${NATIVE_BINARY_DIR}
+      CONFIGURE_COMMAND "" # Do not reconfigure, this must have been done before to produce $IMPORT_EXECUTABLES
+      # Do not do BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>/parsec/interfaces/ptg
+      #   because that breaks parallel make
+      BUILD_COMMAND "$(MAKE)" -C parsec/interfaces/ptg
+            COMMAND "$(MAKE)" -C tools
+      BUILD_ALWAYS TRUE
+      INSTALL_COMMAND "$(MAKE)" -C parsec/interfaces/ptg install
+              COMMAND "$(MAKE)" -C tools install
+      EXCLUDE_FROM_ALL TRUE
+      STEP_TARGETS build install test clean
+      BYPRODUCTS ${PARSEC_PTGPP_EXECUTABLE}
+    )
+    ExternalProject_Add_Step(native test
+      WORKING_DIRECTORY <BINARY_DIR>
+      ALWAYS TRUE
+      COMMAND "$(MAKE)" -C parsec/interfaces/ptg test
+      COMMAND "$(MAKE)" -C tools test
+    )
+    ExternalProject_Add_Step(native clean
+      WORKING_DIRECTORY <BINARY_DIR>
+      ALWAYS TRUE
+      COMMAND "$(MAKE)" -C parsec/interfaces/ptg clean
+      COMMAND "$(MAKE)" -C tools clean
+    )
+    add_dependencies(parsec-ptgpp native-build)
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target native-install)")
+    add_test(NAME native-test COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target native-test)
+  else()
+    set(PARSEC_PTGPP_EXECUTABLE parsec-ptgpp)
+  endif(CMAKE_CROSSCOMPILING)
+  set(PARSEC_PTGPP_EXECUTABLE ${PARSEC_PTGPP_EXECUTABLE} CACHE STRING "Point to the parsec-ptgpp executable")
+endif(PARSEC_BUILD_PTGPP)
 
 # List of files that will go through documentation generation
 include(AddDocumentedFiles)

--- a/parsec/data_dist/matrix/CMakeLists.txt
+++ b/parsec/data_dist/matrix/CMakeLists.txt
@@ -53,10 +53,6 @@ set_property(TARGET parsec
                                      data_dist/matrix/two_dim_tabular.h
                                      data_dist/matrix/grid_2Dcyclic.h
                                      data_dist/matrix/subtile.h)
-set_property(TARGET parsec
-             APPEND PROPERTY
-                    PRIVATE_HEADER_H data_dist/matrix/apply.h)
-
 # Install the deprecated headers.
 set_property(TARGET parsec
              APPEND PROPERTY

--- a/parsec/interfaces/ptg/CMakeLists.txt
+++ b/parsec/interfaces/ptg/CMakeLists.txt
@@ -1,1 +1,3 @@
-Add_Subdirectory(ptg-compiler)
+if(PARSEC_BUILD_PTGPP)
+  Add_Subdirectory(ptg-compiler)
+endif(PARSEC_BUILD_PTGPP)


### PR DESCRIPTION
Not all consumers of PaRSEC require the PTG compiler. Setting `PARSEC_BUILD_PTGPP=OFF` will build only the runtime component needed for DTD and direct users of the PaRSEC runtime.

Also fixes a duplicated installation of apply.h.